### PR TITLE
feat(client): add streaming support

### DIFF
--- a/apps/demo-nextjs-app-router/app/streaming/page.tsx
+++ b/apps/demo-nextjs-app-router/app/streaming/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import * as fal from '@fal-ai/serverless-client';
+import { useState } from 'react';
+
+fal.config({
+  proxyUrl: '/api/fal/proxy',
+});
+
+type LlavaInput = {
+  prompt: string;
+  image_url: string;
+  max_new_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+};
+
+type LlavaOutput = {
+  output: string;
+  partial: boolean;
+  stats: {
+    num_input_tokens: number;
+    num_output_tokens: number;
+  };
+};
+
+export default function StreamingDemo() {
+  const [answer, setAnswer] = useState<string>('');
+  const [streamStatus, setStreamStatus] = useState<string>('idle');
+
+  const runInference = async () => {
+    const stream = await fal.stream<LlavaInput, LlavaOutput>(
+      'fal-ai/llavav15-13b',
+      {
+        input: {
+          prompt:
+            'Do you know who drew this picture and what is the name of it?',
+          image_url: 'https://llava-vl.github.io/static/images/monalisa.jpg',
+          max_new_tokens: 100,
+          temperature: 0.2,
+          top_p: 1,
+        },
+      }
+    );
+    setStreamStatus('running');
+
+    for await (const partial of stream) {
+      setAnswer(partial.output);
+    }
+    const result = await stream.done();
+    setStreamStatus('done');
+    setAnswer(result.output);
+  };
+
+  return (
+    <div className="min-h-screen dark:bg-gray-900 bg-gray-100">
+      <main className="container dark:text-gray-50 text-gray-900 flex flex-col items-center justify-center w-full flex-1 py-10 space-y-8">
+        <h1 className="text-4xl font-bold mb-8">
+          Hello <code className="text-pink-600">fal</code> and{' '}
+          <code className="text-indigo-500">llm</code>
+        </h1>
+
+        <div className="flex flex-row space-x-2">
+          <button
+            onClick={runInference}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-lg py-3 px-6 mx-auto rounded focus:outline-none focus:shadow-outline disabled:opacity-70"
+          >
+            Run inference
+          </button>
+        </div>
+
+        <div className="w-full flex flex-col space-y-4">
+          <div className="flex flex-row items-center justify-between">
+            <h2 className="text-2xl font-bold">Answer</h2>
+            <span>
+              streaming: <code className="font-semibold">{streamStatus}</code>
+            </span>
+          </div>
+          <p className="text-lg p-4 border min-h-[12rem] border-gray-300 bg-gray-200 dark:bg-gray-800 dark:border-gray-700 rounded">
+            {answer}
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/demo-nextjs-app-router/app/streaming/page.tsx
+++ b/apps/demo-nextjs-app-router/app/streaming/page.tsx
@@ -47,6 +47,7 @@ export default function StreamingDemo() {
     for await (const partial of stream) {
       setAnswer(partial.output);
     }
+
     const result = await stream.done();
     setStreamStatus('done');
     setAnswer(result.output);
@@ -56,8 +57,8 @@ export default function StreamingDemo() {
     <div className="min-h-screen dark:bg-gray-900 bg-gray-100">
       <main className="container dark:text-gray-50 text-gray-900 flex flex-col items-center justify-center w-full flex-1 py-10 space-y-8">
         <h1 className="text-4xl font-bold mb-8">
-          Hello <code className="text-pink-600">fal</code> and{' '}
-          <code className="text-indigo-500">llm</code>
+          Hello <code className="text-pink-600">fal</code> +{' '}
+          <code className="text-indigo-500">streaming</code>
         </h1>
 
         <div className="flex flex-row space-x-2">

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.9.0-alpha.1",
+  "version": "0.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.9.0-alpha.0",
+  "version": "0.9.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.8.6",
+  "version": "0.9.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@msgpack/msgpack": "^3.0.0-beta2",
+    "eventsource-parser": "^1.1.2",
     "robot3": "^0.4.1",
     "uuid-random": "^1.3.2"
   },

--- a/libs/client/src/auth.ts
+++ b/libs/client/src/auth.ts
@@ -1,0 +1,26 @@
+import { getRestApiUrl } from './config';
+import { dispatchRequest } from './request';
+import { ensureAppIdFormat } from './utils';
+
+export const TOKEN_EXPIRATION_SECONDS = 120;
+
+/**
+ * Get a token to connect to the realtime endpoint.
+ */
+export async function getTemporaryAuthToken(app: string): Promise<string> {
+  const [, appAlias] = ensureAppIdFormat(app).split('/');
+  const token: string | object = await dispatchRequest<any, string>(
+    'POST',
+    `${getRestApiUrl()}/tokens/`,
+    {
+      allowed_apps: [appAlias],
+      token_expiration: TOKEN_EXPIRATION_SECONDS,
+    }
+  );
+  // keep this in case the response was wrapped (old versions of the proxy do that)
+  // should be safe to remove in the future
+  if (typeof token !== 'string' && token['detail']) {
+    return token['detail'];
+  }
+  return token;
+}

--- a/libs/client/src/index.ts
+++ b/libs/client/src/index.ts
@@ -6,6 +6,7 @@ export { realtimeImpl as realtime } from './realtime';
 export { ApiError, ValidationError } from './response';
 export type { ResponseHandler } from './response';
 export { storageImpl as storage } from './storage';
+export { stream } from './streaming';
 export type {
   QueueStatus,
   ValidationErrorInfo,

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -25,8 +25,8 @@ class FalStream<Input, Output> {
   private buffer: Output[] = [];
 
   // local state
-  private currentData: Output;
-  private lastEventTimestamp: number;
+  private currentData: Output | undefined = undefined;
+  private lastEventTimestamp = 0;
   private streamClosed = false;
   private donePromise: Promise<Output>;
 
@@ -84,6 +84,18 @@ class FalStream<Input, Output> {
       return;
     }
 
+    const body = response.body;
+    if (!body) {
+      this.emit(
+        'error',
+        new ApiError({
+          message: 'Response body is empty.',
+          status: 400,
+          body: undefined,
+        })
+      );
+      return;
+    }
     const decoder = new TextDecoder('utf-8');
     const reader = response.body.getReader();
 

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -1,0 +1,192 @@
+import { createParser } from 'eventsource-parser';
+import { getTemporaryAuthToken } from './auth';
+import { buildUrl } from './function';
+import { ApiError } from './response';
+import { storageImpl } from './storage';
+
+type StreamOptions<Input> = {
+  input: Input;
+  autoUpload?: boolean;
+};
+
+const EVENT_STREAM_TIMEOUT = 15 * 1000;
+
+type FalStreamEventType = 'message' | 'error' | 'done';
+
+type EventHandler = (event: any) => void;
+
+class FalStream<Input, Output> {
+  // properties
+  url: string;
+  input: Input;
+
+  // support for event listeners
+  private listeners: Map<FalStreamEventType, EventHandler[]> = new Map();
+  private buffer: Output[] = [];
+
+  // local state
+  private currentData: Output;
+  private lastEventTimestamp: number;
+  private streamClosed = false;
+  private donePromise: Promise<Output>;
+
+  constructor(url: string, input: Input) {
+    this.url = url;
+    this.input = input;
+    this.donePromise = new Promise<Output>((resolve, reject) => {
+      if (this.streamClosed) {
+        reject(
+          new ApiError({
+            message: 'Streaming connection is already closed.',
+            status: 400,
+            body: undefined,
+          })
+        );
+      }
+      this.on('done', (data) => {
+        this.streamClosed = true;
+        resolve(data);
+      });
+      this.on('error', (error) => {
+        this.streamClosed = true;
+        reject(error);
+      });
+    });
+    this.start();
+  }
+
+  private start = async () => {
+    try {
+      const response = await fetch(this.url, {
+        method: 'POST',
+        headers: {
+          accept: 'text/event-stream',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(this.input),
+      });
+      this.handleResponse(response);
+    } catch (error) {
+      this.handleError(error);
+    }
+  };
+
+  private handleResponse = async (response: Response) => {
+    if (!response.ok) {
+      this.emit(
+        'error',
+        new ApiError({
+          message: response.statusText,
+          status: response.status,
+          body: undefined,
+        })
+      );
+      return;
+    }
+
+    const decoder = new TextDecoder('utf-8');
+    const reader = response.body.getReader();
+
+    const parser = createParser((event) => {
+      if (event.type === 'event') {
+        const data = event.data;
+
+        try {
+          const parsedData = JSON.parse(data);
+          this.buffer.push(parsedData);
+          this.currentData = parsedData;
+          this.emit('message', parsedData);
+        } catch (e) {
+          this.emit('error', e);
+        }
+      }
+    });
+
+    const readPartialResponse = async () => {
+      const { value, done } = await reader.read();
+      this.lastEventTimestamp = Date.now();
+
+      parser.feed(decoder.decode(value));
+
+      if (!done) {
+        readPartialResponse().catch(this.handleError);
+      } else {
+        this.emit('done', this.currentData);
+      }
+    };
+
+    readPartialResponse().catch(this.handleError);
+    return;
+  };
+
+  private handleError = (error: any) => {
+    // TODO convert error to ApiError
+    this.emit('error', error);
+    return;
+  };
+
+  public on = (type: FalStreamEventType, listener: EventHandler) => {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, []);
+    }
+    this.listeners.get(type)?.push(listener);
+  };
+
+  private emit = (type: FalStreamEventType, event: any) => {
+    const listeners = this.listeners.get(type) || [];
+    for (const listener of listeners) {
+      listener(event);
+    }
+  };
+
+  async *[Symbol.asyncIterator]() {
+    let running = true;
+    const stopAsyncIterator = () => (running = false);
+    this.on('error', stopAsyncIterator);
+    this.on('done', stopAsyncIterator);
+    while (running) {
+      const data = this.buffer.shift();
+      if (data) {
+        yield data;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 16));
+
+      if (Date.now() - this.lastEventTimestamp > EVENT_STREAM_TIMEOUT) {
+        running = false;
+        this.emit(
+          'error',
+          new ApiError({
+            message:
+              'Event stream timed out after 15 seconds with no messages.',
+            status: 408,
+            body: undefined,
+          })
+        );
+      }
+    }
+  }
+
+  public done = async () => {
+    return this.donePromise;
+  };
+}
+
+export async function stream<Input = Record<string, any>, Output = any>(
+  appId: string,
+  options: StreamOptions<Input>
+) {
+  const token = await getTemporaryAuthToken(appId);
+  const url = buildUrl(appId, { path: '/stream' });
+
+  const input =
+    options.input && options.autoUpload !== false
+      ? await storageImpl.transformInput(options.input)
+      : options.input;
+
+  const queryParams = new URLSearchParams({
+    fal_jwt_token: token,
+  });
+
+  return new FalStream<Input, Output>(`${url}?${queryParams}`, input as Input);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cross-fetch": "^3.1.5",
         "dotenv": "^16.3.1",
         "encoding": "^0.1.13",
+        "eventsource-parser": "^1.1.2",
         "execa": "^8.0.1",
         "express": "^4.18.2",
         "fast-glob": "^3.2.12",
@@ -14488,6 +14489,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cross-fetch": "^3.1.5",
     "dotenv": "^16.3.1",
     "encoding": "^0.1.13",
+    "eventsource-parser": "^1.1.2",
     "execa": "^8.0.1",
     "express": "^4.18.2",
     "fast-glob": "^3.2.12",


### PR DESCRIPTION
## New streaming API

This PR introduces streaming capabilities to the fal-js client. This is a big milestone, the goal is to support Model APIs that rely on streaming for one-way real-time responses, such as LLMs and vLLMs.

### The API

The signature is as follows:

```ts
async function stream<Input = Record<string, any>, Output = any>(
  appId: string,
  options: StreamOptions<Input>
)

type StreamOptions<Input> = {
  input: Input;
  autoUpload?: boolean;
};
```

### Developer Experience

This API works on both browsers and Node.js without any changes necessary from the developer. In order to work seamless in browsers, it relies on fal's temporary token authentication, which uses a server proxy to safely obtain a JWT token valid for the streaming request, just like the real-time/WebSocket client does.

It is also similar to the existing `fal.run` and `fal.subscribe` APIs, so developers using these other functions to run async inference on media-centric models will feel at home using `fal.stream`.

Last but not least, it also supports JavaScript's [AsyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) out-of-the-box.

#### 1 - Simple call that gets the final result

```ts
const stream = await fal.stream<LlavaInput, LlavaOutput>("fal-ai/llavav15-13b", {
  input: {
    prompt: "Do you know who drew this picture and what is the name of it?",
    image_url: "https://llava-vl.github.io/static/images/monalisa.jpg",
  },
});
const result = await stream.done();
```

#### 2 - Partial results via `AsyncIterator`

```ts
const stream = await fal.stream<LlavaInput, LlavaOutput>("fal-ai/llavav15-13b", {
  input: {
    prompt: "Do you know who drew this picture and what is the name of it?",
    image_url: "https://llava-vl.github.io/static/images/monalisa.jpg",
  },
});

for await (const partial of stream) {
  // do something with the partial result
}

const result = await stream.done();
```

#### 3 - Partial results via event-callback

```ts
const stream = await fal.stream<LlavaInput, LlavaOutput>("fal-ai/llavav15-13b", {
  input: {
    prompt: "Do you know who drew this picture and what is the name of it?",
    image_url: "https://llava-vl.github.io/static/images/monalisa.jpg",
  },
});

stream.on("message", (partial) => {
  // do something with the partial result
});

const result = await stream.done();
```

### API naming and next steps

The reasoning for calling it `fal.stream` was to make it clear what the functionality is + to be general enough that can work with any model that supports streaming.

On top of `fal.stream` we can build a more use-case specific for predictions, with static typing that supports the popular predicitions APIs out there, such as the OpenAI format, and also manage the conversation memory, etc. For example:

```ts
async function fal.prediction.startConversation(): PredictionStream
```

This could be a wrapper around `fal.stream()` tailored for conversational use-cases.