### PR TITLE
fix(client): global reference when accessing fetch

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.14.0",
+  "version": "0.14.1-alpha.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/request.ts
+++ b/libs/client/src/request.ts
@@ -20,7 +20,7 @@ export async function dispatchRequest<Input, Output>(
     credentials: credentialsValue,
     requestMiddleware,
     responseHandler,
-    fetch = global.fetch,
+    fetch,
   } = getConfig();
   const userAgent = isBrowser() ? {} : { 'User-Agent': getUserAgent() };
   const credentials =

--- a/libs/client/src/storage.ts
+++ b/libs/client/src/storage.ts
@@ -76,7 +76,7 @@ type KeyValuePair = [string, any];
 
 export const storageImpl: StorageSupport = {
   upload: async (file: Blob) => {
-    const { fetch = global.fetch } = getConfig();
+    const { fetch } = getConfig();
     const { upload_url: uploadUrl, file_url: url } = await initiateUpload(file);
     const response = await fetch(uploadUrl, {
       method: 'PUT',

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -129,7 +129,7 @@ export class FalStream<Input, Output> {
         // if we are in the browser, we need to get a temporary token
         // to authenticate the request
         const token = await getTemporaryAuthToken(endpointId);
-        const { fetch = global.fetch } = getConfig();
+        const { fetch } = getConfig();
         const parsedUrl = new URL(this.url);
         parsedUrl.searchParams.set('fal_jwt_token', token);
         const response = await fetch(parsedUrl.toString(), {


### PR DESCRIPTION
### Notes:

- No longer refers to `global` when looking for the default `fetch` implementation, since not all environments have a global reference (i.e. frameworks like Next.js might patch it, but it's not a standard practice).