### PR TITLE
feat: add status_url and cancel_url to BaseQueueStatus

### DIFF
--- a/libs/client/src/types/common.ts
+++ b/libs/client/src/types/common.ts
@@ -62,23 +62,23 @@ export type Metrics = {
 interface BaseQueueStatus {
   status: "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED";
   request_id: string;
+  response_url: string;
+  status_url: string;
+  cancel_url: string;
 }
 
 export interface InQueueQueueStatus extends BaseQueueStatus {
   status: "IN_QUEUE";
   queue_position: number;
-  response_url: string;
 }
 
 export interface InProgressQueueStatus extends BaseQueueStatus {
   status: "IN_PROGRESS";
-  response_url: string;
   logs: RequestLog[];
 }
 
 export interface CompletedQueueStatus extends BaseQueueStatus {
   status: "COMPLETED";
-  response_url: string;
   logs: RequestLog[];
   metrics?: Metrics;
 }


### PR DESCRIPTION
A user reported those as missing from api while they do get returned in the response IRL