### PR TITLE
feat(client): allow custom fetch impl

### DIFF
--- a/apps/demo-nextjs-app-router/app/queue/page.tsx
+++ b/apps/demo-nextjs-app-router/app/queue/page.tsx
@@ -52,8 +52,9 @@ export default function Home() {
       const result: any = await fal.subscribe(endpointId, {
         input: JSON.parse(input),
         logs: true,
-        mode: 'streaming',
-        // pollInterval: 1000,
+        // mode: "streaming",
+        mode: 'polling',
+        pollInterval: 1000,
         onQueueUpdate(update) {
           console.log('queue update');
           console.log(update);

--- a/apps/demo-nextjs-app-router/app/queue/page.tsx
+++ b/apps/demo-nextjs-app-router/app/queue/page.tsx
@@ -49,6 +49,20 @@ export default function Home() {
     setLoading(true);
     const start = Date.now();
     try {
+      const requestId = await fal.queue.submit(
+        'fal-ai/fast-animatediff/turbo/text-to-video',
+        {
+          input: {
+            prompt: prompt,
+          },
+          webhookUrl:
+            'https://webhook.site/6679a19d-9dbc-4496-8c2d-53679e417861?userId=1234',
+        }
+      );
+      console.log(requestId);
+      setLoading(false);
+      return;
+
       const result: any = await fal.subscribe(endpointId, {
         input: JSON.parse(input),
         logs: true,

--- a/apps/demo-nextjs-app-router/app/queue/page.tsx
+++ b/apps/demo-nextjs-app-router/app/queue/page.tsx
@@ -49,20 +49,6 @@ export default function Home() {
     setLoading(true);
     const start = Date.now();
     try {
-      const requestId = await fal.queue.submit(
-        'fal-ai/fast-animatediff/turbo/text-to-video',
-        {
-          input: {
-            prompt: prompt,
-          },
-          webhookUrl:
-            'https://webhook.site/6679a19d-9dbc-4496-8c2d-53679e417861?userId=1234',
-        }
-      );
-      console.log(requestId);
-      setLoading(false);
-      return;
-
       const result: any = await fal.subscribe(endpointId, {
         input: JSON.parse(input),
         logs: true,

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.14.0-alpha.0",
+  "version": "0.14.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -65,8 +65,8 @@ export function config(config: Config) {
     configuration = {
       ...configuration,
       requestMiddleware: withMiddleware(
-        configuration.requestMiddleware,
-        withProxy({ targetUrl: config.proxyUrl })
+        withProxy({ targetUrl: config.proxyUrl }),
+        configuration.requestMiddleware
       ),
     };
   }

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -13,6 +13,7 @@ export type Config = {
   proxyUrl?: string;
   requestMiddleware?: RequestMiddleware;
   responseHandler?: ResponseHandler<any>;
+  fetch?: typeof fetch;
 };
 
 export type RequiredConfig = Required<Config>;

--- a/libs/client/src/request.ts
+++ b/libs/client/src/request.ts
@@ -14,6 +14,7 @@ export async function dispatchRequest<Input, Output>(
     credentials: credentialsValue,
     requestMiddleware,
     responseHandler,
+    fetch = global.fetch,
   } = getConfig();
   const userAgent = isBrowser() ? {} : { 'User-Agent': getUserAgent() };
   const credentials =

--- a/libs/client/src/storage.ts
+++ b/libs/client/src/storage.ts
@@ -76,6 +76,7 @@ type KeyValuePair = [string, any];
 
 export const storageImpl: StorageSupport = {
   upload: async (file: Blob) => {
+    const { fetch = global.fetch } = getConfig();
     const { upload_url: uploadUrl, file_url: url } = await initiateUpload(file);
     const response = await fetch(uploadUrl, {
       method: 'PUT',

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -1,5 +1,6 @@
 import { createParser } from 'eventsource-parser';
 import { getTemporaryAuthToken } from './auth';
+import { getConfig } from './config';
 import { buildUrl } from './function';
 import { ApiError, defaultResponseHandler } from './response';
 import { storageImpl } from './storage';
@@ -83,6 +84,7 @@ export class FalStream<Input, Output> {
   private start = async () => {
     const { url, options } = this;
     const { input, method = 'post' } = options;
+    const { fetch = global.fetch } = getConfig();
     try {
       const response = await fetch(url, {
         method: method.toUpperCase(),


### PR DESCRIPTION
This PR introduces the `fetch` function as a config option. It expects the function to follow the `fetch` signature and behavior, so `node-fetch`, `isomorphic-fetch` and similar can be use as a drop-in. When using HTTP clients such as Axios, one needs to write their own adapter function or use something like https://github.com/lifeomic/axios-fetch