### PR TITLE
feat(client): default request source header to sdk

### DIFF
--- a/libs/client/src/headers.ts
+++ b/libs/client/src/headers.ts
@@ -25,6 +25,17 @@ export const QUEUE_PRIORITY_HEADER = "x-fal-queue-priority";
 export const RUNNER_HINT_HEADER = "x-fal-runner-hint";
 
 /**
+ * Header name for the request source/client (surface classification).
+ */
+export const REQUEST_SOURCE_HEADER = "x-fal-request-source";
+
+/**
+ * Default request source for direct fal-js usage. Apps embedding the client
+ * (and per-call headers) override it via requestMiddleware / options.headers.
+ */
+export const DEFAULT_REQUEST_SOURCE = "sdk";
+
+/**
  * Validates the timeout and returns the header value as a string.
  * Throws an error if the timeout is invalid.
  *

--- a/libs/client/src/request.spec.ts
+++ b/libs/client/src/request.spec.ts
@@ -1,0 +1,65 @@
+import { createConfig } from "./config";
+import { REQUEST_SOURCE_HEADER } from "./headers";
+import { dispatchRequest } from "./request";
+
+describe("dispatchRequest request source header", () => {
+  function captureFetch() {
+    const calls: RequestInit[] = [];
+    const fetch = (async (_url: string, init: RequestInit) => {
+      calls.push(init);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-fal-request-id": "req_1",
+        },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    return { calls, fetch };
+  }
+
+  function headersOf(init: RequestInit): Record<string, string> {
+    return init.headers as Record<string, string>;
+  }
+
+  it("defaults the request source to sdk", async () => {
+    const { calls, fetch } = captureFetch();
+    const config = createConfig({
+      credentials: "test-key",
+      fetch,
+      responseHandler: async (response) => response,
+    });
+
+    await dispatchRequest({
+      targetUrl: "https://fal.run/fal-ai/fast-sdxl",
+      input: { prompt: "hello" },
+      config,
+    });
+
+    expect(headersOf(calls[0])[REQUEST_SOURCE_HEADER]).toBe("sdk");
+  });
+
+  it("lets requestMiddleware override the request source", async () => {
+    const { calls, fetch } = captureFetch();
+    const config = createConfig({
+      credentials: "test-key",
+      fetch,
+      responseHandler: async (response) => response,
+      requestMiddleware: async (request) => ({
+        ...request,
+        headers: {
+          ...(request.headers ?? {}),
+          [REQUEST_SOURCE_HEADER]: "web_app",
+        },
+      }),
+    });
+
+    await dispatchRequest({
+      targetUrl: "https://fal.run/fal-ai/fast-sdxl",
+      input: { prompt: "hello" },
+      config,
+    });
+
+    expect(headersOf(calls[0])[REQUEST_SOURCE_HEADER]).toBe("web_app");
+  });
+});

--- a/libs/client/src/request.ts
+++ b/libs/client/src/request.ts
@@ -1,4 +1,5 @@
 import { RequiredConfig } from "./config";
+import { DEFAULT_REQUEST_SOURCE, REQUEST_SOURCE_HEADER } from "./headers";
 import { ResponseHandler } from "./response";
 import {
   calculateBackoffDelay,
@@ -66,6 +67,9 @@ export async function dispatchRequest<Input, Output>(
       ...authHeader,
       Accept: "application/json",
       "Content-Type": "application/json",
+      // Default source for direct SDK usage; embedders and per-call headers
+      // override it via requestMiddleware / options.headers (spread after).
+      [REQUEST_SOURCE_HEADER]: DEFAULT_REQUEST_SOURCE,
       ...userAgent,
       ...(headers ?? {}),
     } as HeadersInit;


### PR DESCRIPTION
## Problem
- Requests from the fal-js SDK are indistinguishable from raw API calls at the gateway - both auth-derive to `api`. There's no way to attribute SDK usage specifically.

## Solution
- Default `x-fal-request-source: sdk` on every request in `dispatchRequest`.
- It's a default: spread before middleware-returned headers and per-call `options.headers`, so embedding apps and callers override it (e.g. a web app tagging `playground`/`sandbox`, or the genmedia CLI tagging `genmedia_cli`).
- No new public config option - kept off the API surface so the source isn't advertised as a client-settable knob.

## Notes
- Gateway side trusts this header in v1; privileged sources are reconciled against auth server-side (separate work). Claiming `sdk` from an API caller is harmless.
- Covers the `dispatchRequest` path (run/subscribe/queue). Streaming/realtime/storage are separate transports - follow-up if needed.

## Test checklist
- [x] `nx test client` - new `request.spec.ts`: default `sdk` + middleware override
- [x] `nx lint client` (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
