### PR TITLE
feat(client): surface x-fal-billable-units on results and errors

### DIFF
--- a/libs/client/src/headers.ts
+++ b/libs/client/src/headers.ts
@@ -25,6 +25,16 @@ export const QUEUE_PRIORITY_HEADER = "x-fal-queue-priority";
 export const RUNNER_HINT_HEADER = "x-fal-runner-hint";
 
 /**
+ * Response header for the request id assigned by fal.
+ */
+export const REQUEST_ID_HEADER = "x-fal-request-id";
+
+/**
+ * Response header for billing units charged for the request.
+ */
+export const BILLABLE_UNITS_HEADER = "x-fal-billable-units";
+
+/**
  * Validates the timeout and returns the header value as a string.
  * Throws an error if the timeout is invalid.
  *

--- a/libs/client/src/response.spec.ts
+++ b/libs/client/src/response.spec.ts
@@ -1,0 +1,145 @@
+import {
+  ApiError,
+  defaultResponseHandler,
+  parseBillableUnits,
+  resultResponseHandler,
+  ValidationError,
+} from "./response";
+
+function jsonResponse(
+  body: unknown,
+  init: {
+    status?: number;
+    headers?: Record<string, string>;
+  } = {},
+): Response {
+  const { status = 200, headers = {} } = init;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  });
+}
+
+describe("parseBillableUnits", () => {
+  it("returns undefined when the header is missing", () => {
+    expect(parseBillableUnits(new Headers())).toBeUndefined();
+  });
+
+  it("returns undefined when the header is empty", () => {
+    expect(
+      parseBillableUnits(new Headers({ "x-fal-billable-units": "" })),
+    ).toBeUndefined();
+  });
+
+  it("parses integer units", () => {
+    expect(
+      parseBillableUnits(new Headers({ "x-fal-billable-units": "42" })),
+    ).toBe(42);
+  });
+
+  it("parses zero", () => {
+    expect(
+      parseBillableUnits(new Headers({ "x-fal-billable-units": "0" })),
+    ).toBe(0);
+  });
+
+  it("parses fractional units", () => {
+    expect(
+      parseBillableUnits(new Headers({ "x-fal-billable-units": "3.14159265" })),
+    ).toBe(3.14159265);
+  });
+
+  it("throws on non-numeric values", () => {
+    expect(() =>
+      parseBillableUnits(
+        new Headers({ "x-fal-billable-units": "not-a-number" }),
+      ),
+    ).toThrow("Invalid x-fal-billable-units header: not-a-number");
+  });
+});
+
+describe("resultResponseHandler", () => {
+  it("surfaces requestId and billableUnits from response headers", async () => {
+    const response = jsonResponse(
+      { image: "https://example.com/image.png" },
+      {
+        headers: {
+          "x-fal-request-id": "req_abc",
+          "x-fal-billable-units": "1.5",
+        },
+      },
+    );
+
+    const result = await resultResponseHandler<{ image: string }>(response);
+
+    expect(result).toEqual({
+      data: { image: "https://example.com/image.png" },
+      requestId: "req_abc",
+      billableUnits: 1.5,
+    });
+  });
+
+  it("omits billableUnits when the header is absent", async () => {
+    const response = jsonResponse(
+      { ok: true },
+      { headers: { "x-fal-request-id": "req_no_units" } },
+    );
+
+    const result = await resultResponseHandler<{ ok: boolean }>(response);
+
+    expect(result).toEqual({
+      data: { ok: true },
+      requestId: "req_no_units",
+      billableUnits: undefined,
+    });
+  });
+});
+
+describe("defaultResponseHandler errors", () => {
+  it("attaches requestId and billableUnits to ApiError", async () => {
+    const error = await defaultResponseHandler(
+      jsonResponse(
+        { message: "Server error" },
+        {
+          status: 500,
+          headers: {
+            "x-fal-request-id": "req_err",
+            "x-fal-billable-units": "0",
+          },
+        },
+      ),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      status: 500,
+      requestId: "req_err",
+      billableUnits: 0,
+    });
+  });
+
+  it("attaches billableUnits to ValidationError", async () => {
+    const error = await defaultResponseHandler(
+      jsonResponse(
+        { message: "Unprocessable", detail: [] },
+        {
+          status: 422,
+          headers: {
+            "x-fal-request-id": "req_422",
+            "x-fal-billable-units": "0",
+          },
+        },
+      ),
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error).toMatchObject({
+      status: 422,
+      requestId: "req_422",
+      billableUnits: 0,
+    });
+  });
+});

--- a/libs/client/src/response.ts
+++ b/libs/client/src/response.ts
@@ -1,14 +1,34 @@
 import { RequiredConfig } from "./config";
-import { REQUEST_TIMEOUT_TYPE_HEADER } from "./headers";
+import {
+  BILLABLE_UNITS_HEADER,
+  REQUEST_ID_HEADER,
+  REQUEST_TIMEOUT_TYPE_HEADER,
+} from "./headers";
 import { Result, ValidationErrorInfo } from "./types/common";
 
 export type ResponseHandler<Output> = (response: Response) => Promise<Output>;
 
-const REQUEST_ID_HEADER = "x-fal-request-id";
-
 export type ResponseHandlerCreator<Output> = (
   config: RequiredConfig,
 ) => ResponseHandler<Output>;
+
+/**
+ * Parses the `x-fal-billable-units` response header into a number.
+ * Returns `undefined` when the header is missing.
+ */
+export function parseBillableUnits(
+  headers: Headers | { get(name: string): string | null },
+): number | undefined {
+  const raw = headers.get(BILLABLE_UNITS_HEADER);
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid ${BILLABLE_UNITS_HEADER} header: ${raw}`);
+  }
+  return value;
+}
 
 type ApiErrorArgs = {
   message: string;
@@ -16,6 +36,7 @@ type ApiErrorArgs = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;
   requestId?: string;
+  billableUnits?: number;
   /**
    * The type of timeout that occurred. If "user", this was a user-specified
    * timeout via startTimeout and should NOT be retried.
@@ -27,13 +48,22 @@ export class ApiError<Body> extends Error {
   public readonly status: number;
   public readonly body: Body;
   public readonly requestId: string;
+  public readonly billableUnits?: number;
   public readonly timeoutType?: string;
-  constructor({ message, status, body, requestId, timeoutType }: ApiErrorArgs) {
+  constructor({
+    message,
+    status,
+    body,
+    requestId,
+    billableUnits,
+    timeoutType,
+  }: ApiErrorArgs) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.body = body;
     this.requestId = requestId || "";
+    this.billableUnits = billableUnits;
     this.timeoutType = timeoutType;
   }
 
@@ -84,6 +114,7 @@ export async function defaultResponseHandler<Output>(
   const { status, statusText } = response;
   const contentType = response.headers.get("Content-Type") ?? "";
   const requestId = response.headers.get(REQUEST_ID_HEADER) || undefined;
+  const billableUnits = parseBillableUnits(response.headers);
   const timeoutType =
     response.headers.get(REQUEST_TIMEOUT_TYPE_HEADER) || undefined;
   if (!response.ok) {
@@ -95,6 +126,7 @@ export async function defaultResponseHandler<Output>(
         status,
         body,
         requestId,
+        billableUnits,
         timeoutType,
       });
     }
@@ -102,6 +134,7 @@ export async function defaultResponseHandler<Output>(
       message: `HTTP ${status}: ${statusText}`,
       status,
       requestId,
+      billableUnits,
       timeoutType,
     });
   }
@@ -125,5 +158,6 @@ export async function resultResponseHandler<Output>(
   return {
     data,
     requestId: response.headers.get(REQUEST_ID_HEADER) || "",
+    billableUnits: parseBillableUnits(response.headers),
   } satisfies Result<Output>;
 }

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -1,8 +1,13 @@
 import { createParser } from "eventsource-parser";
 import { type TokenProvider, getTemporaryAuthToken } from "./auth";
 import { RequiredConfig } from "./config";
+import { REQUEST_ID_HEADER } from "./headers";
 import { buildUrl, dispatchRequest } from "./request";
-import { ApiError, defaultResponseHandler } from "./response";
+import {
+  ApiError,
+  defaultResponseHandler,
+  parseBillableUnits,
+} from "./response";
 import { type StorageClient } from "./storage";
 import { EndpointType, InputType, OutputType } from "./types/client";
 import { ensureEndpointIdFormat, resolveEndpointPath } from "./utils";
@@ -103,6 +108,7 @@ export class FalStream<Input, Output> {
   private lastEventTimestamp = 0;
   private streamClosed = false;
   private _requestId: string | null = null;
+  private _billableUnits: number | undefined = undefined;
   private donePromise: Promise<Output>;
 
   private abortController = new AbortController();
@@ -194,7 +200,8 @@ export class FalStream<Input, Output> {
           body: input && method !== "get" ? JSON.stringify(input) : undefined,
           signal: this.abortController.signal,
         });
-        this._requestId = response.headers.get("x-fal-request-id");
+        this._requestId = response.headers.get(REQUEST_ID_HEADER);
+        this._billableUnits = parseBillableUnits(response.headers);
         return await this.handleResponse(response);
       }
       return await dispatchRequest({
@@ -207,7 +214,8 @@ export class FalStream<Input, Output> {
             accept: options.accept ?? CONTENT_TYPE_EVENT_STREAM,
           },
           responseHandler: async (response) => {
-            this._requestId = response.headers.get("x-fal-request-id");
+            this._requestId = response.headers.get(REQUEST_ID_HEADER);
+            this._billableUnits = parseBillableUnits(response.headers);
             return await this.handleResponse(response);
           },
           signal: this.abortController.signal,
@@ -413,6 +421,16 @@ export class FalStream<Input, Output> {
    */
   public get requestId() {
     return this._requestId;
+  }
+
+  /**
+   * Gets the billable units charged for the streaming request, when present
+   * on the response headers.
+   *
+   * @returns the billable units, or `undefined` when the header was not set.
+   */
+  public get billableUnits() {
+    return this._billableUnits;
   }
 }
 

--- a/libs/client/src/types/common.ts
+++ b/libs/client/src/types/common.ts
@@ -7,6 +7,15 @@ import type { StorageSettings } from "../storage";
 export type Result<T> = {
   data: T;
   requestId: string;
+  /**
+   * Billing units charged for this request, from the `x-fal-billable-units`
+   * response header. Multiply by the endpoint's unit price to get cost.
+   * Absent when the platform did not return the header.
+   *
+   * @see https://docs.fal.ai/documentation/model-apis/common-parameters
+   * @see https://docs.fal.ai/documentation/model-apis/pricing
+   */
+  billableUnits?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Parse `x-fal-billable-units` from response headers and surface it as `billableUnits` on `Result` (`run` / `subscribe` / `queue.result`), `ApiError` / `ValidationError`, and `FalStream`
- Centralize `REQUEST_ID_HEADER` and `BILLABLE_UNITS_HEADER` in `headers.ts`
- Add unit tests for parsing and response handlers

Callers can combine `billableUnits` with unit price from the [pricing API](https://docs.fal.ai/documentation/model-apis/pricing) to compute per-request cost.

## Related issues

- Closes #177
- Closes #133

## Test plan

- [x] `nx test client` (including new `response.spec.ts`)
- [ ] Verify against a live model response that returns `x-fal-billable-units`
- [ ] Confirm missing header leaves `billableUnits` undefined