### PR TITLE
feat(client): allow proxy middleware in non-browser runtimes

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.9.6",
+  "version": "1.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/config.ts
+++ b/libs/client/src/config.ts
@@ -1,6 +1,7 @@
 import {
   withMiddleware,
   withProxy,
+  type ProxyRuntimeGate,
   type RequestMiddleware,
 } from "./middleware";
 import type { ResponseHandler } from "./response";
@@ -9,6 +10,23 @@ import { DEFAULT_RETRY_OPTIONS, type RetryOptions } from "./retry";
 import { isBrowser } from "./runtime";
 
 export type CredentialsResolver = () => string | undefined;
+
+/**
+ * Full configuration for the proxy middleware. Use this object form of
+ * `proxyUrl` to control when the proxy applies in non-browser runtimes.
+ */
+export type ProxyUrlConfig = {
+  /**
+   * The URL of the proxy server. The proxy server should forward the
+   * requests to the fal api.
+   */
+  url: string;
+  /**
+   * When the proxy middleware should apply. Defaults to `"browser"`.
+   * @see ProxyRuntimeGate
+   */
+  when?: ProxyRuntimeGate;
+};
 
 type FetchType = typeof fetch;
 
@@ -41,10 +59,39 @@ export type Config = {
    */
   suppressLocalCredentialsWarning?: boolean;
   /**
-   * The URL of the proxy server to use for the client requests. The proxy
-   * server should forward the requests to the fal api.
+   * The proxy server to use for the client requests. The proxy server should
+   * forward the requests to the fal api.
+   *
+   * Pass a `string` for the common browser-only case — the middleware rewrites
+   * requests to this URL when a DOM `window` is available and does nothing
+   * otherwise (the default, recommended for standard web apps).
+   *
+   * Pass a {@link ProxyUrlConfig} object to opt into non-browser runtimes
+   * (Electron, server, edge/worker, Bun, etc.) via the `when` gate.
+   *
+   * @example Browser-only (unchanged behavior):
+   * ```ts
+   * fal.config({ proxyUrl: "/api/fal/proxy" });
+   * ```
+   *
+   * @example Always apply, regardless of runtime:
+   * ```ts
+   * fal.config({
+   *   proxyUrl: { url: "/api/fal/proxy", when: "always" },
+   * });
+   * ```
+   *
+   * @example Custom predicate (e.g. Electron renderer only):
+   * ```ts
+   * fal.config({
+   *   proxyUrl: {
+   *     url: "/api/fal/proxy",
+   *     when: ({ isBrowser }) => isBrowser || process.type === "renderer",
+   *   },
+   * });
+   * ```
    */
-  proxyUrl?: string;
+  proxyUrl?: string | ProxyUrlConfig;
   /**
    * The request middleware to use for the client requests. By default it
    * doesn't apply any middleware.
@@ -124,11 +171,15 @@ export function createConfig(config: Config): RequiredConfig {
     },
   } as RequiredConfig;
   if (config.proxyUrl) {
+    const proxy =
+      typeof config.proxyUrl === "string"
+        ? { url: config.proxyUrl }
+        : config.proxyUrl;
     configuration = {
       ...configuration,
       requestMiddleware: withMiddleware(
         configuration.requestMiddleware,
-        withProxy({ targetUrl: config.proxyUrl }),
+        withProxy({ targetUrl: proxy.url, when: proxy.when }),
       ),
     };
   }

--- a/libs/client/src/index.ts
+++ b/libs/client/src/index.ts
@@ -6,8 +6,14 @@ import { RunOptions } from "./types/common";
 
 export type { TokenProvider } from "./auth";
 export { createFalClient, type FalClient } from "./client";
+export type { ProxyUrlConfig } from "./config";
 export { withMiddleware, withProxy } from "./middleware";
-export type { RequestMiddleware } from "./middleware";
+export type {
+  ProxyRuntimeEnv,
+  ProxyRuntimeGate,
+  RequestMiddleware,
+  RequestProxyConfig,
+} from "./middleware";
 export type { QueueClient } from "./queue";
 export type { RealtimeClient } from "./realtime";
 export { ApiError, ValidationError } from "./response";

--- a/libs/client/src/middleware.spec.ts
+++ b/libs/client/src/middleware.spec.ts
@@ -1,0 +1,132 @@
+import { TARGET_URL_HEADER, withProxy, type RequestConfig } from "./middleware";
+
+const PROXY_URL = "https://example.com/api/fal/proxy";
+const ORIGIN_URL = "https://queue.fal.run/fal-ai/flux/text-to-image";
+
+function makeRequest(headers?: RequestConfig["headers"]): RequestConfig {
+  return {
+    url: ORIGIN_URL,
+    method: "POST",
+    headers,
+  };
+}
+
+function fakeBrowser() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  global.window = { document: {} } as any;
+}
+
+function clearBrowser() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).window;
+}
+
+describe("withProxy", () => {
+  afterEach(() => {
+    clearBrowser();
+  });
+
+  describe("default (browser-only) behavior", () => {
+    it("rewrites the request URL in a browser environment", async () => {
+      fakeBrowser();
+      const middleware = withProxy({ targetUrl: PROXY_URL });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(PROXY_URL);
+      expect(result.headers?.[TARGET_URL_HEADER]).toBe(ORIGIN_URL);
+    });
+
+    it("passes requests through unchanged outside a browser", async () => {
+      const middleware = withProxy({ targetUrl: PROXY_URL });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(ORIGIN_URL);
+      expect(result.headers?.[TARGET_URL_HEADER]).toBeUndefined();
+    });
+
+    it("evaluates the runtime per call, not at construction", async () => {
+      const middleware = withProxy({ targetUrl: PROXY_URL });
+
+      const serverResult = await middleware(makeRequest());
+      expect(serverResult.url).toBe(ORIGIN_URL);
+
+      fakeBrowser();
+      const browserResult = await middleware(makeRequest());
+      expect(browserResult.url).toBe(PROXY_URL);
+    });
+  });
+
+  describe("when: 'always'", () => {
+    it("rewrites the request URL outside a browser", async () => {
+      const middleware = withProxy({ targetUrl: PROXY_URL, when: "always" });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(PROXY_URL);
+      expect(result.headers?.[TARGET_URL_HEADER]).toBe(ORIGIN_URL);
+    });
+
+    it("rewrites the request URL in a browser", async () => {
+      fakeBrowser();
+      const middleware = withProxy({ targetUrl: PROXY_URL, when: "always" });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(PROXY_URL);
+    });
+  });
+
+  describe("when: predicate", () => {
+    it("rewrites when the predicate returns true", async () => {
+      const middleware = withProxy({
+        targetUrl: PROXY_URL,
+        when: ({ isBrowser }) => !isBrowser,
+      });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(PROXY_URL);
+      expect(result.headers?.[TARGET_URL_HEADER]).toBe(ORIGIN_URL);
+    });
+
+    it("skips when the predicate returns false", async () => {
+      fakeBrowser();
+      const middleware = withProxy({
+        targetUrl: PROXY_URL,
+        when: ({ isBrowser }) => !isBrowser,
+      });
+      const result = await middleware(makeRequest());
+
+      expect(result.url).toBe(ORIGIN_URL);
+    });
+
+    it("receives the correct runtime env flags", async () => {
+      const seen: boolean[] = [];
+      const middleware = withProxy({
+        targetUrl: PROXY_URL,
+        when: ({ isBrowser }) => {
+          seen.push(isBrowser);
+          return true;
+        },
+      });
+
+      await middleware(makeRequest());
+      fakeBrowser();
+      await middleware(makeRequest());
+
+      expect(seen).toEqual([false, true]);
+    });
+  });
+
+  describe("re-entrancy", () => {
+    it("passes through when the target URL header is already set", async () => {
+      fakeBrowser();
+      const middleware = withProxy({ targetUrl: PROXY_URL, when: "always" });
+      const result = await middleware(
+        makeRequest({ [TARGET_URL_HEADER]: "https://other.example/api" }),
+      );
+
+      expect(result.url).toBe(ORIGIN_URL);
+      expect(result.headers?.[TARGET_URL_HEADER]).toBe(
+        "https://other.example/api",
+      );
+    });
+  });
+});

--- a/libs/client/src/middleware.ts
+++ b/libs/client/src/middleware.ts
@@ -38,29 +38,63 @@ export function withMiddleware(
   };
 }
 
+/**
+ * Runtime information passed to a user-provided {@link ProxyRuntimeGate}
+ * predicate so it can decide whether the proxy middleware should apply.
+ */
+export type ProxyRuntimeEnv = {
+  isBrowser: boolean;
+};
+
+/**
+ * Controls when the proxy middleware applies:
+ * - `"browser"` — only when a DOM `window` is available (default).
+ * - `"always"` — in every runtime (Node, Electron, Bun, workers, etc.).
+ * - A predicate receiving {@link ProxyRuntimeEnv} — full control per call.
+ */
+export type ProxyRuntimeGate =
+  | "browser"
+  | "always"
+  | ((env: ProxyRuntimeEnv) => boolean);
+
 export type RequestProxyConfig = {
   targetUrl: string;
+  when?: ProxyRuntimeGate;
 };
 
 export const TARGET_URL_HEADER = "x-fal-target-url";
 
-export function withProxy(config: RequestProxyConfig): RequestMiddleware {
-  const passthrough = (requestConfig: RequestConfig) =>
-    Promise.resolve(requestConfig);
-  // when running on the server, we don't need to proxy the request
-  if (typeof window === "undefined") {
-    return passthrough;
+function shouldProxy(when: ProxyRuntimeGate | undefined): boolean {
+  const env: ProxyRuntimeEnv = {
+    isBrowser:
+      typeof window !== "undefined" && typeof window.document !== "undefined",
+  };
+  if (typeof when === "function") {
+    return when(env);
   }
-  // if x-fal-target-url is already set, we skip it
-  return (requestConfig) =>
-    requestConfig.headers && TARGET_URL_HEADER in requestConfig
-      ? passthrough(requestConfig)
-      : Promise.resolve({
-          ...requestConfig,
-          url: config.targetUrl,
-          headers: {
-            ...(requestConfig.headers || {}),
-            [TARGET_URL_HEADER]: requestConfig.url,
-          },
-        });
+  if (when === "always") {
+    return true;
+  }
+  return env.isBrowser;
+}
+
+export function withProxy(config: RequestProxyConfig): RequestMiddleware {
+  return (requestConfig) => {
+    // if x-fal-target-url is already set, we skip it to keep the middleware
+    // re-entrant (e.g. when composed with other proxy-like middlewares)
+    if (requestConfig.headers && TARGET_URL_HEADER in requestConfig.headers) {
+      return Promise.resolve(requestConfig);
+    }
+    if (!shouldProxy(config.when)) {
+      return Promise.resolve(requestConfig);
+    }
+    return Promise.resolve({
+      ...requestConfig,
+      url: config.targetUrl,
+      headers: {
+        ...(requestConfig.headers || {}),
+        [TARGET_URL_HEADER]: requestConfig.url,
+      },
+    });
+  };
 }

--- a/libs/proxy/README.md
+++ b/libs/proxy/README.md
@@ -74,6 +74,32 @@ fal.config({
 
 Now all your client calls will route through your server proxy, so your credentials are protected.
 
+By default, the proxy middleware only runs in browser environments — requests made from Node, Electron, Bun, or edge/worker runtimes are sent directly to the fal API. To opt into the proxy in these runtimes, pass an object instead of a string:
+
+```ts
+fal.config({
+  proxyUrl: {
+    url: "/api/fal/proxy",
+    when: "always",
+  },
+});
+```
+
+`when` accepts:
+
+- `"browser"` — only in environments with a DOM `window` (default).
+- `"always"` — in every runtime.
+- `(env) => boolean` — a custom predicate. `env` is `{ isBrowser: boolean }`, so you can layer your own checks — for example, routing through the proxy only from an Electron renderer process:
+
+  ```ts
+  fal.config({
+    proxyUrl: {
+      url: "/api/fal/proxy",
+      when: ({ isBrowser }) => isBrowser || (typeof process !== "undefined" && process.type === "renderer"),
+    },
+  });
+  ```
+
 ## More information
 
 For a deeper dive into the proxy library and its capabilities, explore the [official documentation](https://fal.ai/docs).


### PR DESCRIPTION
## Summary

- `withProxy` previously short-circuited to passthrough whenever `typeof window === "undefined"`, blocking Electron, Node servers, Bun, and edge/worker runtimes from routing through a proxy.
- Widen `proxyUrl` to accept `string | { url, when? }` with a `when` gate that's evaluated per request. Supports `"browser"` (default, unchanged behavior), `"always"`, or a predicate receiving `{ isBrowser }`.
- Bumps `@fal-ai/client` to `1.10.0`.

### Usage

```ts
// Existing form — unchanged, browser-only
fal.config({ proxyUrl: "/api/fal/proxy" });

// Opt into Electron / server / edge
fal.config({ proxyUrl: { url: "/api/fal/proxy", when: "always" } });

// Custom predicate
fal.config({
  proxyUrl: {
    url: "/api/fal/proxy",
    when: ({ isBrowser }) => isBrowser || process.type === "renderer",
  },
});
```

### Non-breaking guarantees

- String `proxyUrl` keeps identical semantics (`when` defaults to `"browser"`).
- `RequestMiddleware`, `RequestConfig`, and `x-fal-target-url` wire format are unchanged — existing `@fal-ai/server-proxy` deployments keep working.
- Type change on `Config.proxyUrl` is a widening.

### Incidental fix

The existing re-entrancy bypass had a typo (`TARGET_URL_HEADER in requestConfig` instead of `... in requestConfig.headers`). Corrected while reworking the function so the comment ("if x-fal-target-url is already set, we skip it") matches the code.

## Test plan

- [x] `nx test client` — 10 suites / 68 tests pass, including new `middleware.spec.ts` covering string/object forms, all three `when` values, per-call runtime evaluation, and the header re-entrancy bypass.
- [x] `nx test proxy` — existing 54 tests still pass (server-side unchanged).
- [x] `nx build client` — typecheck clean with widened `Config.proxyUrl`.
- [x] `nx lint client` — no new warnings.
- [ ] Manual smoke test in an Electron main process with `when: "always"`.