### PR TITLE
fix(client): restore Node 18+ support

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The client uses standard Web APIs (`fetch`, `TextDecoder`, `ReadableStream`) that have been stable since Node 18. There's no technical requirement for Node 22.

This restores compatibility with Node 18, 20, and 22 LTS versions.

Fixes #175