### PR TITLE
feat(release): enable npm staged publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: "24"
           cache: "npm"
       - name: "Set npm version"
-        run: npm install -g npm@11.10.0
+        run: npm install -g npm@11.15.0
       - name: Install dependencies
         run: npm ci
       - name: Format check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: "Set npm version"
-        run: npm install -g npm@11.10.0
+        run: npm install -g npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -88,4 +88,4 @@ jobs:
         run: |
           echo "Publishing ${{ steps.tag-info.outputs.package }}@${{ steps.tag-info.outputs.version }} with tag ${{ steps.tag-info.outputs.npm_tag }}"
           cd dist/libs/${{ steps.tag-info.outputs.package }}
-          npm publish --access public --tag ${{ steps.tag-info.outputs.npm_tag }} ${{ inputs.dry_run && '--dry-run' || '' }}
+          npm stage publish --access public --tag ${{ steps.tag-info.outputs.npm_tag }} ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@fal-ai/fal-js",
   "version": "0.0.0",
   "license": "MIT",
-  "packageManager": "npm@11.10.0",
+  "packageManager": "npm@11.15.0",
   "engines": {
-    "npm": ">=11.10.0"
+    "npm": ">=11.15.0"
   },
   "scripts": {
     "start": "nx serve",


### PR DESCRIPTION
## Summary

- Switch `npm publish` to `npm stage publish` in the release workflow so packages go through an approval checkpoint before going live on the registry
- Bump npm pin from `11.10.0` to `11.15.0` (minimum version that supports `npm stage`)
- Update `packageManager` and `engines.npm` in `package.json` to match

## How it works

After this change, triggering a release will submit the package to npm's staging area. A maintainer then runs `npm stage approve <stage-id>` with 2FA to promote it to the public registry. See [npm staged publishing docs](https://docs.npmjs.com/staged-publishing) for details.

## Test plan

- [ ] Trigger a dry-run release via workflow dispatch and confirm `npm stage publish` is invoked
- [ ] Verify a real release stages successfully and can be approved with `npm stage approve <stage-id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)