### PR TITLE
refactor: update credentials type

### DIFF
--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -6,10 +6,16 @@ import {
 import type { ResponseHandler } from './response';
 import { defaultResponseHandler } from './response';
 
-export type CredentialsResolver = () => string | undefined;
+/**
+ * Represents the credentials for authentication.
+ * The credentials are in the format of "FAL_KEY_ID:FAL_KEY_SECRET".
+ */
+export type Credentials = `${string}:${string}`;
+
+export type CredentialsResolver = () => Credentials | undefined;
 
 export type Config = {
-  credentials?: undefined | string | CredentialsResolver;
+  credentials?: undefined | Credentials | CredentialsResolver;
   proxyUrl?: string;
   requestMiddleware?: RequestMiddleware;
   responseHandler?: ResponseHandler<any>;
@@ -57,6 +63,15 @@ let configuration: RequiredConfig;
  * Configures the fal serverless client.
  *
  * @param config the new configuration.
+ */
+/**
+ * Configures the fal serverless client.
+ *
+ * @param config - The new configuration. It is an object that can have the following properties:
+ * - credentials: The credentials for authentication. They are in the format of "FAL_KEY_ID:FAL_KEY_SECRET". It can also be a function that returns the credentials.
+ * - proxyUrl: The URL of the proxy server.
+ * - requestMiddleware: A function that can be used to modify the request before it is sent.
+ * - responseHandler: A function that can be used to handle the response.
  */
 export function config(config: Config) {
   configuration = { ...DEFAULT_CONFIG, ...config } as RequiredConfig;

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -62,11 +62,6 @@ let configuration: RequiredConfig;
 /**
  * Configures the fal serverless client.
  *
- * @param config the new configuration.
- */
-/**
- * Configures the fal serverless client.
- *
  * @param config - The new configuration. It is an object that can have the following properties:
  * - credentials: The credentials for authentication. They are in the format of "FAL_KEY_ID:FAL_KEY_SECRET". It can also be a function that returns the credentials.
  * - proxyUrl: The URL of the proxy server.

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -39,13 +39,13 @@ function hasEnvVariables(): boolean {
   );
 }
 
-export const credentialsFromEnv: CredentialsResolver = () => {
+export const credentialsFromEnv: CredentialsResolver = (): Credentials => {
   if (!hasEnvVariables()) {
     return undefined;
   }
 
   if (typeof process.env.FAL_KEY !== 'undefined') {
-    return process.env.FAL_KEY;
+    return process.env.FAL_KEY as Credentials;
   }
 
   return `${process.env.FAL_KEY_ID}:${process.env.FAL_KEY_SECRET}`;


### PR DESCRIPTION
I'm not sure it's a necessary improvement. 

I think developers' experience could be improved this way to make sure they receive and use the key in the correct format. 

So if they try to just add `secret` or `id` they will get a warning from TypeScript.


![Code_pBuYnffaIQ](https://github.com/fal-ai/fal-js/assets/7966133/00b7c02f-f406-4595-a2ca-68b53669944a)
