### PR TITLE
feat(client): enable both polling and streaming for queue status

### DIFF
--- a/apps/demo-nextjs-app-router/app/queue/page.tsx
+++ b/apps/demo-nextjs-app-router/app/queue/page.tsx
@@ -52,6 +52,8 @@ export default function Home() {
       const result: any = await fal.subscribe(endpointId, {
         input: JSON.parse(input),
         logs: true,
+        mode: 'streaming',
+        // pollInterval: 1000,
         onQueueUpdate(update) {
           console.log('queue update');
           console.log(update);

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Notes:**

This PR adds polling back to `fal.subscribe` but also keeps streaming as an option. Polling will be the default until status streaming is stable and faster.