### PR TITLE
feat: introduce useJwt for realtime client

### DIFF
--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -21,6 +21,14 @@ export function resolveDefaultFetch(): FetchType {
   return fetch;
 }
 
+export type WebSocketFactory = (
+  url: string,
+  protocols?: string | string[],
+  options?: {
+    headers?: Record<string, string>;
+  },
+) => WebSocket;
+
 export type Config = {
   /**
    * The credentials to use for the fal client. When using the
@@ -65,6 +73,11 @@ export type Config = {
    * When not specified, a default retry configuration is used.
    */
   retry?: Partial<RetryOptions>;
+  /**
+   * Optional WebSocket factory used by the realtime client.
+   * Required for header-based auth in server environments.
+   */
+  websocketFactory?: WebSocketFactory;
 };
 
 export type RequiredConfig = Required<Config>;


### PR DESCRIPTION
For backward compat we default to useJwt=True, but you will now be able to turn it off in case jwt are not working or something.