### PR TITLE
fix(client): retry Node-level transport errors in subscribe/dispatch

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/retry.spec.ts
+++ b/libs/client/src/retry.spec.ts
@@ -83,6 +83,24 @@ describe("Retry functionality", () => {
       );
     });
 
+    it("should not retry TimeoutError (e.g. AbortSignal.timeout)", () => {
+      const error = new Error("The operation was aborted due to timeout");
+      error.name = "TimeoutError";
+      expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        false,
+      );
+    });
+
+    it("should not retry when an AbortError is buried in the cause chain", () => {
+      const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+      const wrapped = Object.assign(new TypeError("fetch failed"), {
+        cause: abort,
+      });
+      expect(isRetryableError(wrapped, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        false,
+      );
+    });
+
     it("should walk a deeper cause chain to find a retryable code", () => {
       const root = Object.assign(new Error("root"), { code: "ETIMEDOUT" });
       const middle = Object.assign(new Error("middle"), { cause: root });

--- a/libs/client/src/retry.spec.ts
+++ b/libs/client/src/retry.spec.ts
@@ -5,8 +5,14 @@ import {
   DEFAULT_RETRYABLE_STATUS_CODES,
   executeWithRetry,
   isRetryableError,
+  isRetryableNetworkError,
   type RetryOptions,
 } from "./retry";
+
+function makeFetchFailed(code: string): TypeError {
+  const cause = Object.assign(new Error(`connect ${code}`), { code });
+  return Object.assign(new TypeError("fetch failed"), { cause });
+}
 
 const BAD_GATEWAY_ERROR = new ApiError({ message: "Bad gateway", status: 502 });
 
@@ -26,11 +32,64 @@ describe("Retry functionality", () => {
       );
     });
 
-    it("should return false for non-ApiError errors", () => {
-      const error = new Error("Network error");
+    it("should return false for unrelated non-ApiError errors", () => {
+      const error = new Error("Some other failure");
       expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
         false,
       );
+    });
+
+    it.each([
+      "ETIMEDOUT",
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "EPIPE",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "UND_ERR_SOCKET",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_BODY_TIMEOUT",
+    ])("should retry Node fetch wrapping %s", (code) => {
+      const error = makeFetchFailed(code);
+      expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        true,
+      );
+    });
+
+    it("should retry errors that expose `code` directly (e.g. node-fetch)", () => {
+      const error = Object.assign(new Error("socket hang up"), {
+        code: "ECONNRESET",
+      });
+      expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        true,
+      );
+    });
+
+    it("should retry generic `TypeError: fetch failed` without a known code", () => {
+      const error = new TypeError("fetch failed");
+      expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        true,
+      );
+    });
+
+    it("should not retry AbortError even when wrapped by fetch", () => {
+      const error = new Error("The operation was aborted.");
+      error.name = "AbortError";
+      expect(isRetryableError(error, DEFAULT_RETRYABLE_STATUS_CODES)).toBe(
+        false,
+      );
+    });
+
+    it("should walk a deeper cause chain to find a retryable code", () => {
+      const root = Object.assign(new Error("root"), { code: "ETIMEDOUT" });
+      const middle = Object.assign(new Error("middle"), { cause: root });
+      const top = Object.assign(new TypeError("fetch failed"), {
+        cause: middle,
+      });
+      expect(isRetryableNetworkError(top)).toBe(true);
     });
 
     it("should return false for user-specified timeout (504 with timeoutType: user)", () => {
@@ -173,6 +232,27 @@ describe("Retry functionality", () => {
       await executeWithRetry(operation, options, onRetry);
 
       expect(onRetry).toHaveBeenCalledWith(1, BAD_GATEWAY_ERROR, 10);
+    });
+
+    it("should retry on Node-level network errors (ETIMEDOUT)", async () => {
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(makeFetchFailed("ETIMEDOUT"))
+        .mockRejectedValueOnce(makeFetchFailed("ECONNRESET"))
+        .mockResolvedValue("success");
+
+      const options: RetryOptions = {
+        ...DEFAULT_RETRY_OPTIONS,
+        maxRetries: 3,
+        baseDelay: 10,
+        enableJitter: false,
+      };
+
+      const { result, metrics } = await executeWithRetry(operation, options);
+
+      expect(result).toBe("success");
+      expect(metrics.totalAttempts).toBe(3);
+      expect(operation).toHaveBeenCalledTimes(3);
     });
 
     it("should not retry on user-specified timeout", async () => {

--- a/libs/client/src/retry.ts
+++ b/libs/client/src/retry.ts
@@ -55,20 +55,28 @@ export function isRetryableNetworkError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
-  // User-initiated cancellation must not be retried.
-  if ((error as { name?: string }).name === "AbortError") {
-    return false;
-  }
 
+  // Walk the cause chain. User cancellation (AbortError) and signal-driven
+  // timeouts (TimeoutError, e.g. AbortSignal.timeout) are explicit user
+  // intent — never retry them, even if buried in a wrapper.
   const seen = new Set<unknown>();
   let current: any = error;
+  let sawTransportShape = false;
   while (current && typeof current === "object" && !seen.has(current)) {
     seen.add(current);
+    const name = (current as { name?: unknown }).name;
+    if (name === "AbortError" || name === "TimeoutError") {
+      return false;
+    }
     const code = (current as { code?: unknown }).code;
     if (typeof code === "string" && RETRYABLE_NETWORK_ERROR_CODES.has(code)) {
-      return true;
+      sawTransportShape = true;
     }
     current = (current as { cause?: unknown }).cause;
+  }
+
+  if (sawTransportShape) {
+    return true;
   }
 
   // Generic Node `fetch` failure (`TypeError: fetch failed`) without a

--- a/libs/client/src/retry.ts
+++ b/libs/client/src/retry.ts
@@ -25,21 +25,83 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 };
 
 /**
- * Determines if an error is retryable based on the status code.
- * User-specified timeouts (504 with X-Fal-Request-Timeout-Type: user) are NOT retryable.
+ * Network/transport-level error codes that indicate transient failures worth
+ * retrying. Node's `fetch` (undici) wraps the underlying SystemError inside a
+ * `TypeError("fetch failed")` and exposes the original via `.cause`; other
+ * fetch implementations such as `node-fetch` set `.code` directly on the error.
+ */
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * Returns true for transient transport-level failures (connection resets,
+ * DNS hiccups, socket timeouts, etc.). Mirrors the Python client's behavior
+ * of retrying `httpx.TransportError` and `httpx.TimeoutException`.
+ */
+export function isRetryableNetworkError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  // User-initiated cancellation must not be retried.
+  if ((error as { name?: string }).name === "AbortError") {
+    return false;
+  }
+
+  const seen = new Set<unknown>();
+  let current: any = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && RETRYABLE_NETWORK_ERROR_CODES.has(code)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  // Generic Node `fetch` failure (`TypeError: fetch failed`) without a
+  // recognised `.code` — still a transport-layer problem, treat it as
+  // retryable like httpx.TransportError does.
+  if (
+    error instanceof TypeError &&
+    typeof (error as { message?: unknown }).message === "string" &&
+    /fetch failed/i.test((error as { message: string }).message)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Determines if an error is retryable based on the status code or, for
+ * non-HTTP failures, on the underlying transport error. User-specified
+ * timeouts (504 with X-Fal-Request-Timeout-Type: user) are NOT retryable.
  */
 export function isRetryableError(
   error: any,
   retryableStatusCodes: number[],
 ): boolean {
-  if (!(error instanceof ApiError)) {
-    return false;
+  if (error instanceof ApiError) {
+    // User-specified timeouts should NOT be retried
+    if (error.isUserTimeout) {
+      return false;
+    }
+    return retryableStatusCodes.includes(error.status);
   }
-  // User-specified timeouts should NOT be retried
-  if (error.isUserTimeout) {
-    return false;
-  }
-  return retryableStatusCodes.includes(error.status);
+  return isRetryableNetworkError(error);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `fal.subscribe()` already retries HTTP 429/502/503/504, but transport-layer failures (Node's `fetch` wrapping `ETIMEDOUT`/`ECONNRESET`/`ENOTFOUND`/etc. in a `TypeError: fetch failed`) silently fell through because `isRetryableError` bailed out on any non-`ApiError`.
- `isRetryableError` now also recognises Node-level transport errors via a new `isRetryableNetworkError` helper that walks the `.cause` chain (covers Node fetch / undici, `node-fetch`, and other implementations that set `.code` directly), and treats a bare `TypeError: fetch failed` as a transport failure too.
- Mirrors the Python client's behavior of retrying `httpx.TransportError` and `httpx.TimeoutException` (other than user-set timeouts). `AbortError` is still skipped, so user-cancelled requests are not retried.
- Applies to every code path that goes through `dispatchRequest`: `subscribe`, `submit`, `status`, `result`, `cancel`, storage init.