### PR TITLE
feat(client): local credentials warning suppress option

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.14.0",
+  "version": "0.14.1-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -9,10 +9,43 @@ import { defaultResponseHandler } from './response';
 export type CredentialsResolver = () => string | undefined;
 
 export type Config = {
+  /**
+   * The credentials to use for the fal serverless client. When using the
+   * client in the browser, it's recommended to use a proxy server to avoid
+   * exposing the credentials in the client's environment.
+   *
+   * By default it tries to use the `FAL_KEY` environment variable, when
+   * `process.env` is defined.
+   *
+   * @see https://fal.ai/docs/model-endpoints/server-side
+   * @see #suppressLocalCredentialsWarning
+   */
   credentials?: undefined | string | CredentialsResolver;
+  /**
+   * Suppresses the warning when the fal credentials are exposed in the
+   * browser's environment. Make sure you understand the security implications
+   * before enabling this option.
+   */
+  suppressLocalCredentialsWarning?: boolean;
+  /**
+   * The URL of the proxy server to use for the client requests. The proxy
+   * server should forward the requests to the fal serverless rest api.
+   */
   proxyUrl?: string;
+  /**
+   * The request middleware to use for the client requests. By default it
+   * doesn't apply any middleware.
+   */
   requestMiddleware?: RequestMiddleware;
+  /**
+   * The response handler to use for the client requests. By default it uses
+   * a built-in response handler that returns the JSON response.
+   */
   responseHandler?: ResponseHandler<any>;
+  /**
+   * The fetch implementation to use for the client requests. By default it uses
+   * the global `fetch` function.
+   */
   fetch?: typeof fetch;
 };
 
@@ -48,6 +81,7 @@ export const credentialsFromEnv: CredentialsResolver = () => {
 
 const DEFAULT_CONFIG: Partial<Config> = {
   credentials: credentialsFromEnv,
+  suppressLocalCredentialsWarning: false,
   requestMiddleware: (request) => Promise.resolve(request),
   responseHandler: defaultResponseHandler,
 };
@@ -69,6 +103,17 @@ export function config(config: Config) {
         configuration.requestMiddleware
       ),
     };
+  }
+  const { credentials, suppressLocalCredentialsWarning } = configuration;
+  if (
+    typeof window !== 'undefined' &&
+    credentials &&
+    !suppressLocalCredentialsWarning
+  ) {
+    console.warn(
+      "The fal credentials are exposed in the browser's environment. " +
+        "That's not recommended for production use cases."
+    );
   }
 }
 

--- a/libs/client/src/request.ts
+++ b/libs/client/src/request.ts
@@ -32,12 +32,6 @@ export async function dispatchRequest<Input, Output>(
     url: targetUrl,
   });
   const authHeader = credentials ? { Authorization: `Key ${credentials}` } : {};
-  if (typeof window !== 'undefined' && credentials) {
-    console.warn(
-      "The fal credentials are exposed in the browser's environment. " +
-        "That's not recommended for production use cases."
-    );
-  }
   const requestHeaders = {
     ...authHeader,
     Accept: 'application/json',


### PR DESCRIPTION
### Notes:

- The local credentials warning is no longer emitted on every request, but at config time instead
- An option to suppress it has been added: `suppressLocalCredentialsWarning`
- Config options documentation added