### PR TITLE
Fix Sam2ImageInput/PointPrompt input type

### DIFF
--- a/libs/client/src/types/endpoints.ts
+++ b/libs/client/src/types/endpoints.ts
@@ -511,7 +511,7 @@ export type PointPrompt = {
   /**
    * Label of the prompt. 1 for foreground, 0 for background Default value: `"1"`
    */
-  label?: "0" | "1";
+  label?: 0 | 1;
   /**
    * The frame index to interact with.
    */


### PR DESCRIPTION
Model: https://fal.ai/models/fal-ai/sam2/image

I attempted to call API and got this validation error:

```
{
    "detail": [
        {
            "loc": [
                "body",
                "prompts",
                0,
                "label"
            ],
            "msg": "unexpected value; permitted: 0, 1",
            "type": "value_error.const",
            "ctx": {
                "given": "1",
                "permitted": [
                    0,
                    1
                ]
            }
        },
        {
            "loc": [
                "body",
                "prompts",
                1,
                "label"
            ],
            "msg": "unexpected value; permitted: 0, 1",
            "type": "value_error.const",
            "ctx": {
                "given": "1",
                "permitted": [
                    0,
                    1
                ]
            }
        },
        {
            "loc": [
                "body",
                "prompts",
                2,
                "label"
            ],
            "msg": "unexpected value; permitted: 0, 1",
            "type": "value_error.const",
            "ctx": {
                "given": "1",
                "permitted": [
                    0,
                    1
                ]
            }
        }
    ]
}
```

Seems that the types are misleading. An integer is expected.