### PR TITLE
feat(client): subscribe to status

### DIFF
--- a/apps/demo-nextjs-app-router/app/api/fal/proxy/route.ts
+++ b/apps/demo-nextjs-app-router/app/api/fal/proxy/route.ts
@@ -1,3 +1,3 @@
 import { route } from '@fal-ai/serverless-proxy/nextjs';
 
-export const { GET, POST } = route;
+export const { GET, POST, PUT } = route;

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.14.0-alpha.2",
+  "version": "0.14.0-alpha.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -131,7 +131,7 @@ export async function run<Input, Output>(
   return send(id, options);
 }
 
-type TimeoutId = ReturnType<typeof setTimeout>;
+type TimeoutId = ReturnType<typeof setTimeout> | undefined;
 
 const DEFAULT_POLL_INTERVAL = 500;
 

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -56,6 +56,8 @@ export class FalStream<Input, Output> {
   private streamClosed = false;
   private donePromise: Promise<Output>;
 
+  private abortController = new AbortController();
+
   constructor(url: string, options: StreamOptions<Input>) {
     this.url = url;
     this.options = options;
@@ -93,6 +95,7 @@ export class FalStream<Input, Output> {
           'content-type': 'application/json',
         },
         body: input && method !== 'get' ? JSON.stringify(input) : undefined,
+        signal: this.abortController.signal,
       });
       this.handleResponse(response);
     } catch (error) {
@@ -225,6 +228,13 @@ export class FalStream<Input, Output> {
    * @returns the promise that resolves when the request is done.
    */
   public done = async () => this.donePromise;
+
+  /**
+   * Aborts the streaming request.
+   */
+  public abort = () => {
+    this.abortController.abort();
+  };
 }
 
 /**

--- a/libs/client/src/types.ts
+++ b/libs/client/src/types.ts
@@ -17,26 +17,40 @@ export type Metrics = {
   inference_time: number | null;
 };
 
+interface BaseQueueStatus {
+  status: 'IN_PROGRESS' | 'COMPLETED' | 'IN_QUEUE';
+}
+
+export interface InProgressQueueStatus extends BaseQueueStatus {
+  status: 'IN_PROGRESS';
+  response_url: string;
+  logs: RequestLog[];
+}
+
+export interface CompletedQueueStatus extends BaseQueueStatus {
+  status: 'COMPLETED';
+  response_url: string;
+  logs: RequestLog[];
+  metrics: Metrics;
+}
+
+export interface EnqueuedQueueStatus extends BaseQueueStatus {
+  status: 'IN_QUEUE';
+  queue_position: number;
+  response_url: string;
+}
+
 export type QueueStatus =
-  | {
-      status: 'IN_PROGRESS';
-      response_url: string;
-      logs: null | RequestLog[];
-    }
-  | {
-      status: 'COMPLETED';
-      response_url: string;
-      logs: null | RequestLog[];
-      metrics: Metrics;
-    }
-  | {
-      status: 'IN_QUEUE';
-      queue_position: number;
-      response_url: string;
-    };
+  | InProgressQueueStatus
+  | CompletedQueueStatus
+  | EnqueuedQueueStatus;
 
 export function isQueueStatus(obj: any): obj is QueueStatus {
   return obj && obj.status && obj.response_url;
+}
+
+export function isCompletedQueueStatus(obj: any): obj is CompletedQueueStatus {
+  return isQueueStatus(obj) && obj.status === 'COMPLETED';
 }
 
 export type ValidationErrorInfo = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "ts-node": "^10.9.1",
         "ts-protoc-gen": "^0.15.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "5.1.6"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2451,19 +2451,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@commitlint/message": {
@@ -5556,6 +5543,19 @@
         "eslint": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nx/linter/node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@nx/next": {
@@ -29617,9 +29617,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -121,6 +121,6 @@
     "ts-node": "^10.9.1",
     "ts-protoc-gen": "^0.15.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.1.6"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
### `subscribeToStatus` API

The `fal.queue.subscribeToStatus(endpointId, options)` exposes the polling (or streaming) mechanism used by `fal.subscribe(endpointId, options)` as an API so that users can use to manage more complex workflows, such as client/server integration.

See #59 for feature request and use case details.

### How to use it

After calling `fal.queue.submit()` or have obtained a `requestId` submitted to fal some other way (e.g. in your server), call `fal.queue.subscribeToStatus()` to listen to queue status updates until it's done:

```tsx

const { requestId } = await fal.queue.submit("my/endpoint");

await fal.queue.subscribeToStatus("my/endpoint", {
  requestId,
  onQueueUpdate(update) {
    console.log(update.status);
  }
});

//  it's all done, you can fetch the result now
const result = await fal.queue.result("my/endpoint", { requestId });

```