### PR TITLE
fix(proxy): harden request/response forwarding across adapters

### DIFF
--- a/libs/proxy/src/config.ts
+++ b/libs/proxy/src/config.ts
@@ -1,6 +1,6 @@
 import picomatch from "picomatch";
 import { ProxyBehavior } from "./types";
-import { singleHeaderValue } from "./utils";
+import { DEFAULT_MAX_REQUEST_BODY_BYTES, singleHeaderValue } from "./utils";
 
 /**
  * The fal REST API URL used for storage operations.
@@ -163,7 +163,7 @@ export async function isAuthorizationHeaderPresent(
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   allowedUrlPatterns: DEFAULT_ALLOWED_URL_PATTERNS,
   serviceHosts: ["wma.fal.run"],
-  maxRequestBodyBytes: 32 * 1024 * 1024,
+  maxRequestBodyBytes: DEFAULT_MAX_REQUEST_BODY_BYTES,
   allowedEndpoints: [],
   forwardRequestHeaders: [],
   allowUnauthorizedRequests: true,
@@ -182,6 +182,15 @@ export function applyProxyConfig(config: Partial<ProxyConfig>): ProxyConfig {
     ...DEFAULT_PROXY_CONFIG,
     ...config,
   };
+  resolvedConfig.maxRequestBodyBytes ??= DEFAULT_MAX_REQUEST_BODY_BYTES;
+  if (
+    !Number.isSafeInteger(resolvedConfig.maxRequestBodyBytes) ||
+    resolvedConfig.maxRequestBodyBytes < 0
+  ) {
+    throw new TypeError(
+      "maxRequestBodyBytes must be a non-negative safe integer",
+    );
+  }
   if (
     !Array.isArray(resolvedConfig.allowedEndpoints) ||
     resolvedConfig.allowedEndpoints.length === 0

--- a/libs/proxy/src/config.ts
+++ b/libs/proxy/src/config.ts
@@ -75,6 +75,23 @@ export interface ProxyConfig {
   allowedEndpoints?: string[] | undefined;
 
   /**
+   * Additional request header names (lowercase, exact) to forward to the target.
+   *
+   * The proxy forwards `x-fal-*` headers plus `accept` and `content-type` by default and nothing
+   * else: applications commonly authenticate their own proxy route with custom headers
+   * (`x-api-key`, session tokens, CSRF tokens) that a pass-through would leak to the upstream on
+   * every call, and no denylist can enumerate them. A realtime extension that needs a
+   * provider-specific header through the proxy names it here — an explicit operator decision.
+   *
+   * ```js
+   * forwardRequestHeaders: ["x-provider-ticket"]
+   * ```
+   *
+   * @default []
+   */
+  forwardRequestHeaders?: string[];
+
+  /**
    * Whether to allow requests without an authorization header. Currently for backwards compatibility
    * this is set to `true` by default. In the future the behavior might change to disallow unauthorized
    * requests by default and require explicitly allowing unauthorized requests.
@@ -125,6 +142,7 @@ export async function isAuthorizationHeaderPresent(
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   allowedUrlPatterns: DEFAULT_ALLOWED_URL_PATTERNS,
   allowedEndpoints: [],
+  forwardRequestHeaders: [],
   allowUnauthorizedRequests: true,
   isAuthenticated: isAuthorizationHeaderPresent,
   resolveFalAuth: fallbackToFalKey,

--- a/libs/proxy/src/config.ts
+++ b/libs/proxy/src/config.ts
@@ -53,6 +53,27 @@ export interface ProxyConfig {
   allowedUrlPatterns?: string[];
 
   /**
+   * fal-operated SERVICE hosts (infrastructure that serves no customer app, like the WMA
+   * signalling bridge). These bypass `allowedUrlPatterns` — their paths are not app ids — but are
+   * default-deny by route: only the service's known paths forward, and app-scoped routes enforce
+   * `allowedEndpoints` against the app identity in the request body. Set to `[]` to refuse
+   * service hosts entirely, or extend it when fal ships a new service host before your package
+   * updates.
+   *
+   * @default ["wma.fal.run"]
+   */
+  serviceHosts?: string[];
+
+  /**
+   * Upper bound, in bytes, for request bodies the proxy buffers whole (the raw-stream path used
+   * for multipart and binary bodies). Parser-backed paths are bounded by the parser's own limits;
+   * this bounds the one path that had none.
+   *
+   * @default 33554432 (32 MiB)
+   */
+  maxRequestBodyBytes?: number;
+
+  /**
    * Endpoint patterns (glob-style) that are allowed to be called via POST requests.
    * The endpoint is the path portion of the URL without the leading slash.
    *
@@ -141,6 +162,8 @@ export async function isAuthorizationHeaderPresent(
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   allowedUrlPatterns: DEFAULT_ALLOWED_URL_PATTERNS,
+  serviceHosts: ["wma.fal.run"],
+  maxRequestBodyBytes: 32 * 1024 * 1024,
   allowedEndpoints: [],
   forwardRequestHeaders: [],
   allowUnauthorizedRequests: true,

--- a/libs/proxy/src/express.ts
+++ b/libs/proxy/src/express.ts
@@ -31,15 +31,20 @@ export const createHandler = (
           id: "express",
           method: request.method,
           getRequestBody: async () => {
-            const parsed = serializeParsedBody(
+            // The STREAM decides which side to trust, not req.body: body-parser stamps
+            // `req.body = {}` on EVERY request before its content-type check, so a defined body
+            // does not mean the request was parsed. A still-readable stream means nothing
+            // consumed it — forward those raw bytes (the multipart and binary path, even with a
+            // global express.json()). Parser output is trusted only once something actually
+            // read the stream, which is also what makes serializeParsedBody's multipart error
+            // truthful: at that point a multipart parser really did consume the bytes.
+            if (request.readable) {
+              return readUnconsumedRequestBody(request);
+            }
+            return serializeParsedBody(
               request.body,
               request.headers["content-type"],
             );
-            // A parser that does not handle this content type (multipart, binary) leaves the body
-            // unset and the stream unread — forward the raw bytes instead of an empty body.
-            return parsed !== undefined
-              ? parsed
-              : readUnconsumedRequestBody(request);
           },
           getHeaders: () => request.headers,
           getHeader: (name) => request.headers[name],

--- a/libs/proxy/src/express.ts
+++ b/libs/proxy/src/express.ts
@@ -39,12 +39,28 @@ export const createHandler = (
             // read the stream, which is also what makes serializeParsedBody's multipart error
             // truthful: at that point a multipart parser really did consume the bytes.
             if (request.readable) {
-              return readUnconsumedRequestBody(request);
+              return readUnconsumedRequestBody(
+                request,
+                resolvedConfig.maxRequestBodyBytes,
+              );
             }
-            return serializeParsedBody(
+            const parsed = serializeParsedBody(
               request.body,
               request.headers["content-type"],
             );
+            if (parsed !== undefined) return parsed;
+            // Not readable AND no parser output: something consumed the stream without leaving
+            // anything to forward (an audit/signature middleware, say). If the request declared
+            // a body, forwarding nothing under its intact content-type would make the payload
+            // silently vanish upstream — fail loudly where the developer can fix the route.
+            const declaredLength = Number(request.headers["content-length"] ?? 0);
+            if (declaredLength > 0 || request.headers["transfer-encoding"]) {
+              throw new Error(
+                "The request body was consumed before the fal proxy ran, without producing a " +
+                  "parsed body to forward. Exclude body-consuming middleware from the proxy route.",
+              );
+            }
+            return undefined;
           },
           getHeaders: () => request.headers,
           getHeader: (name) => request.headers[name],
@@ -52,6 +68,10 @@ export const createHandler = (
           respondWith: (status, data) => response.status(status).json(data),
           sendResponse: async (res) => {
             if (res.body instanceof ReadableStream) {
+              // The upstream STATUS rides the stream branch too — every undici response body is
+              // a ReadableStream, so without this line a fal 401/422/429 error payload streamed
+              // back under HTTP 200 and the client treated it as a successful result.
+              response.status(res.status);
               const reader = res.body.getReader();
               const stream = async () => {
                 const { done, value } = await reader.read();
@@ -74,7 +94,11 @@ export const createHandler = (
             if (res.headers.get("content-type")?.includes("application/json")) {
               return response.status(res.status).json(await res.json());
             }
-            return response.status(res.status).send(await res.text());
+            // Bytes, not text(): the same UTF-8 corruption the pages-router response fix
+            // removed — a binary response admitted by the forwarded accept header must survive.
+            return response
+              .status(res.status)
+              .send(Buffer.from(await res.arrayBuffer()));
           },
         },
         resolvedConfig,

--- a/libs/proxy/src/express.ts
+++ b/libs/proxy/src/express.ts
@@ -38,6 +38,13 @@ export const createHandler = (
             // global express.json()). Parser output is trusted only once something actually
             // read the stream, which is also what makes serializeParsedBody's multipart error
             // truthful: at that point a multipart parser really did consume the bytes.
+            if (request.readable && request.readableDidRead) {
+              throw new Error(
+                "The request body was partially consumed before the fal proxy ran. Exclude " +
+                  "body-consuming middleware from the proxy route so the complete raw stream " +
+                  "reaches the proxy.",
+              );
+            }
             if (request.readable) {
               return readUnconsumedRequestBody(
                 request,
@@ -53,7 +60,9 @@ export const createHandler = (
             // anything to forward (an audit/signature middleware, say). If the request declared
             // a body, forwarding nothing under its intact content-type would make the payload
             // silently vanish upstream — fail loudly where the developer can fix the route.
-            const declaredLength = Number(request.headers["content-length"] ?? 0);
+            const declaredLength = Number(
+              request.headers["content-length"] ?? 0,
+            );
             if (declaredLength > 0 || request.headers["transfer-encoding"]) {
               throw new Error(
                 "The request body was consumed before the fal proxy ran, without producing a " +

--- a/libs/proxy/src/express.ts
+++ b/libs/proxy/src/express.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 import { ProxyConfig, resolveProxyConfig } from "./config";
 import { DEFAULT_PROXY_ROUTE, handleRequest } from "./index";
+import { readUnconsumedRequestBody, serializeParsedBody } from "./utils";
 
 /**
  * The default Express route for the fal.ai client proxy.
@@ -21,45 +22,62 @@ export const createHandler = (
 ): RequestHandler => {
   const resolvedConfig = resolveProxyConfig(config);
   return async (request, response, next) => {
-    await handleRequest(
-      {
-        id: "express",
-        method: request.method,
-        getRequestBody: async () => JSON.stringify(request.body),
-        getHeaders: () => request.headers,
-        getHeader: (name) => request.headers[name],
-        sendHeader: (name, value) => response.setHeader(name, value),
-        respondWith: (status, data) => response.status(status).json(data),
-        sendResponse: async (res) => {
-          if (res.body instanceof ReadableStream) {
-            const reader = res.body.getReader();
-            const stream = async () => {
-              const { done, value } = await reader.read();
-              if (done) {
-                response.end();
-                return response;
-              }
-              response.write(value);
-              return await stream();
-            };
+    // Express 4 does not route a rejected async handler to error middleware; without this
+    // try/catch a deliberate proxy throw (a parser-consumed multipart body, say) becomes an
+    // unhandled rejection with the request left open.
+    try {
+      await handleRequest(
+        {
+          id: "express",
+          method: request.method,
+          getRequestBody: async () => {
+            const parsed = serializeParsedBody(
+              request.body,
+              request.headers["content-type"],
+            );
+            // A parser that does not handle this content type (multipart, binary) leaves the body
+            // unset and the stream unread — forward the raw bytes instead of an empty body.
+            return parsed !== undefined
+              ? parsed
+              : readUnconsumedRequestBody(request);
+          },
+          getHeaders: () => request.headers,
+          getHeader: (name) => request.headers[name],
+          sendHeader: (name, value) => response.setHeader(name, value),
+          respondWith: (status, data) => response.status(status).json(data),
+          sendResponse: async (res) => {
+            if (res.body instanceof ReadableStream) {
+              const reader = res.body.getReader();
+              const stream = async () => {
+                const { done, value } = await reader.read();
+                if (done) {
+                  response.end();
+                  return response;
+                }
+                response.write(value);
+                return await stream();
+              };
 
-            return await stream().catch((error) => {
-              if (!response.headersSent) {
-                response.status(500).send(error.message);
-              } else {
-                response.end();
-              }
-            });
-          }
-          if (res.headers.get("content-type")?.includes("application/json")) {
-            return response.status(res.status).json(await res.json());
-          }
-          return response.status(res.status).send(await res.text());
+              return await stream().catch((error) => {
+                if (!response.headersSent) {
+                  response.status(500).send(error.message);
+                } else {
+                  response.end();
+                }
+              });
+            }
+            if (res.headers.get("content-type")?.includes("application/json")) {
+              return response.status(res.status).json(await res.json());
+            }
+            return response.status(res.status).send(await res.text());
+          },
         },
-      },
-      resolvedConfig,
-    );
-    next();
+        resolvedConfig,
+      );
+      next();
+    } catch (error) {
+      next(error);
+    }
   };
 };
 

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -53,7 +53,14 @@ export function createRouteHandler({
         getHeaders: () => fromHeaders(context.req.raw.headers),
         getHeader: (name) => context.req.header(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),
-        getRequestBody: async () => readWebRequestBody(context.req.raw),
+        // Through HonoRequest's bodyCache, NOT context.req.raw: upstream middleware (a
+        // validator calling c.req.json()) has often already consumed the raw single-use stream,
+        // and reading it again would reject with "Body is unusable". The cache-aware accessor
+        // replays the same bytes.
+        getRequestBody: async () =>
+          readWebRequestBody({
+            arrayBuffer: () => context.req.arrayBuffer(),
+          }),
         sendResponse: responsePassthrough,
         resolveApiKey,
       },

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -8,7 +8,7 @@ import {
   resolveApiKeyFromEnv,
   responsePassthrough,
 } from "./index";
-import { readWebRequestBody } from "./utils";
+import { assertUtf8ParsedBody, readWebRequestBody } from "./utils";
 
 /**
  * @deprecated Use `Partial<ProxyConfig>` instead.
@@ -72,6 +72,12 @@ export function createRouteHandler({
                 "consumed without caching its original bytes. Cache c.req.arrayBuffer() or " +
                 "c.req.blob(), or exclude the proxy route from that middleware.",
             );
+          }
+          if (bodyCacheKeys.length > 0 && !hasByteFaithfulCache) {
+            // Hono rebuilds bytes from cached text/JSON as UTF-8. That is faithful only when the
+            // incoming parsed representation was UTF-8 too; otherwise preserving the old charset
+            // header would make the upstream decode different content.
+            assertUtf8ParsedBody(contentType);
           }
           if (context.req.raw.bodyUsed && bodyCacheKeys.length === 0) {
             throw new Error(

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -64,11 +64,11 @@ export function createRouteHandler({
         getRequestBody: async () => {
           const rawRequest = context.req.raw;
           const bodyCacheKeys = Object.keys(context.req.bodyCache);
+          const firstBodyCacheKey = bodyCacheKeys[0];
           const contentType = context.req.header("content-type") ?? "";
           const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
           const hasByteFaithfulCache =
-            "arrayBuffer" in context.req.bodyCache ||
-            "blob" in context.req.bodyCache;
+            firstBodyCacheKey === "arrayBuffer" || firstBodyCacheKey === "blob";
 
           // parseBody() can cache `{}` for media types it ignores without touching the stream.
           // Prefer the original stream whenever it is still available, regardless of cache keys.
@@ -76,6 +76,10 @@ export function createRouteHandler({
             return readWebRequestBody(rawRequest, maxRequestBodyBytes);
           }
 
+          // Hono derives every later representation from the FIRST cached one. A later
+          // arrayBuffer/blob key therefore does not establish byte fidelity if text(), json(),
+          // or formData() consumed the stream first. Only a byte representation that was itself
+          // first in the cache can contain the original request bytes.
           if (hasByteFaithfulCache) {
             return readWebRequestBody(
               {
@@ -93,7 +97,8 @@ export function createRouteHandler({
             throw new Error(
               "The fal proxy cannot forward a multipart body that Hono middleware already " +
                 "consumed without caching its original bytes. Cache c.req.arrayBuffer() or " +
-                "c.req.blob(), or exclude the proxy route from that middleware.",
+                "c.req.blob() before any decoded representation, or exclude the proxy route " +
+                "from that middleware.",
             );
           }
 
@@ -148,8 +153,8 @@ export function createRouteHandler({
           }
           throw new Error(
             `The fal proxy cannot faithfully reconstruct a cached ${mediaType || "untyped"} ` +
-              "Hono request body. Cache c.req.arrayBuffer() or c.req.blob(), or exclude the " +
-              "proxy route from body-parsing middleware.",
+              "Hono request body. Cache c.req.arrayBuffer() or c.req.blob() before any decoded " +
+              "representation, or exclude the proxy route from body-parsing middleware.",
           );
         },
         sendResponse: responsePassthrough,

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -2,11 +2,13 @@ import { Context } from "hono";
 import { type StatusCode } from "hono/utils/http-status";
 import { ProxyConfig, resolveProxyConfig } from "./config";
 import {
+  fromHeaders,
   handleRequest,
   HeaderValue,
   resolveApiKeyFromEnv,
   responsePassthrough,
 } from "./index";
+import { readWebRequestBody } from "./utils";
 
 /**
  * @deprecated Use `Partial<ProxyConfig>` instead.
@@ -46,10 +48,12 @@ export function createRouteHandler({
         respondWith: (status, data) => {
           return context.json(data, status as StatusCode, responseHeaders);
         },
-        getHeaders: () => responseHeaders,
+        // The INCOMING request's headers — `responseHeaders` is the outgoing accumulator that
+        // `sendHeader` fills, and enumerating it here would make the proxy forward nothing.
+        getHeaders: () => fromHeaders(context.req.raw.headers),
         getHeader: (name) => context.req.header(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),
-        getRequestBody: async () => JSON.stringify(await context.req.json()),
+        getRequestBody: async () => readWebRequestBody(context.req.raw),
         sendResponse: responsePassthrough,
         resolveApiKey,
       },

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -8,7 +8,13 @@ import {
   resolveApiKeyFromEnv,
   responsePassthrough,
 } from "./index";
-import { assertUtf8ParsedBody, readWebRequestBody } from "./utils";
+import {
+  assertUtf8ParsedBody,
+  DEFAULT_MAX_REQUEST_BODY_BYTES,
+  isJsonContentType,
+  readWebRequestBody,
+  RequestBodyTooLargeError,
+} from "./utils";
 
 /**
  * @deprecated Use `Partial<ProxyConfig>` instead.
@@ -39,6 +45,8 @@ export function createRouteHandler({
   ...config
 }: FalHonoProxyOptions = {}): RouteHandler {
   const resolvedConfig = resolveProxyConfig(config);
+  const maxRequestBodyBytes =
+    resolvedConfig.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
   const routeHandler: RouteHandler = async (context) => {
     const responseHeaders: Record<string, HeaderValue> = {};
     const response = await handleRequest(
@@ -54,16 +62,31 @@ export function createRouteHandler({
         getHeader: (name) => context.req.header(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),
         getRequestBody: async () => {
+          const rawRequest = context.req.raw;
           const bodyCacheKeys = Object.keys(context.req.bodyCache);
           const contentType = context.req.header("content-type") ?? "";
+          const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
           const hasByteFaithfulCache =
             "arrayBuffer" in context.req.bodyCache ||
             "blob" in context.req.bodyCache;
-          if (
-            contentType.toLowerCase().startsWith("multipart/") &&
-            bodyCacheKeys.length > 0 &&
-            !hasByteFaithfulCache
-          ) {
+
+          // parseBody() can cache `{}` for media types it ignores without touching the stream.
+          // Prefer the original stream whenever it is still available, regardless of cache keys.
+          if (!rawRequest.bodyUsed && !rawRequest.body?.locked) {
+            return readWebRequestBody(rawRequest, maxRequestBodyBytes);
+          }
+
+          if (hasByteFaithfulCache) {
+            return readWebRequestBody(
+              {
+                arrayBuffer: () => context.req.arrayBuffer(),
+                headers: rawRequest.headers,
+              },
+              maxRequestBodyBytes,
+            );
+          }
+
+          if (mediaType.startsWith("multipart/") && bodyCacheKeys.length > 0) {
             // Hono recreates arrayBuffer() from the first cached representation. Recreating it
             // from FormData chooses a NEW multipart boundary while this proxy forwards the old
             // content-type header, so the upstream cannot parse it.
@@ -73,31 +96,60 @@ export function createRouteHandler({
                 "c.req.blob(), or exclude the proxy route from that middleware.",
             );
           }
-          if (bodyCacheKeys.length > 0 && !hasByteFaithfulCache) {
-            // Hono rebuilds bytes from cached text/JSON as UTF-8. That is faithful only when the
-            // incoming parsed representation was UTF-8 too; otherwise preserving the old charset
-            // header would make the upstream decode different content.
+
+          if (
+            mediaType === "application/x-www-form-urlencoded" &&
+            "formData" in context.req.bodyCache
+          ) {
             assertUtf8ParsedBody(contentType);
+            const formData = await context.req.bodyCache.formData;
+            const params = new URLSearchParams();
+            formData.forEach((value, key) => {
+              if (typeof value !== "string") {
+                throw new Error(
+                  "The fal proxy cannot encode a file as application/x-www-form-urlencoded.",
+                );
+              }
+              params.append(key, value);
+            });
+            const body = params.toString();
+            if (
+              new TextEncoder().encode(body).byteLength > maxRequestBodyBytes
+            ) {
+              throw new RequestBodyTooLargeError(maxRequestBodyBytes);
+            }
+            return body;
           }
-          if (context.req.raw.bodyUsed && bodyCacheKeys.length === 0) {
+
+          const hasJsonCache = "json" in context.req.bodyCache;
+          const hasTextCache = "text" in context.req.bodyCache;
+          if (
+            bodyCacheKeys.length > 0 &&
+            ((hasJsonCache && isJsonContentType(contentType)) ||
+              (hasTextCache &&
+                (mediaType.startsWith("text/") ||
+                  isJsonContentType(contentType))))
+          ) {
+            assertUtf8ParsedBody(contentType);
+            return readWebRequestBody(
+              {
+                arrayBuffer: () => context.req.arrayBuffer(),
+                headers: rawRequest.headers,
+              },
+              maxRequestBodyBytes,
+            );
+          }
+
+          if (bodyCacheKeys.length === 0) {
             throw new Error(
               "The request body was consumed before the fal proxy ran without a reusable Hono " +
                 "body cache. Exclude body-consuming middleware from the proxy route.",
             );
           }
-
-          // An untouched raw request can be streamed and capped before the full allocation.
-          // If middleware used Hono's cache, its cache-aware accessor is the only replayable copy.
-          const request =
-            bodyCacheKeys.length === 0
-              ? context.req.raw
-              : {
-                  arrayBuffer: () => context.req.arrayBuffer(),
-                  headers: context.req.raw.headers,
-                };
-          return readWebRequestBody(
-            request,
-            resolvedConfig.maxRequestBodyBytes,
+          throw new Error(
+            `The fal proxy cannot faithfully reconstruct a cached ${mediaType || "untyped"} ` +
+              "Hono request body. Cache c.req.arrayBuffer() or c.req.blob(), or exclude the " +
+              "proxy route from body-parsing middleware.",
           );
         },
         sendResponse: responsePassthrough,

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -56,18 +56,21 @@ export function createRouteHandler({
         getRequestBody: async () => {
           const bodyCacheKeys = Object.keys(context.req.bodyCache);
           const contentType = context.req.header("content-type") ?? "";
+          const hasByteFaithfulCache =
+            "arrayBuffer" in context.req.bodyCache ||
+            "blob" in context.req.bodyCache;
           if (
             contentType.toLowerCase().startsWith("multipart/") &&
             bodyCacheKeys.length > 0 &&
-            !("arrayBuffer" in context.req.bodyCache)
+            !hasByteFaithfulCache
           ) {
             // Hono recreates arrayBuffer() from the first cached representation. Recreating it
             // from FormData chooses a NEW multipart boundary while this proxy forwards the old
             // content-type header, so the upstream cannot parse it.
             throw new Error(
               "The fal proxy cannot forward a multipart body that Hono middleware already " +
-                "consumed without caching its original bytes. Read c.req.arrayBuffer() before " +
-                "parsing, or exclude the proxy route from that middleware.",
+                "consumed without caching its original bytes. Cache c.req.arrayBuffer() or " +
+                "c.req.blob(), or exclude the proxy route from that middleware.",
             );
           }
           if (context.req.raw.bodyUsed && bodyCacheKeys.length === 0) {

--- a/libs/proxy/src/hono.ts
+++ b/libs/proxy/src/hono.ts
@@ -53,14 +53,44 @@ export function createRouteHandler({
         getHeaders: () => fromHeaders(context.req.raw.headers),
         getHeader: (name) => context.req.header(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),
-        // Through HonoRequest's bodyCache, NOT context.req.raw: upstream middleware (a
-        // validator calling c.req.json()) has often already consumed the raw single-use stream,
-        // and reading it again would reject with "Body is unusable". The cache-aware accessor
-        // replays the same bytes.
-        getRequestBody: async () =>
-          readWebRequestBody({
-            arrayBuffer: () => context.req.arrayBuffer(),
-          }),
+        getRequestBody: async () => {
+          const bodyCacheKeys = Object.keys(context.req.bodyCache);
+          const contentType = context.req.header("content-type") ?? "";
+          if (
+            contentType.toLowerCase().startsWith("multipart/") &&
+            bodyCacheKeys.length > 0 &&
+            !("arrayBuffer" in context.req.bodyCache)
+          ) {
+            // Hono recreates arrayBuffer() from the first cached representation. Recreating it
+            // from FormData chooses a NEW multipart boundary while this proxy forwards the old
+            // content-type header, so the upstream cannot parse it.
+            throw new Error(
+              "The fal proxy cannot forward a multipart body that Hono middleware already " +
+                "consumed without caching its original bytes. Read c.req.arrayBuffer() before " +
+                "parsing, or exclude the proxy route from that middleware.",
+            );
+          }
+          if (context.req.raw.bodyUsed && bodyCacheKeys.length === 0) {
+            throw new Error(
+              "The request body was consumed before the fal proxy ran without a reusable Hono " +
+                "body cache. Exclude body-consuming middleware from the proxy route.",
+            );
+          }
+
+          // An untouched raw request can be streamed and capped before the full allocation.
+          // If middleware used Hono's cache, its cache-aware accessor is the only replayable copy.
+          const request =
+            bodyCacheKeys.length === 0
+              ? context.req.raw
+              : {
+                  arrayBuffer: () => context.req.arrayBuffer(),
+                  headers: context.req.raw.headers,
+                };
+          return readWebRequestBody(
+            request,
+            resolvedConfig.maxRequestBodyBytes,
+          );
+        },
         sendResponse: responsePassthrough,
         resolveApiKey,
       },

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -889,6 +889,101 @@ describe("createRouteHandler (hono) body handling", () => {
     }
   });
 
+  it.each(["arrayBuffer", "blob"] as const)(
+    "does not trust a derived %s cache created after cached text",
+    async (derivedCacheKind) => {
+      const { Hono } = await import("hono");
+      const { createRouteHandler } = await import("./hono");
+      const app = new Hono();
+      app.use("/proxy", async (context, next) => {
+        await context.req.text();
+        const derived =
+          derivedCacheKind === "arrayBuffer"
+            ? await context.req.arrayBuffer()
+            : await context.req.blob();
+        // Current Hono versions do not retain derived representations, but retaining them is a
+        // valid cache implementation detail. Model that state to prove fidelity is determined by
+        // the first representation rather than the presence of a later byte-shaped cache key.
+        (context.req.bodyCache as Record<string, unknown>)[derivedCacheKind] =
+          Promise.resolve(derived);
+        await next();
+      });
+      app.onError((error, context) => context.text(error.message, 500));
+      app.post(
+        "/proxy",
+        createRouteHandler({
+          allowUnauthorizedRequests: false,
+          isAuthenticated: async () => true,
+          resolveFalAuth: async () => "Key secret",
+        }),
+      );
+
+      const fetchMock = jest.spyOn(global, "fetch");
+      try {
+        const response = await app.request("http://local.test/proxy", {
+          method: "POST",
+          headers: {
+            "x-fal-target-url": "https://fal.run/owner/app",
+            "content-type": "text/plain; charset=iso-8859-1",
+          },
+          body: new Uint8Array([0xe9]),
+        });
+
+        expect(response.status).toBe(500);
+        await expect(response.text()).resolves.toMatch(/iso-8859-1/);
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        fetchMock.mockRestore();
+      }
+    },
+  );
+
+  it("does not trust a derived byte cache created after cached multipart text", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.text();
+      const derived = await context.req.arrayBuffer();
+      (context.req.bodyCache as Record<string, unknown>).arrayBuffer =
+        Promise.resolve(derived);
+      await next();
+    });
+    app.onError((error, context) => context.text(error.message, 500));
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "multipart/form-data; boundary=boundary",
+        },
+        body: new Uint8Array([
+          ...new TextEncoder().encode(
+            '--boundary\r\nContent-Disposition: form-data; name="file"\r\n\r\n',
+          ),
+          0xff,
+          ...new TextEncoder().encode("\r\n--boundary--\r\n"),
+        ]),
+      });
+
+      expect(response.status).toBe(500);
+      await expect(response.text()).resolves.toMatch(/multipart.*consumed/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("rejects cached text for a binary media type", async () => {
     const { Hono } = await import("hono");
     const { createRouteHandler } = await import("./hono");

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -474,6 +474,89 @@ describe("serializeParsedBody", () => {
   });
 });
 
+describe("createHandler (express) body handling", () => {
+  function expressRequest(options: {
+    readable: boolean;
+    body: unknown;
+    contentType?: string;
+    chunks?: Uint8Array[];
+  }) {
+    return {
+      method: "POST",
+      readable: options.readable,
+      body: options.body,
+      headers: {
+        "x-fal-target-url": "https://wma.fal.run/upload",
+        ...(options.contentType ? { "content-type": options.contentType } : {}),
+      },
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of options.chunks ?? []) yield chunk;
+      },
+    };
+  }
+  function expressResponse() {
+    return {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+      write: jest.fn(),
+      end: jest.fn(),
+    };
+  }
+
+  it("forwards the raw stream when a global parser skipped the body", async () => {
+    // body-parser stamps req.body = {} on EVERY request before its content-type check, so a
+    // multipart POST through app.use(express.json()) arrives here as {} with the stream UNREAD.
+    // The stream, not req.body, decides: raw multipart bytes must be forwarded, not a throw
+    // blaming a multipart parser that does not exist (and not an empty body).
+    const { createHandler } = await import("./express");
+    const handler = createHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const payload = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x80, 0x00, 0xff]);
+    const request = expressRequest({
+      readable: true,
+      body: {}, // body-parser's untouched stamp
+      contentType: "multipart/form-data; boundary=x",
+      chunks: [payload],
+    });
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handler(request as never, expressResponse() as never, jest.fn());
+      const sent = fetchMock.mock.calls[0][1]?.body as Uint8Array;
+      expect(new Uint8Array(sent)).toEqual(payload);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("uses parser output once the stream was actually consumed", async () => {
+    const { createHandler } = await import("./express");
+    const handler = createHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = expressRequest({
+      readable: false, // express.json() read the stream
+      body: { prompt: "hello" },
+      contentType: "application/json",
+    });
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handler(request as never, expressResponse() as never, jest.fn());
+      expect(fetchMock.mock.calls[0][1]?.body).toBe('{"prompt":"hello"}');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});
+
 describe("createPageRouterHandler body handling", () => {
   it("fails loudly for multipart bodies Next's parser already corrupted", async () => {
     // Next's default bodyParser drains EVERY request and stringifies unknown content types

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -474,6 +474,18 @@ describe("serializeParsedBody", () => {
   });
 });
 
+describe("readUnconsumedRequestBody", () => {
+  it("caps raw-stream buffering instead of holding unbounded bodies in memory", async () => {
+    const { readUnconsumedRequestBody } = await import("./utils");
+    async function* endless() {
+      for (;;) yield new Uint8Array(1024 * 1024);
+    }
+    await expect(
+      readUnconsumedRequestBody(endless(), 4 * 1024 * 1024),
+    ).rejects.toThrow(/exceeded/);
+  });
+});
+
 describe("createHandler (express) body handling", () => {
   function expressRequest(options: {
     readable: boolean;
@@ -486,7 +498,7 @@ describe("createHandler (express) body handling", () => {
       readable: options.readable,
       body: options.body,
       headers: {
-        "x-fal-target-url": "https://wma.fal.run/upload",
+        "x-fal-target-url": "https://fal.run/owner/app",
         ...(options.contentType ? { "content-type": options.contentType } : {}),
       },
       async *[Symbol.asyncIterator]() {
@@ -569,7 +581,7 @@ describe("createPageRouterHandler body handling", () => {
       resolveFalAuth: async () => "Key secret",
     });
     const headers: Record<string, string> = {
-      "x-fal-target-url": "https://wma.fal.run/upload",
+      "x-fal-target-url": "https://fal.run/owner/app",
       "content-type": "multipart/form-data; boundary=x",
     };
     const request = {
@@ -632,7 +644,7 @@ describe("createPageRouterHandler body handling", () => {
       method: "GET",
       body: undefined,
       headers: {
-        "x-fal-target-url": "https://wma.fal.run/preview",
+        "x-fal-target-url": "https://fal.run/owner/app",
         accept: "image/png",
       },
     };
@@ -670,7 +682,7 @@ describe("createPageRouterHandler body handling", () => {
     const request = {
       method: "POST",
       body: "already�mangled",
-      headers: { "x-fal-target-url": "https://wma.fal.run/upload" },
+      headers: { "x-fal-target-url": "https://fal.run/owner/app" },
     };
     const response = {
       setHeader: jest.fn(),
@@ -764,13 +776,13 @@ describe("handleRequest rejection reasons", () => {
   it("preserves multipart boundaries when forwarding a request body", async () => {
     const boundary = "multipart/form-data; boundary=----fal-test-boundary";
     const { behavior } = behaviorFor(
-      "https://wma.fal.run/upload",
+      "https://fal.run/owner/app",
       "POST",
       "------fal-test-boundary--",
     );
     behavior.getHeaders = () => ({ "content-type": boundary });
     behavior.getHeader = (name: string) => {
-      if (name === "x-fal-target-url") return "https://wma.fal.run/upload";
+      if (name === "x-fal-target-url") return "https://fal.run/owner/app";
       if (name.toLowerCase() === "content-type") return boundary;
       return undefined;
     };
@@ -784,7 +796,7 @@ describe("handleRequest rejection reasons", () => {
         resolveFalAuth: async () => "secret",
       });
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://wma.fal.run/upload",
+        "https://fal.run/owner/app",
         expect.objectContaining({
           headers: expect.objectContaining({ "content-type": boundary }),
         }),
@@ -799,7 +811,7 @@ describe("handleRequest rejection reasons", () => {
     // that are not valid UTF-8, so the proxy must hand fetch exactly what the adapter read.
     const binary = new Uint8Array([0xff, 0x00, 0xd8, 0x88, 0x01]);
     const { behavior } = behaviorFor(
-      "https://wma.fal.run/upload",
+      "https://fal.run/owner/app",
       "POST",
       binary,
     );
@@ -813,7 +825,7 @@ describe("handleRequest rejection reasons", () => {
         resolveFalAuth: async () => "secret",
       });
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://wma.fal.run/upload",
+        "https://fal.run/owner/app",
         expect.objectContaining({ body: binary }),
       );
       expect(fetchMock.mock.calls[0][1]?.body).toBe(binary);
@@ -950,7 +962,7 @@ describe("handleRequest rejection reasons", () => {
     // would make upstream endpoints parse valid bytes as JSON. Present headers pass through
     // untouched, absent ones stay absent.
     const { behavior } = behaviorFor(
-      "https://wma.fal.run/upload",
+      "https://fal.run/owner/app",
       "POST",
       new Uint8Array([0xff, 0x00]),
     );
@@ -978,7 +990,7 @@ describe("handleRequest rejection reasons", () => {
     // JSON rewrite (the browser would otherwise have labeled the body text/plain). Binary bodies
     // stay label-free; string bodies keep the JSON default.
     const { behavior } = behaviorFor(
-      "https://wma.fal.run/upload",
+      "https://fal.run/owner/app",
       "POST",
       '{"prompt":"a cat"}',
     );
@@ -1045,12 +1057,110 @@ describe("handleRequest rejection reasons", () => {
     });
   });
 
+  it("rejects non-POST methods on fal service hosts", async () => {
+    // The allowlist bypass must not become a method-shaped hole: endpoint policy is POST-only,
+    // so a GET/PUT/DELETE to the bridge would otherwise forward credentialed with no check.
+    for (const method of ["GET", "PUT", "PATCH", "DELETE"]) {
+      expect(
+        await run(
+          "https://wma.fal.run/session",
+          { isAuthenticated: async () => true },
+          method,
+        ),
+      ).toEqual({
+        status: 400,
+        data: "Invalid request: fal service hosts only accept POST",
+      });
+    }
+  });
+
+  it("rejects unknown fal service routes (default-deny)", async () => {
+    // A route added upstream must be added HERE deliberately — unknown spellings, matrix
+    // parameters, embedded NULs, and plain unknown paths all refuse rather than forward.
+    for (const path of [
+      "/upload",
+      "/session;x=1",
+      "/session%00",
+      "/session/v2",
+    ]) {
+      expect(
+        await run(`https://wma.fal.run${path}`, {
+          isAuthenticated: async () => true,
+        }),
+      ).toEqual({
+        status: 400,
+        data: "Invalid request: unknown fal service route",
+      });
+    }
+  });
+
+  it("allows the session-scoped heartbeat without an app id under restriction", async () => {
+    expect(
+      await run("https://wma.fal.run/session/heartbeat", {
+        allowedEndpoints: ["me/my-app/**"],
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => undefined,
+      }),
+    ).toEqual({ status: 401, data: "Unauthorized" }); // passed policy, stopped only by no key
+  });
+
+  it("rejects duplicate app_id keys in an app-scoped service body", async () => {
+    // JSON parsers disagree about which duplicate wins; the allowlist verdict must not depend
+    // on the proxy's parser agreeing with the upstream's.
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        {
+          allowedEndpoints: ["me/my-app/**"],
+          isAuthenticated: async () => true,
+        },
+        "POST",
+        '{"app_id":"me/my-app","app_id":"someone/other-app"}',
+      ),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target path is not permitted by allowedEndpoints",
+    });
+  });
+
+  it("lets operators refuse service hosts entirely with serviceHosts: []", async () => {
+    expect(
+      await run("https://wma.fal.run/session", {
+        serviceHosts: [],
+        isAuthenticated: async () => true,
+      }),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target URL is not permitted by allowedUrlPatterns",
+    });
+  });
+
+  it("rejects a malformed target URL as a 400, not a 500", async () => {
+    expect(
+      await run("not a url at all", { isAuthenticated: async () => true }),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: x-fal-target-url is not a valid absolute URL",
+    });
+  });
+
+  it("rejects an unauthenticated caller before revealing endpoint policy", async () => {
+    // Auth runs FIRST: an unauthenticated caller must not learn which endpoints this proxy
+    // permits by reading which check rejected them.
+    expect(
+      await run("https://fal.run/someone/other-app", {
+        allowedEndpoints: ["me/my-app/**"],
+      }),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+  });
+
   it("names allowedEndpoints when the path is not permitted", async () => {
     // The URL is allowlisted but the path is not. Naming the failed policy tells the caller whether
     // to update host permissions, endpoint permissions, or request construction.
     expect(
       await run("https://fal.run/someone/other-app", {
         allowedEndpoints: ["me/my-app/**"],
+        isAuthenticated: async () => true,
       }),
     ).toEqual({
       status: 400,
@@ -1066,6 +1176,7 @@ describe("handleRequest rejection reasons", () => {
       expect(
         await run(`https://${host}/someone/other-app`, {
           allowedEndpoints: ["me/my-app/**"],
+          isAuthenticated: async () => true,
         }),
       ).toEqual({
         status: 400,

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -776,6 +776,46 @@ describe("createRouteHandler (hono) body handling", () => {
     }
   });
 
+  it("preserves cached multipart bytes when middleware cached a Blob", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.blob();
+      await next();
+    });
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const form = new FormData();
+    form.append("field", "value");
+    const request = new Request("http://local.test/proxy", {
+      method: "POST",
+      headers: { "x-fal-target-url": "https://fal.run/owner/app" },
+      body: form,
+    });
+    const originalBody = new Uint8Array(await request.clone().arrayBuffer());
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      const response = await app.request(request);
+
+      expect(response.status).toBe(200);
+      expect(
+        new Uint8Array(fetchMock.mock.calls[0][1]?.body as ArrayBuffer),
+      ).toEqual(originalBody);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("rejects cached FormData whose original multipart boundary is gone", async () => {
     const { Hono } = await import("hono");
     const { createRouteHandler } = await import("./hono");

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -1,5 +1,10 @@
 import { createUrlMatcher, DEFAULT_ALLOWED_URL_PATTERNS } from "./config";
-import { getEndpoint, isAllowedEndpoint, isAllowedUrl } from "./index";
+import {
+  getEndpoint,
+  handleRequest,
+  isAllowedEndpoint,
+  isAllowedUrl,
+} from "./index";
 
 const FAL_REST_API_URL = "rest.fal.ai";
 
@@ -97,6 +102,16 @@ describe("isAllowedUrl with default patterns", () => {
 
     it("should NOT allow queue.fal.ai", () => {
       expect(isAllowedUrl("queue.fal.ai/some/path")).toBe(false);
+    });
+  });
+
+  describe("wma.fal.run (admitted by the service-host rule, not this allowlist)", () => {
+    // Pins where the decision lives. `handleRequest` short-circuits on fal's service hosts BEFORE
+    // consulting the allowlist, so an entry here could never be what admits the bridge — it would
+    // read as load-bearing while being dead, and it would not survive a caller narrowing
+    // `allowedUrlPatterns` anyway. See "allows the bridge even when allowedUrlPatterns is narrowed".
+    it("should NOT be allowed by the default URL patterns", () => {
+      expect(isAllowedUrl("wma.fal.run/session")).toBe(false);
     });
   });
 
@@ -337,6 +352,774 @@ describe("isAllowedEndpoint", () => {
       expect(
         isAllowedEndpoint("fal-ai/flux-dev/requests/abc123/status", patterns),
       ).toBe(true);
+    });
+  });
+});
+
+describe("serializeParsedBody", () => {
+  it("re-encodes a parsed form body as form data, not JSON", async () => {
+    // The proxy forwards the request's content-type verbatim, so a body the framework parsed from
+    // application/x-www-form-urlencoded must be re-encoded the same way — JSON bytes labeled as
+    // form data cannot be parsed upstream.
+    const { serializeParsedBody } = await import("./utils");
+    expect(
+      serializeParsedBody(
+        { prompt: "a cat", seed: "42" },
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBe("prompt=a+cat&seed=42");
+    expect(
+      serializeParsedBody(
+        { prompt: "a cat" },
+        "application/x-www-form-urlencoded; charset=utf-8",
+      ),
+    ).toBe("prompt=a+cat");
+    // JSON stays JSON, strings and bytes pass through, empty stays empty.
+    expect(serializeParsedBody({ a: 1 }, "application/json")).toBe('{"a":1}');
+    expect(serializeParsedBody({ a: 1 }, undefined)).toBe('{"a":1}');
+    expect(
+      serializeParsedBody("raw", "application/x-www-form-urlencoded"),
+    ).toBe("raw");
+    const bytes = new Uint8Array([1, 2]);
+    expect(serializeParsedBody(bytes, "multipart/form-data")).toBe(bytes);
+    // ArrayBuffer is part of ProxyRequestBody and must pass through, not stringify to "{}".
+    const buffer = new Uint8Array([3, 4]).buffer;
+    expect(serializeParsedBody(buffer, "application/octet-stream")).toBe(
+      buffer,
+    );
+    expect(serializeParsedBody(undefined, "application/json")).toBeUndefined();
+    // Every JSON-typed string lacks decidable provenance (raw text vs parsed value, parseable
+    // or not) and fails loudly; adapters that KNOW their parser re-encode before this helper.
+    // An UNPARSEABLE string is decidably a parsed top-level value and re-encodes; any PARSEABLE
+    // string is ambiguous under json strict:false (raw text vs quoted string value) and fails
+    // loudly rather than silently changing the upstream value's type. Non-JSON types pass raw.
+    expect(serializeParsedBody("hello", "text/plain")).toBe("hello");
+    for (const ambiguous of [
+      "hello",
+      '{"a":1}',
+      '"quoted"',
+      "123",
+      "null",
+      "[1,2]",
+    ]) {
+      expect(() => serializeParsedBody(ambiguous, "application/json")).toThrow(
+        /unambiguous/,
+      );
+    }
+    // Parsed JSON null is a real body; null under other types still reads as absent.
+    expect(serializeParsedBody(null, "application/json")).toBe("null");
+    expect(serializeParsedBody(null, "application/json; charset=utf-8")).toBe(
+      "null",
+    );
+    expect(serializeParsedBody(null, "multipart/form-data")).toBeUndefined();
+    expect(serializeParsedBody(null, undefined)).toBeUndefined();
+    // Structured-suffix JSON media types carry JSON payloads too (RFC 6839).
+    expect(serializeParsedBody(null, "application/ld+json")).toBe("null");
+    expect(
+      serializeParsedBody(null, "application/hal+json; charset=utf-8"),
+    ).toBe("null");
+    // Prefix lookalikes are NOT JSON documents: json-seq is a record-separated sequence.
+    expect(serializeParsedBody(null, "application/json-seq")).toBeUndefined();
+  });
+
+  it("preserves repeated URL-encoded fields", async () => {
+    // Parsers represent `tag=a&tag=b` as { tag: ["a", "b"] }; the record-constructor form of
+    // URLSearchParams would collapse that to tag=a%2Cb and change the upstream semantics.
+    const { serializeParsedBody } = await import("./utils");
+    expect(
+      serializeParsedBody(
+        { tag: ["a", "b"], solo: "x" },
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBe("tag=a&tag=b&solo=x");
+    expect(
+      serializeParsedBody(
+        { keep: "yes", missing: undefined, empty: null },
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBe("keep=yes");
+  });
+
+  it("rejects parsed multipart bodies instead of JSON-encoding them", async () => {
+    // multer/formidable populate request.body with an object after consuming the stream; the
+    // bytes and boundary framing are unrecoverable, and JSON under a multipart header would be
+    // corruption, not forwarding.
+    const { serializeParsedBody } = await import("./utils");
+    expect(() =>
+      serializeParsedBody(
+        { field: "value" },
+        "multipart/form-data; boundary=----x",
+      ),
+    ).toThrow(/multipart/);
+  });
+
+  it("re-encodes nested URL-encoded fields with bracket notation", async () => {
+    // express.urlencoded({ extended: true }) parses user[name]=alice into nested objects;
+    // stringifying those would forward user=%5Bobject+Object%5D.
+    const { serializeParsedBody } = await import("./utils");
+    expect(
+      serializeParsedBody(
+        { user: { name: "alice", tags: ["a", "b"] } },
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBe("user%5Bname%5D=alice&user%5Btags%5D=a&user%5Btags%5D=b");
+    // Arrays of structured values keep their indices, or two objects collapse into one on
+    // reparse; scalar arrays stay repeated keys.
+    expect(
+      serializeParsedBody(
+        { users: [{ name: "alice" }, { name: "bob" }] },
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBe("users%5B0%5D%5Bname%5D=alice&users%5B1%5D%5Bname%5D=bob");
+  });
+});
+
+describe("createPageRouterHandler body handling", () => {
+  it("fails loudly for multipart bodies Next's parser already corrupted", async () => {
+    // Next's default bodyParser drains EVERY request and stringifies unknown content types
+    // through UTF-8, so a multipart body reaching the adapter as a string is irreversibly
+    // corrupted — forwarding it would hand the upstream garbage under a valid boundary.
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const headers: Record<string, string> = {
+      "x-fal-target-url": "https://wma.fal.run/upload",
+      "content-type": "multipart/form-data; boundary=x",
+    };
+    const request = {
+      method: "POST",
+      body: "already�corrupted",
+      headers,
+    };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+    };
+
+    await expect(handler(request as never, response as never)).rejects.toThrow(
+      /bodyParser: false/,
+    );
+  });
+
+  it("re-encodes a parsed top-level JSON string body", async () => {
+    // Next PARSES application/json, so a string body is a JSON string VALUE; forwarding it
+    // verbatim would send invalid JSON (hello instead of "hello") under a JSON content type.
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = {
+      method: "POST",
+      body: "hello",
+      headers: {
+        "x-fal-target-url": "https://wma.fal.run/session",
+        "content-type": "application/json",
+      },
+    };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+    };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handler(request as never, response as never);
+      expect(fetchMock.mock.calls[0][1]?.body).toBe('"hello"');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("forwards a binary upstream response as exact bytes", async () => {
+    // A forwarded accept header can make the upstream answer with binary (an image, an
+    // octet-stream); text() would UTF-8-decode and corrupt it before it reaches the caller.
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = {
+      method: "GET",
+      body: undefined,
+      headers: {
+        "x-fal-target-url": "https://wma.fal.run/preview",
+        accept: "image/png",
+      },
+    };
+    const send = jest.fn();
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send })),
+    };
+    // Invalid UTF-8 on purpose: a lone continuation byte (0x80) becomes U+FFFD through text().
+    const payload = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x80, 0x00, 0xff]);
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(payload, {
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    try {
+      await handler(request as never, response as never);
+      const sent = send.mock.calls[0][0] as Buffer;
+      expect(Buffer.isBuffer(sent)).toBe(true);
+      expect(new Uint8Array(sent)).toEqual(payload);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("fails loudly for untyped bodies Next decoded as text", async () => {
+    // Binary posted without a content-type is text-decoded by Next's default parser too — and a
+    // forwarded string would then be labeled application/json by the string default.
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = {
+      method: "POST",
+      body: "already�mangled",
+      headers: { "x-fal-target-url": "https://wma.fal.run/upload" },
+    };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+    };
+
+    await expect(handler(request as never, response as never)).rejects.toThrow(
+      /bodyParser: false/,
+    );
+  });
+});
+
+describe("readUnconsumedRequestBody", () => {
+  const streamOf = (chunks: Array<string | Uint8Array>) =>
+    (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+  it("concatenates raw stream chunks byte-identical", async () => {
+    const { readUnconsumedRequestBody } = await import("./utils");
+    const body = await readUnconsumedRequestBody(
+      streamOf([new Uint8Array([0xff, 0x00]), new Uint8Array([0xd8])]),
+    );
+    expect(body).toEqual(new Uint8Array([0xff, 0x00, 0xd8]));
+  });
+
+  it("encodes string chunks and treats an empty stream as no body", async () => {
+    const { readUnconsumedRequestBody } = await import("./utils");
+    expect(await readUnconsumedRequestBody(streamOf(["ab", "c"]))).toEqual(
+      new TextEncoder().encode("abc"),
+    );
+    expect(await readUnconsumedRequestBody(streamOf([]))).toBeUndefined();
+  });
+});
+
+describe("handleRequest rejection reasons", () => {
+  /**
+   * A minimal ProxyBehavior that records what handleRequest responded with.
+   *
+   * The 400 paths all return before any network call, so nothing needs stubbing for them. For the
+   * paths that get PAST validation, auth is left unsatisfied on purpose: a 401 then proves the request
+   * cleared the endpoint gate, which is exactly what the exemption tests need to show.
+   */
+  function behaviorFor(
+    targetUrl: string | undefined,
+    method = "POST",
+    requestBody: string | Uint8Array = "{}",
+  ) {
+    const responses: Array<{ status: number; data: unknown }> = [];
+    return {
+      responses,
+      behavior: {
+        id: "test",
+        method,
+        getRequestBody: async () => requestBody,
+        getHeaders: () => ({}),
+        getHeader: (name: string) =>
+          name === "x-fal-target-url" ? targetUrl : undefined,
+        sendHeader: () => undefined,
+        respondWith: (status: number, data: unknown) => {
+          responses.push({ status, data });
+          return undefined as never;
+        },
+        sendResponse: async () => undefined as never,
+      },
+    };
+  }
+
+  const run = async (
+    targetUrl: string | undefined,
+    config: Record<string, unknown> = {},
+    method = "POST",
+    requestBody: string | Uint8Array = "{}",
+  ) => {
+    const { behavior, responses } = behaviorFor(targetUrl, method, requestBody);
+    await handleRequest(
+      behavior as never,
+      {
+        // No credentials available, so anything reaching the auth step stops with 401 rather than
+        // attempting a real request.
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => false,
+        ...config,
+      } as never,
+    );
+    return responses[0];
+  };
+
+  it("preserves multipart boundaries when forwarding a request body", async () => {
+    const boundary = "multipart/form-data; boundary=----fal-test-boundary";
+    const { behavior } = behaviorFor(
+      "https://wma.fal.run/upload",
+      "POST",
+      "------fal-test-boundary--",
+    );
+    behavior.getHeaders = () => ({ "content-type": boundary });
+    behavior.getHeader = (name: string) => {
+      if (name === "x-fal-target-url") return "https://wma.fal.run/upload";
+      if (name.toLowerCase() === "content-type") return boundary;
+      return undefined;
+    };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "secret",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://wma.fal.run/upload",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "content-type": boundary }),
+        }),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("forwards a binary request body byte-identical", async () => {
+    // Multipart file parts are binary. A body that ever passes through a string corrupts the bytes
+    // that are not valid UTF-8, so the proxy must hand fetch exactly what the adapter read.
+    const binary = new Uint8Array([0xff, 0x00, 0xd8, 0x88, 0x01]);
+    const { behavior } = behaviorFor(
+      "https://wma.fal.run/upload",
+      "POST",
+      binary,
+    );
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "secret",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://wma.fal.run/upload",
+        expect.objectContaining({ body: binary }),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toBe(binary);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("forwards an allowlist of request headers, never ambient credentials", async () => {
+    // Applications authenticate their own proxy route with custom headers no denylist can
+    // enumerate; forwarding is therefore allowlist-only. x-fal-* and accept travel by default, a
+    // provider header travels only when named in forwardRequestHeaders, and credentials addressed
+    // to the proxy host never travel — even ambient infra headers stay behind.
+    const incoming: Record<string, string> = {
+      "x-fal-target-url": "https://wma.fal.run/session",
+      accept: "text/event-stream",
+      "x-provider-ticket": "abc",
+      "x-session-token": "user-secret",
+      "x-forwarded-for": "10.0.0.1",
+      authorization: "Bearer proxy-user-token",
+      cookie: "session=1",
+    };
+    const makeBehavior = () => {
+      const { behavior } = behaviorFor("https://wma.fal.run/session");
+      behavior.getHeaders = () => incoming;
+      behavior.getHeader = (name: string) => incoming[name.toLowerCase()];
+      return behavior;
+    };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(makeBehavior() as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      });
+      let sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(sent["x-fal-target-url"]).toBe("https://wma.fal.run/session");
+      expect(sent.accept).toBe("text/event-stream");
+      expect(sent.authorization).toBe("Key secret");
+      // Not allowlisted: custom and ambient headers stay behind by default.
+      expect(sent["x-provider-ticket"]).toBeUndefined();
+      expect(sent["x-session-token"]).toBeUndefined();
+      expect(sent["x-forwarded-for"]).toBeUndefined();
+      expect(sent.cookie).toBeUndefined();
+
+      fetchMock.mockClear();
+      await handleRequest(makeBehavior() as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+        forwardRequestHeaders: ["x-provider-ticket", "cookie"],
+      });
+      sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      // The named provider header now travels; proxy-host credentials never do, even when named.
+      expect(sent["x-provider-ticket"]).toBe("abc");
+      expect(sent["x-session-token"]).toBeUndefined();
+      expect(sent.cookie).toBeUndefined();
+
+      // content-encoding is end-to-end metadata for the raw-bytes path: never forwarded by
+      // default, forwardable when the operator names it.
+      incoming["content-encoding"] = "gzip";
+      fetchMock.mockClear();
+      await handleRequest(makeBehavior() as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      });
+      sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(sent["content-encoding"]).toBeUndefined();
+
+      fetchMock.mockClear();
+      await handleRequest(makeBehavior() as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+        forwardRequestHeaders: ["content-encoding"],
+      });
+      sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      // The behavior's body is a STRING here — parser output, already inflated — so even an
+      // explicitly forwarded content-encoding is stripped; it only describes raw byte bodies.
+      expect(sent["content-encoding"]).toBeUndefined();
+
+      fetchMock.mockClear();
+      const rawBehavior = behaviorFor(
+        "https://wma.fal.run/session",
+        "POST",
+        new Uint8Array([0x1f, 0x8b, 0x08]),
+      ).behavior;
+      rawBehavior.getHeaders = () => incoming;
+      rawBehavior.getHeader = (name: string) => incoming[name.toLowerCase()];
+      await handleRequest(rawBehavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+        forwardRequestHeaders: ["content-encoding"],
+      });
+      sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(sent["content-encoding"]).toBe("gzip");
+
+      // A parser-produced buffer (express.raw output) is already inflated too — the brand from
+      // serializeParsedBody must strip the header even though the body is bytes, not a string.
+      fetchMock.mockClear();
+      const { serializeParsedBody } = await import("./utils");
+      const parsedBytes = serializeParsedBody(
+        new Uint8Array([0x7b, 0x7d]),
+        "application/octet-stream",
+      ) as Uint8Array;
+      const parsedByteBehavior = behaviorFor(
+        "https://wma.fal.run/session",
+        "POST",
+        parsedBytes,
+      ).behavior;
+      parsedByteBehavior.getHeaders = () => incoming;
+      parsedByteBehavior.getHeader = (name: string) =>
+        incoming[name.toLowerCase()];
+      await handleRequest(parsedByteBehavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+        forwardRequestHeaders: ["content-encoding"],
+      });
+      sent = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(sent["content-encoding"]).toBeUndefined();
+      delete incoming["content-encoding"];
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("omits content-type when the incoming request omitted it", async () => {
+    // Fetch generates no content type for raw binary bodies; the proxy defaulting one to JSON
+    // would make upstream endpoints parse valid bytes as JSON. Present headers pass through
+    // untouched, absent ones stay absent.
+    const { behavior } = behaviorFor(
+      "https://wma.fal.run/upload",
+      "POST",
+      new Uint8Array([0xff, 0x00]),
+    );
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      });
+      const sent = fetchMock.mock.calls[0][1]?.headers as Record<
+        string,
+        string
+      >;
+      expect("content-type" in sent).toBe(false);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("defaults string bodies to application/json when no content-type came in", async () => {
+    // Bare fetch(proxy, { body: JSON.stringify(x) }) callers relied on the proxy's historical
+    // JSON rewrite (the browser would otherwise have labeled the body text/plain). Binary bodies
+    // stay label-free; string bodies keep the JSON default.
+    const { behavior } = behaviorFor(
+      "https://wma.fal.run/upload",
+      "POST",
+      '{"prompt":"a cat"}',
+    );
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      });
+      const sent = fetchMock.mock.calls[0][1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(sent["content-type"]).toBe("application/json");
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("extracts the WMA app id from a bytes body", async () => {
+    // Adapters now hand over raw bytes; the app-id gate decodes them for parsing while the
+    // forwarded body stays untouched. Auth is satisfied and no fal credential is configured, so a
+    // 401 from the credential step proves the gate accepted the decoded id — a rejected id would
+    // have returned 400 before it.
+    const body = new TextEncoder().encode(
+      JSON.stringify({ app_id: "me/my-app/world" }),
+    );
+    const config = {
+      allowedEndpoints: ["me/my-app/**"],
+      isAuthenticated: async () => true,
+      // No credential, so an accepted app id stops at the credential 401 instead of fetching.
+      resolveFalAuth: async () => undefined,
+    };
+    expect(
+      await run("https://wma.fal.run/session", config, "POST", body),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        config,
+        "POST",
+        new TextEncoder().encode(JSON.stringify({ app_id: "someone/else" })),
+      ),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target path is not permitted by allowedEndpoints",
+    });
+  });
+
+  it("names the missing header", async () => {
+    expect(await run(undefined)).toEqual({
+      status: 400,
+      data: "Invalid request: missing x-fal-target-url header",
+    });
+  });
+
+  it("names allowedUrlPatterns when the host is not permitted", async () => {
+    expect(await run("https://evil.example/steal")).toEqual({
+      status: 400,
+      data: "Invalid request: target URL is not permitted by allowedUrlPatterns",
+    });
+  });
+
+  it("names allowedEndpoints when the path is not permitted", async () => {
+    // The URL is allowlisted but the path is not. Naming the failed policy tells the caller whether
+    // to update host permissions, endpoint permissions, or request construction.
+    expect(
+      await run("https://fal.run/someone/other-app", {
+        allowedEndpoints: ["me/my-app/**"],
+      }),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target path is not permitted by allowedEndpoints",
+    });
+  });
+
+  it("STILL enforces allowedEndpoints for app-serving fal.run hosts", async () => {
+    // The security property. Exempting fal's service hosts from the endpoint check must not exempt
+    // the hosts that serve customer apps, or allowedEndpoints stops restricting anything on its main
+    // path. A suffix rule on `.fal.run` would break exactly this.
+    for (const host of ["fal.run", "queue.fal.run"]) {
+      expect(
+        await run(`https://${host}/someone/other-app`, {
+          allowedEndpoints: ["me/my-app/**"],
+        }),
+      ).toEqual({
+        status: 400,
+        data: "Invalid request: target path is not permitted by allowedEndpoints",
+      });
+    }
+  });
+
+  it("checks the WMA app id instead of treating its route as an app path", async () => {
+    // Reaches auth (401) because the body app_id is allowed. The literal `session` path is bridge
+    // infrastructure and is not itself an endpoint id.
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        { allowedEndpoints: ["me/my-app/**"] },
+        "POST",
+        JSON.stringify({ app_id: "me/my-app/world" }),
+      ),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+  });
+
+  it("authenticates before reading an app-scoped WMA body", async () => {
+    const { behavior, responses } = behaviorFor(
+      "https://wma.fal.run/session",
+      "POST",
+      JSON.stringify({ app_id: "me/my-app" }),
+    );
+    const getRequestBody = jest.spyOn(behavior, "getRequestBody");
+
+    await handleRequest(
+      behavior as never,
+      {
+        allowedEndpoints: ["me/my-app/**"],
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => false,
+      } as never,
+    );
+
+    expect(responses[0]).toEqual({ status: 401, data: "Unauthorized" });
+    expect(getRequestBody).not.toHaveBeenCalled();
+  });
+
+  it("allows the bridge by default, without any allowlisting", async () => {
+    expect(await run("https://wma.fal.run/session/heartbeat")).toEqual({
+      status: 401,
+      data: "Unauthorized",
+    });
+  });
+
+  it("allows the bridge even when allowedUrlPatterns is narrowed", async () => {
+    // The case a default entry cannot cover: supplying allowedUrlPatterns REPLACES the defaults, so a
+    // caller who scopes the proxy to their own apps — the careful configuration — would otherwise lose
+    // signalling with no way to know why.
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        {
+          allowedUrlPatterns: ["fal.run/me/my-app/**"],
+          allowedEndpoints: ["me/my-app/**"],
+        },
+        "POST",
+        JSON.stringify({ app_id: "me/my-app/world" }),
+      ),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+  });
+
+  it("enforces allowedEndpoints against WMA request app_id values", async () => {
+    for (const path of ["ice", "session"]) {
+      expect(
+        await run(
+          `https://wma.fal.run/${path}`,
+          {
+            allowedEndpoints: ["me/my-app/**"],
+            isAuthenticated: async () => true,
+          },
+          "POST",
+          JSON.stringify({ app_id: "someone/other-app" }),
+        ),
+      ).toEqual({
+        status: 400,
+        data: "Invalid request: target path is not permitted by allowedEndpoints",
+      });
+    }
+  });
+
+  it("enforces WMA app identity through percent-encoded route spellings", async () => {
+    expect(
+      await run(
+        "https://wma.fal.run/%73ession",
+        {
+          allowedEndpoints: ["me/my-app/**"],
+          isAuthenticated: async () => true,
+        },
+        "POST",
+        JSON.stringify({ app_id: "someone/other-app" }),
+      ),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target path is not permitted by allowedEndpoints",
+    });
+  });
+
+  it("rejects an app-scoped WMA request with no app_id when endpoints are restricted", async () => {
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        {
+          allowedEndpoints: ["me/my-app/**"],
+          isAuthenticated: async () => true,
+        },
+        "POST",
+        "{}",
+      ),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target path is not permitted by allowedEndpoints",
+    });
+  });
+
+  it("does not exempt the bridge host over plaintext HTTP", async () => {
+    expect(
+      await run("http://wma.fal.run/session", {
+        allowedUrlPatterns: ["fal.run/me/my-app/**"],
+        allowedEndpoints: ["me/my-app/**"],
+      }),
+    ).toEqual({
+      status: 400,
+      data: "Invalid request: target URL is not permitted by allowedUrlPatterns",
+    });
+  });
+
+  it("does NOT implicitly allow fal.ai, which is not allowed by default today", async () => {
+    // The exemption is the enumerated service set, not every fal-owned domain. Widening it to `.fal.ai`
+    // would silently start permitting hosts this proxy has always refused.
+    expect(await run("https://fal.ai/anything")).toEqual({
+      status: 400,
+      data: "Invalid request: target URL is not permitted by allowedUrlPatterns",
     });
   });
 });

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -504,6 +504,18 @@ describe("serializeParsedBody", () => {
       /application\/cbor/,
     );
   });
+
+  it("rejects parsed bodies whose declared charset is not UTF-8", async () => {
+    const { serializeParsedBody } = await import("./utils");
+
+    expect(() =>
+      serializeParsedBody("é", "text/plain; charset=iso-8859-1"),
+    ).toThrow(/iso-8859-1/);
+    expect(() =>
+      serializeParsedBody({ value: "é" }, 'application/json; charset="utf-16"'),
+    ).toThrow(/utf-16/);
+    expect(serializeParsedBody("é", "text/plain; charset=utf-8")).toBe("é");
+  });
 });
 
 describe("readUnconsumedRequestBody", () => {
@@ -646,6 +658,33 @@ describe("createHandler (express) body handling", () => {
     try {
       await handler(request as never, expressResponse() as never, jest.fn());
       expect(fetchMock.mock.calls[0][1]?.body).toBe('{"prompt":"hello"}');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects parser-decoded text with a non-UTF-8 charset", async () => {
+    const { createHandler } = await import("./express");
+    const request = expressRequest({
+      readable: false,
+      body: "é",
+      contentType: "text/plain; charset=iso-8859-1",
+    });
+    const next = jest.fn();
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      await createHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      })(request as never, expressResponse() as never, next);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/iso-8859-1/),
+        }),
+      );
     } finally {
       fetchMock.mockRestore();
     }
@@ -976,6 +1015,36 @@ describe("createPageRouterHandler body handling", () => {
     await expect(handler(request as never, response as never)).rejects.toThrow(
       /bodyParser: false/,
     );
+  });
+
+  it("rejects text Next decoded with a non-UTF-8 charset", async () => {
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = {
+      method: "POST",
+      body: "é",
+      headers: {
+        "x-fal-target-url": "https://fal.run/owner/app",
+        "content-type": "text/plain; charset=iso-8859-1",
+      },
+    };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+    };
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      await expect(
+        handler(request as never, response as never),
+      ).rejects.toThrow(/iso-8859-1/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 });
 

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from "stream";
 import { createUrlMatcher, DEFAULT_ALLOWED_URL_PATTERNS } from "./config";
 import {
   getEndpoint,
@@ -203,6 +204,16 @@ describe("isAllowedUrl with custom patterns", () => {
   it("should work with empty patterns array", () => {
     expect(isAllowedUrl("fal.run/path", [])).toBe(false);
   });
+
+  it("recompiles a cached matcher when its pattern array changes", () => {
+    const patterns = ["fal.run/owner/app"];
+    expect(isAllowedUrl("fal.run/owner/app", patterns)).toBe(true);
+
+    patterns.splice(0, 1, "fal.run/owner/other-app");
+
+    expect(isAllowedUrl("fal.run/owner/app", patterns)).toBe(false);
+    expect(isAllowedUrl("fal.run/owner/other-app", patterns)).toBe(true);
+  });
 });
 
 describe("getEndpoint", () => {
@@ -324,6 +335,16 @@ describe("isAllowedEndpoint", () => {
       expect(isAllowedEndpoint("any/random/endpoint", [])).toBe(true);
       expect(isAllowedEndpoint("", [])).toBe(true);
     });
+  });
+
+  it("recompiles a cached endpoint matcher when its patterns change", () => {
+    const patterns = ["owner/app"];
+    expect(isAllowedEndpoint("owner/app", patterns)).toBe(true);
+
+    patterns.splice(0, 1, "owner/other-app");
+
+    expect(isAllowedEndpoint("owner/app", patterns)).toBe(false);
+    expect(isAllowedEndpoint("owner/other-app", patterns)).toBe(true);
   });
 
   describe("real-world endpoint examples", () => {
@@ -472,6 +493,17 @@ describe("serializeParsedBody", () => {
       ),
     ).toBe("users%5B0%5D%5Bname%5D=alice&users%5B1%5D%5Bname%5D=bob");
   });
+
+  it("rejects parsed objects whose declared media type cannot be reconstructed", async () => {
+    const { serializeParsedBody } = await import("./utils");
+
+    expect(() => serializeParsedBody({ value: 1 }, "application/xml")).toThrow(
+      /application\/xml/,
+    );
+    expect(() => serializeParsedBody({ value: 1 }, "application/cbor")).toThrow(
+      /application\/cbor/,
+    );
+  });
 });
 
 describe("readUnconsumedRequestBody", () => {
@@ -483,6 +515,57 @@ describe("readUnconsumedRequestBody", () => {
     await expect(
       readUnconsumedRequestBody(endless(), 4 * 1024 * 1024),
     ).rejects.toThrow(/exceeded/);
+  });
+
+  it("marks body-limit errors as HTTP 413", async () => {
+    const { readUnconsumedRequestBody } = await import("./utils");
+    async function* body() {
+      yield new Uint8Array([1, 2]);
+    }
+
+    await expect(readUnconsumedRequestBody(body(), 1)).rejects.toMatchObject({
+      status: 413,
+      statusCode: 413,
+    });
+  });
+
+  it("caps Fetch-API request streams before forwarding them", async () => {
+    const { readWebRequestBody } = await import("./utils");
+    const request = new Request("https://proxy.test", {
+      method: "POST",
+      body: new Uint8Array([1, 2]),
+    });
+
+    await expect(
+      (
+        readWebRequestBody as (
+          request: Request,
+          maxBytes: number,
+        ) => Promise<unknown>
+      )(request, 1),
+    ).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+});
+
+describe("proxy body limit configuration", () => {
+  it("rejects values that would disable or make the byte bound ambiguous", async () => {
+    const { resolveProxyConfig } = await import("./config");
+    const safeConfig = {
+      allowedEndpoints: ["owner/app"],
+      allowUnauthorizedRequests: false,
+    };
+
+    for (const maxRequestBodyBytes of [NaN, Infinity, -1, 1.5]) {
+      expect(() =>
+        resolveProxyConfig({ ...safeConfig, maxRequestBodyBytes }),
+      ).toThrow(/non-negative safe integer/);
+    }
+    expect(
+      resolveProxyConfig({ ...safeConfig, maxRequestBodyBytes: 0 })
+        .maxRequestBodyBytes,
+    ).toBe(0);
   });
 });
 
@@ -563,6 +646,167 @@ describe("createHandler (express) body handling", () => {
     try {
       await handler(request as never, expressResponse() as never, jest.fn());
       expect(fetchMock.mock.calls[0][1]?.body).toBe('{"prompt":"hello"}');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects a partially consumed request instead of forwarding its tail", async () => {
+    const { createHandler } = await import("./express");
+    const request = new Readable({ read: jest.fn() }) as Readable & {
+      method: string;
+      body: unknown;
+      headers: Record<string, string>;
+    };
+    request.push(Buffer.from("abc"));
+    request.push(Buffer.from("def"));
+    request.push(null);
+    request.method = "POST";
+    request.body = undefined;
+    request.headers = {
+      "x-fal-target-url": "https://fal.run/owner/app",
+      "content-type": "application/octet-stream",
+      "content-length": "6",
+    };
+    expect(request.read(3)?.toString()).toBe("abc");
+    expect(request.readable).toBe(true);
+    expect(request.readableDidRead).toBe(true);
+
+    const next = jest.fn();
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      await createHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      })(request as never, expressResponse() as never, next);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringMatching(/consumed/) }),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});
+
+describe("createRouteHandler (hono) body handling", () => {
+  it("replays cached JSON through Hono middleware", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.json();
+      await next();
+    });
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "application/json",
+        },
+        body: '{ "prompt": "hello" }',
+      });
+
+      expect(response.status).toBe(200);
+      expect(fetchMock.mock.calls[0][1]?.body).toEqual(
+        new TextEncoder().encode('{"prompt":"hello"}').buffer,
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("preserves cached multipart bytes when middleware cached arrayBuffer first", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.arrayBuffer();
+      await next();
+    });
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const form = new FormData();
+    form.append("field", "value");
+    const request = new Request("http://local.test/proxy", {
+      method: "POST",
+      headers: { "x-fal-target-url": "https://fal.run/owner/app" },
+      body: form,
+    });
+    const originalContentType = request.headers.get("content-type");
+    const originalBody = new Uint8Array(await request.clone().arrayBuffer());
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      const response = await app.request(request);
+
+      expect(response.status).toBe(200);
+      const forwarded = fetchMock.mock.calls[0][1];
+      expect(
+        (forwarded?.headers as Record<string, string>)["content-type"],
+      ).toBe(originalContentType);
+      expect(new Uint8Array(forwarded?.body as ArrayBuffer)).toEqual(
+        originalBody,
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects cached FormData whose original multipart boundary is gone", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.formData();
+      await next();
+    });
+    app.onError((error, context) => context.text(error.message, 500));
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const form = new FormData();
+    form.append("field", "value");
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: { "x-fal-target-url": "https://fal.run/owner/app" },
+        body: form,
+      });
+
+      expect(response.status).toBe(500);
+      await expect(response.text()).resolves.toMatch(/multipart.*consumed/i);
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       fetchMock.mockRestore();
     }
@@ -692,6 +936,35 @@ describe("createPageRouterHandler body handling", () => {
     await expect(handler(request as never, response as never)).rejects.toThrow(
       /bodyParser: false/,
     );
+  });
+});
+
+describe("createRouteHandler (Next app router) body handling", () => {
+  it("returns 413 before fetch when a raw body exceeds maxRequestBodyBytes", async () => {
+    const { createRouteHandler } = await import("./nextjs");
+    const { POST } = createRouteHandler({
+      maxRequestBodyBytes: 1,
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = new Request("http://local.test/api/fal/proxy", {
+      method: "POST",
+      headers: {
+        "x-fal-target-url": "https://fal.run/owner/app",
+        "content-type": "application/octet-stream",
+      },
+      body: new Uint8Array([1, 2]),
+    });
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      const response = await POST(request as never);
+
+      expect(response.status).toBe(413);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 });
 
@@ -1041,6 +1314,23 @@ describe("handleRequest rejection reasons", () => {
       status: 400,
       data: "Invalid request: target path is not permitted by allowedEndpoints",
     });
+  });
+
+  it("returns 413 when the app-scoped service body exceeds the adapter limit", async () => {
+    const { RequestBodyTooLargeError } = await import("./utils");
+    const { behavior, responses } = behaviorFor("https://wma.fal.run/session");
+    behavior.getRequestBody = async () => {
+      throw new RequestBodyTooLargeError(1);
+    };
+
+    await handleRequest(behavior as never, {
+      allowedEndpoints: ["owner/app"],
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+
+    expect(responses[0]).toMatchObject({ status: 413 });
   });
 
   it("names the missing header", async () => {

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -954,6 +954,36 @@ describe("createPageRouterHandler body handling", () => {
     }
   });
 
+  it("does not double-encode structured-suffix JSON that Next leaves as raw text", async () => {
+    const { createPageRouterHandler } = await import("./nextjs");
+    const handler = createPageRouterHandler({
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => true,
+      resolveFalAuth: async () => "Key secret",
+    });
+    const request = {
+      method: "POST",
+      body: '{"title":"bad request"}',
+      headers: {
+        "x-fal-target-url": "https://fal.run/owner/app",
+        "content-type": "application/problem+json",
+      },
+    };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ json: jest.fn(), send: jest.fn() })),
+    };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handler(request as never, response as never);
+      expect(fetchMock.mock.calls[0][1]?.body).toBe('{"title":"bad request"}');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("forwards a binary upstream response as exact bytes", async () => {
     // A forwarded accept header can make the upstream answer with binary (an image, an
     // octet-stream); text() would UTF-8-decode and corrupt it before it reaches the caller.

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -1670,6 +1670,60 @@ describe("handleRequest rejection reasons", () => {
     expect(getRequestBody).not.toHaveBeenCalled();
   });
 
+  it("shares one cached body read with authentication callbacks and fetch", async () => {
+    const requestBody = '{"prompt":"hello"}';
+    const { behavior } = behaviorFor(
+      "https://fal.run/owner/app",
+      "POST",
+      requestBody,
+    );
+    const originalBodyReader = jest
+      .fn()
+      .mockResolvedValueOnce(requestBody)
+      .mockResolvedValueOnce(undefined);
+    behavior.getRequestBody = originalBodyReader;
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async (authBehavior) => {
+          expect(await authBehavior.getRequestBody()).toBe(requestBody);
+          return true;
+        },
+        resolveFalAuth: async (authBehavior) => {
+          expect(await authBehavior.getRequestBody()).toBe(requestBody);
+          return "Key secret";
+        },
+      });
+
+      expect(originalBodyReader).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][1]?.body).toBe(requestBody);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("returns 413 when authentication reads an oversized body", async () => {
+    const { RequestBodyTooLargeError } = await import("./utils");
+    const { behavior, responses } = behaviorFor("https://fal.run/owner/app");
+    behavior.getRequestBody = async () => {
+      throw new RequestBodyTooLargeError(1);
+    };
+
+    await handleRequest(behavior as never, {
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async (authBehavior) => {
+        await authBehavior.getRequestBody();
+        return true;
+      },
+      resolveFalAuth: async () => "Key secret",
+    });
+
+    expect(responses[0]).toMatchObject({ status: 413 });
+  });
+
   it("allows the bridge by default, without any allowlisting", async () => {
     expect(await run("https://wma.fal.run/session/heartbeat")).toEqual({
       status: 401,

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -770,6 +770,88 @@ describe("createRouteHandler (hono) body handling", () => {
     }
   });
 
+  it("uses the untouched raw stream when parseBody cached without consuming it", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.parseBody();
+      expect(context.req.raw.bodyUsed).toBe(false);
+      await next();
+    });
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const rawBody = '{  "prompt": "hello"  }';
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "application/json",
+        },
+        body: rawBody,
+      });
+
+      expect(response.status).toBe(200);
+      expect(fetchMock.mock.calls[0][1]?.body).toEqual(
+        new TextEncoder().encode(rawBody),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("re-encodes cached URL-encoded FormData without changing its media type", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.formData();
+      await next();
+    });
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "tag=a&tag=b",
+      });
+
+      expect(response.status).toBe(200);
+      const forwarded = fetchMock.mock.calls[0][1];
+      expect(forwarded?.body).toBe("tag=a&tag=b");
+      expect(
+        (forwarded?.headers as Record<string, string>)["content-type"],
+      ).toBe("application/x-www-form-urlencoded");
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("rejects lossy cached text with a non-UTF-8 charset", async () => {
     const { Hono } = await import("hono");
     const { createRouteHandler } = await import("./hono");
@@ -801,6 +883,43 @@ describe("createRouteHandler (hono) body handling", () => {
 
       expect(response.status).toBe(500);
       await expect(response.text()).resolves.toMatch(/iso-8859-1/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects cached text for a binary media type", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.text();
+      await next();
+    });
+    app.onError((error, context) => context.text(error.message, 500));
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "application/octet-stream",
+        },
+        body: new Uint8Array([0xff]),
+      });
+
+      expect(response.status).toBe(500);
+      await expect(response.text()).resolves.toMatch(/cannot faithfully/);
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       fetchMock.mockRestore();

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -770,6 +770,43 @@ describe("createRouteHandler (hono) body handling", () => {
     }
   });
 
+  it("rejects lossy cached text with a non-UTF-8 charset", async () => {
+    const { Hono } = await import("hono");
+    const { createRouteHandler } = await import("./hono");
+    const app = new Hono();
+    app.use("/proxy", async (context, next) => {
+      await context.req.text();
+      await next();
+    });
+    app.onError((error, context) => context.text(error.message, 500));
+    app.post(
+      "/proxy",
+      createRouteHandler({
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => true,
+        resolveFalAuth: async () => "Key secret",
+      }),
+    );
+
+    const fetchMock = jest.spyOn(global, "fetch");
+    try {
+      const response = await app.request("http://local.test/proxy", {
+        method: "POST",
+        headers: {
+          "x-fal-target-url": "https://fal.run/owner/app",
+          "content-type": "text/plain; charset=iso-8859-1",
+        },
+        body: new Uint8Array([0xe9]),
+      });
+
+      expect(response.status).toBe(500);
+      await expect(response.text()).resolves.toMatch(/iso-8859-1/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("preserves cached multipart bytes when middleware cached arrayBuffer first", async () => {
     const { Hono } = await import("hono");
     const { createRouteHandler } = await import("./hono");

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -1453,6 +1453,28 @@ describe("handleRequest rejection reasons", () => {
     });
   });
 
+  it("rejects duplicate app_id keys written with JSON escapes", async () => {
+    for (const body of [
+      '{"app_id":"blocked/app","app_\\u0069d":"owner/app"}',
+      '{"app_\\u0069d":"blocked/app","app_id":"owner/app"}',
+    ]) {
+      expect(
+        await run(
+          "https://wma.fal.run/session",
+          {
+            allowedEndpoints: ["owner/app"],
+            isAuthenticated: async () => true,
+          },
+          "POST",
+          body,
+        ),
+      ).toEqual({
+        status: 400,
+        data: "Invalid request: target path is not permitted by allowedEndpoints",
+      });
+    }
+  });
+
   it("lets operators refuse service hosts entirely with serviceHosts: []", async () => {
     expect(
       await run("https://wma.fal.run/session", {

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -89,13 +89,42 @@ function normalizeServicePath(url: URL): string | undefined {
   return path.replace(/\/+$/, "") || "/";
 }
 
+function countJsonKeys(body: string, key: string): number {
+  let count = 0;
+  for (let index = 0; index < body.length; index++) {
+    if (body[index] !== '"') continue;
+    const start = index;
+    for (index++; index < body.length; index++) {
+      if (body[index] === "\\") {
+        // Skip the escaped character so an escaped quote cannot look like a string boundary.
+        index++;
+        continue;
+      }
+      if (body[index] !== '"') continue;
+
+      let next = index + 1;
+      while (/\s/.test(body[next] ?? "")) next++;
+      if (body[next] === ":") {
+        try {
+          if (JSON.parse(body.slice(start, index + 1)) === key) count++;
+        } catch {
+          // The full JSON parse below rejects malformed strings. This scan only decides whether
+          // a syntactically decodable key appears more than once.
+        }
+      }
+      break;
+    }
+  }
+  return count;
+}
+
 function appIdFromRequestBody(body: string | undefined): string | undefined {
   if (!body) return undefined;
   // Fail closed on duplicate keys: JSON parsers disagree about which duplicate wins, and this
   // value gates allowedEndpoints — the proxy's verdict must not depend on its parser agreeing
-  // with the upstream's. (Matching the raw text over-counts an "app_id" inside a nested string,
-  // which only ever rejects more, never less.)
-  if ((body.match(/"app_id"\s*:/g) ?? []).length > 1) return undefined;
+  // with the upstream's. Decode every object-key token so escaped spellings such as
+  // `app_\u0069d` count too. Nested keys are deliberately included; that can only reject more.
+  if (countJsonKeys(body, "app_id") > 1) return undefined;
   try {
     const value = JSON.parse(body) as { app_id?: unknown };
     return typeof value.app_id === "string" ? value.app_id : undefined;

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -261,6 +261,17 @@ export async function handleRequest<ResponseType>(
   let requestBodyPromise: Promise<ProxyRequestBody> | undefined;
   const readRequestBody = () =>
     (requestBodyPromise ??= behavior.getRequestBody());
+  // Authentication callbacks sometimes verify a signature over the request body. Give them the
+  // same cached reader used by policy checks and forwarding, or a one-shot adapter stream would
+  // be consumed before the proxy reaches fetch.
+  const behaviorWithCachedBody = new Proxy(behavior, {
+    get(target, property) {
+      if (property === "getRequestBody") return readRequestBody;
+      const value = Reflect.get(target, property, target) as unknown;
+      // Preserve class-based ProxyBehavior implementations whose methods use private fields.
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
   // The forwarded body stays raw bytes — decoding a multipart payload corrupts its file parts.
   // Only the WMA app-id extraction needs text, and those routes carry JSON.
   const readRequestBodyText = async (): Promise<string | undefined> => {
@@ -316,8 +327,16 @@ export async function handleRequest<ResponseType>(
 
   // Authentication FIRST, once: an unauthenticated caller learns nothing about endpoint policy,
   // and the check cannot diverge between the service and app paths.
-  const isAuthenticated =
-    (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
+  let isAuthenticated: boolean;
+  try {
+    isAuthenticated =
+      (await resolvedConfig.isAuthenticated?.(behaviorWithCachedBody)) ?? false;
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return behavior.respondWith(error.status, error.message);
+    }
+    throw error;
+  }
   if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
     return behavior.respondWith(401, "Unauthorized");
   }
@@ -381,9 +400,17 @@ export async function handleRequest<ResponseType>(
     }
   }
 
-  const authorization =
-    (await resolvedConfig.resolveFalAuth?.(behavior)) ??
-    (await behavior.resolveApiKey?.());
+  let authorization: string | undefined;
+  try {
+    authorization =
+      (await resolvedConfig.resolveFalAuth?.(behaviorWithCachedBody)) ??
+      (await behavior.resolveApiKey?.());
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return behavior.respondWith(error.status, error.message);
+    }
+    throw error;
+  }
   if (!authorization) {
     return behavior.respondWith(401, "Unauthorized");
   }

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -37,9 +37,21 @@ const defaultUrlMatcher = createUrlMatcher(DEFAULT_ALLOWED_URL_PATTERNS);
  * @param patterns the allowed URL patterns (glob-style). If not provided, uses default patterns.
  * @returns whether the URL is allowed.
  */
+// Compiled matchers are memoized by the pattern array's identity: a resolved config carries the
+// same array on every request, and glob→regex compilation is the expensive half of the check.
+const matcherCache = new WeakMap<string[], (url: string) => boolean>();
+function cachedMatcher(patterns: string[]): (url: string) => boolean {
+  let matcher = matcherCache.get(patterns);
+  if (!matcher) {
+    matcher = createUrlMatcher(patterns);
+    matcherCache.set(patterns, matcher);
+  }
+  return matcher;
+}
+
 export function isAllowedUrl(url: string, patterns?: string[]): boolean {
   if (patterns) {
-    return createUrlMatcher(patterns)(url);
+    return cachedMatcher(patterns)(url);
   }
   return defaultUrlMatcher(url);
 }
@@ -55,38 +67,37 @@ function getUrlWithoutScheme(targetUrl: string): string {
 }
 
 /**
- * fal service hosts that serve no customer app, and therefore have no app id to match.
- *
- * Kept as an explicit set so adding one is a deliberate act. A host belongs here only if every path
- * on it is fal's own — `wma.fal.run` is signalling, with paths like `session` and `session/heartbeat`.
+ * Routes fal's service hosts are permitted to forward, DEFAULT-DENY: a path absent from both sets
+ * is rejected, so a route added upstream can never silently escape endpoint policy before this
+ * list learns about it. App-scoped routes carry the app identity in their JSON body and enforce
+ * `allowedEndpoints` against it; session-scoped routes act on an already-negotiated session and
+ * carry no app authority.
  */
-const FAL_SERVICE_HOSTS = new Set(["wma.fal.run"]);
-const WMA_APP_SCOPED_PATHS = new Set(["/ice", "/session"]);
+const SERVICE_APP_SCOPED_PATHS = new Set(["/ice", "/session"]);
+const SERVICE_SESSION_SCOPED_PATHS = new Set(["/session/heartbeat"]);
 
-/** Is this fal's own service infrastructure, carrying no customer app? */
-function isFalServiceHost(targetUrl: string): boolean {
-  const url = new URL(targetUrl);
-  return url.protocol === "https:" && FAL_SERVICE_HOSTS.has(url.host);
-}
-
-function isWmaAppScopedRoute(targetUrl: string): boolean {
-  const url = new URL(targetUrl);
-  if (!isFalServiceHost(targetUrl)) return false;
+/**
+ * The service-relative path, normalized the way the upstream router sees it (percent escapes
+ * decoded, duplicate slashes collapsed, trailing slashes stripped). `undefined` for malformed
+ * escapes — which never match a known route, failing closed.
+ */
+function normalizeServicePath(url: URL): string | undefined {
   let path: string;
   try {
-    // URL.pathname keeps percent escapes intact, while the upstream router decodes them. Apply the
-    // same normalization before deciding whether the route carries app authority in its JSON body.
     path = decodeURIComponent(url.pathname).replace(/\/{2,}/g, "/");
   } catch {
-    // A malformed escape must not turn a potentially app-scoped service route into an exemption.
-    return true;
+    return undefined;
   }
-  path = path.replace(/\/+$/, "") || "/";
-  return WMA_APP_SCOPED_PATHS.has(path);
+  return path.replace(/\/+$/, "") || "/";
 }
 
 function appIdFromRequestBody(body: string | undefined): string | undefined {
   if (!body) return undefined;
+  // Fail closed on duplicate keys: JSON parsers disagree about which duplicate wins, and this
+  // value gates allowedEndpoints — the proxy's verdict must not depend on its parser agreeing
+  // with the upstream's. (Matching the raw text over-counts an "app_id" inside a nested string,
+  // which only ever rejects more, never less.)
+  if ((body.match(/"app_id"\s*:/g) ?? []).length > 1) return undefined;
   try {
     const value = JSON.parse(body) as { app_id?: unknown };
     return typeof value.app_id === "string" ? value.app_id : undefined;
@@ -108,14 +119,16 @@ function appIdFromRequestBody(body: string | undefined): string | undefined {
  * @param targetUrl the full URL including scheme.
  * @returns true when the host is fal's own service infrastructure.
  */
-function isFalInfrastructure(targetUrl: string): boolean {
-  const { host } = new URL(targetUrl);
+function isFalInfrastructure(url: URL, serviceHosts: Set<string>): boolean {
   // Enumerated, NOT a suffix rule on `.fal.run`. `fal.run` and `queue.fal.run` serve customer apps,
   // and `getEndpoint()` on those yields an app id — which is exactly what `allowedEndpoints` is for.
   // Exempting the whole domain would leave that option restricting nothing on its main path, so the
   // widening has to name the service hosts rather than the domain they happen to share.
+  const host = url.host.toLowerCase();
   return (
-    host === "fal.ai" || host.endsWith(".fal.ai") || isFalServiceHost(targetUrl)
+    host === "fal.ai" ||
+    host.endsWith(".fal.ai") ||
+    (url.protocol === "https:" && serviceHosts.has(host))
   );
 }
 
@@ -145,7 +158,7 @@ export function isAllowedEndpoint(
   if (patterns.length === 0) {
     return true;
   }
-  return createUrlMatcher(patterns)(endpoint);
+  return cachedMatcher(patterns)(endpoint);
 }
 
 function getFalKey(): string | undefined {
@@ -216,15 +229,10 @@ export async function handleRequest<ResponseType>(
   const resolvedConfig = isResolved
     ? (config as ProxyConfig)
     : applyProxyConfig(config);
-  let requestBody: ProxyRequestBody;
-  let requestBodyRead = false;
-  const readRequestBody = async () => {
-    if (!requestBodyRead) {
-      requestBody = await behavior.getRequestBody();
-      requestBodyRead = true;
-    }
-    return requestBody;
-  };
+  // One cached promise, so the read-once guarantee is unrepresentable to break — a flag-plus-value
+  // pair invites a concurrent double read of an already-consumed stream.
+  let requestBodyPromise: Promise<ProxyRequestBody> | undefined;
+  const readRequestBody = () => (requestBodyPromise ??= behavior.getRequestBody());
   // The forwarded body stays raw bytes — decoding a multipart payload corrupts its file parts.
   // Only the WMA app-id extraction needs text, and those routes carry JSON.
   const readRequestBodyText = async (): Promise<string | undefined> => {
@@ -238,20 +246,37 @@ export async function handleRequest<ResponseType>(
     return new TextDecoder().decode(body);
   };
 
-  const urlToValidate = getUrlWithoutScheme(targetUrl);
-  // fal's own SERVICE hosts skip the URL allowlist entirely, and are deliberately absent from
-  // DEFAULT_ALLOWED_URL_PATTERNS: this short-circuit runs first, so a default entry could never be
-  // the thing that admits them. Supplying `allowedUrlPatterns` REPLACES the defaults, so an entry
+  // ONE parse for the whole request, and the single choke point for malformed target URLs —
+  // a throwing `new URL` inside a helper would otherwise surface as a 500 from whichever check
+  // happened to run first.
+  let url: URL;
+  try {
+    url = new URL(targetUrl);
+  } catch {
+    return behavior.respondWith(
+      400,
+      `Invalid request: ${TARGET_URL_HEADER} is not a valid absolute URL`,
+    );
+  }
+  const serviceHosts = new Set(
+    (resolvedConfig.serviceHosts ?? ["wma.fal.run"]).map((host) =>
+      host.toLowerCase(),
+    ),
+  );
+  const isServiceHost =
+    url.protocol === "https:" && serviceHosts.has(url.host.toLowerCase());
+
+  // fal's own SERVICE hosts skip the URL allowlist, and are deliberately absent from
+  // DEFAULT_ALLOWED_URL_PATTERNS: supplying `allowedUrlPatterns` REPLACES the defaults, so an entry
   // there would only help callers who never narrow the list — and narrowing it is the careful thing
   // to do. Anyone scoping the proxy to their two apps would lose signalling and have no way to know
-  // why, which is the failure this exists to remove.
-  //
-  // Deliberately the enumerated service set and NOT `.fal.ai`: fal.ai is not allowed by default today
-  // and this must not quietly start permitting it. Service hosts carry no customer-app authority —
-  // `wma.fal.run` only signals — so allowing them is equivalent to allowing realtime sessions at all.
+  // why. Operators who want them refused entirely set `serviceHosts: []`.
   if (
-    !isFalServiceHost(targetUrl) &&
-    !isAllowedUrl(urlToValidate, resolvedConfig.allowedUrlPatterns)
+    !isServiceHost &&
+    !isAllowedUrl(
+      `${url.host}${url.pathname}${url.search}`,
+      resolvedConfig.allowedUrlPatterns,
+    )
   ) {
     // Names the OPTION, never its contents. Which check rejected you is something a blocked caller
     // can already infer; the configured patterns would hand them a map of what this proxy may reach.
@@ -261,29 +286,55 @@ export async function handleRequest<ResponseType>(
     );
   }
 
-  // App-serving POST paths carry the app id in the URL. WMA's app-scoped infrastructure routes
-  // carry it in JSON instead, so both must enforce the same endpoint policy.
-  const allowedEndpoints = resolvedConfig.allowedEndpoints ?? [];
-  const restrictEndpoints =
-    behavior.method?.toUpperCase() === "POST" && allowedEndpoints.length > 0;
-  const wmaAppScoped = restrictEndpoints && isWmaAppScopedRoute(targetUrl);
-  let isAuthenticated: boolean | undefined;
-  if (wmaAppScoped) {
-    isAuthenticated =
-      (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
-    if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
-      return behavior.respondWith(401, "Unauthorized");
+  // Authentication FIRST, once: an unauthenticated caller learns nothing about endpoint policy,
+  // and the check cannot diverge between the service and app paths.
+  const isAuthenticated =
+    (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
+  if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
+    return behavior.respondWith(401, "Unauthorized");
+  }
+
+  // Service hosts are DEFAULT-DENY by shape: fal's signalling legs are all POST to a known route,
+  // so anything else — another method, an unknown or unnormalizable path — is refused rather than
+  // forwarded with credentials. A route added upstream must be added here deliberately.
+  let serviceAppScoped = false;
+  if (isServiceHost) {
+    if (behavior.method?.toUpperCase() !== "POST") {
+      return behavior.respondWith(
+        400,
+        "Invalid request: fal service hosts only accept POST",
+      );
+    }
+    const servicePath = normalizeServicePath(url);
+    serviceAppScoped =
+      servicePath !== undefined && SERVICE_APP_SCOPED_PATHS.has(servicePath);
+    if (
+      !serviceAppScoped &&
+      (servicePath === undefined ||
+        !SERVICE_SESSION_SCOPED_PATHS.has(servicePath))
+    ) {
+      return behavior.respondWith(
+        400,
+        "Invalid request: unknown fal service route",
+      );
     }
   }
 
+  // App-serving POST paths carry the app id in the URL. The service hosts' app-scoped routes
+  // carry it in JSON instead, so both enforce the same endpoint policy.
+  const allowedEndpoints = resolvedConfig.allowedEndpoints ?? [];
+  const restrictEndpoints =
+    behavior.method?.toUpperCase() === "POST" && allowedEndpoints.length > 0;
   if (restrictEndpoints) {
-    const endpoint = wmaAppScoped
-      ? appIdFromRequestBody(await readRequestBodyText())
-      : isFalInfrastructure(targetUrl)
+    const endpoint = isServiceHost
+      ? serviceAppScoped
+        ? appIdFromRequestBody(await readRequestBodyText())
+        : undefined
+      : isFalInfrastructure(url, serviceHosts)
         ? undefined
         : getEndpoint(targetUrl);
     if (
-      (wmaAppScoped && endpoint === undefined) ||
+      (isServiceHost && serviceAppScoped && endpoint === undefined) ||
       (endpoint !== undefined && !isAllowedEndpoint(endpoint, allowedEndpoints))
     ) {
       // The URL is allowlisted and the path is not, which is a different option and a different fix.
@@ -292,12 +343,6 @@ export async function handleRequest<ResponseType>(
         "Invalid request: target path is not permitted by allowedEndpoints",
       );
     }
-  }
-
-  isAuthenticated ??=
-    (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
-  if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
-    return behavior.respondWith(401, "Unauthorized");
   }
 
   const authorization =

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -5,7 +5,11 @@ import {
   type ProxyConfig,
 } from "./config";
 import type { HeaderValue, ProxyBehavior, ProxyRequestBody } from "./types";
-import { isParserProducedByteBody, singleHeaderValue } from "./utils";
+import {
+  isParserProducedByteBody,
+  RequestBodyTooLargeError,
+  singleHeaderValue,
+} from "./utils";
 
 export {
   createUrlMatcher,
@@ -37,16 +41,20 @@ const defaultUrlMatcher = createUrlMatcher(DEFAULT_ALLOWED_URL_PATTERNS);
  * @param patterns the allowed URL patterns (glob-style). If not provided, uses default patterns.
  * @returns whether the URL is allowed.
  */
-// Compiled matchers are memoized by the pattern array's identity: a resolved config carries the
-// same array on every request, and glob→regex compilation is the expensive half of the check.
-const matcherCache = new WeakMap<string[], (url: string) => boolean>();
+// Compiled matchers are memoized by the pattern array's identity and contents: a resolved config
+// normally carries the same unchanged array on every request, but callers may mutate it in place.
+const matcherCache = new WeakMap<
+  string[],
+  { signature: string; matcher: (url: string) => boolean }
+>();
 function cachedMatcher(patterns: string[]): (url: string) => boolean {
-  let matcher = matcherCache.get(patterns);
-  if (!matcher) {
-    matcher = createUrlMatcher(patterns);
-    matcherCache.set(patterns, matcher);
+  const signature = JSON.stringify(patterns);
+  let cached = matcherCache.get(patterns);
+  if (!cached || cached.signature !== signature) {
+    cached = { signature, matcher: createUrlMatcher(patterns) };
+    matcherCache.set(patterns, cached);
   }
-  return matcher;
+  return cached.matcher;
 }
 
 export function isAllowedUrl(url: string, patterns?: string[]): boolean {
@@ -54,16 +62,6 @@ export function isAllowedUrl(url: string, patterns?: string[]): boolean {
     return cachedMatcher(patterns)(url);
   }
   return defaultUrlMatcher(url);
-}
-
-/**
- * Extracts the URL without the scheme for validation purposes.
- * @param targetUrl the full URL including scheme.
- * @returns the URL without the scheme (host + path + query).
- */
-function getUrlWithoutScheme(targetUrl: string): string {
-  const url = new URL(targetUrl);
-  return `${url.host}${url.pathname}${url.search}`;
 }
 
 /**
@@ -232,7 +230,8 @@ export async function handleRequest<ResponseType>(
   // One cached promise, so the read-once guarantee is unrepresentable to break — a flag-plus-value
   // pair invites a concurrent double read of an already-consumed stream.
   let requestBodyPromise: Promise<ProxyRequestBody> | undefined;
-  const readRequestBody = () => (requestBodyPromise ??= behavior.getRequestBody());
+  const readRequestBody = () =>
+    (requestBodyPromise ??= behavior.getRequestBody());
   // The forwarded body stays raw bytes — decoding a multipart payload corrupts its file parts.
   // Only the WMA app-id extraction needs text, and those routes carry JSON.
   const readRequestBodyText = async (): Promise<string | undefined> => {
@@ -326,13 +325,21 @@ export async function handleRequest<ResponseType>(
   const restrictEndpoints =
     behavior.method?.toUpperCase() === "POST" && allowedEndpoints.length > 0;
   if (restrictEndpoints) {
-    const endpoint = isServiceHost
-      ? serviceAppScoped
-        ? appIdFromRequestBody(await readRequestBodyText())
-        : undefined
-      : isFalInfrastructure(url, serviceHosts)
-        ? undefined
-        : getEndpoint(targetUrl);
+    let endpoint: string | undefined;
+    if (isServiceHost) {
+      if (serviceAppScoped) {
+        try {
+          endpoint = appIdFromRequestBody(await readRequestBodyText());
+        } catch (error) {
+          if (error instanceof RequestBodyTooLargeError) {
+            return behavior.respondWith(error.status, error.message);
+          }
+          throw error;
+        }
+      }
+    } else if (!isFalInfrastructure(url, serviceHosts)) {
+      endpoint = getEndpoint(targetUrl);
+    }
     if (
       (isServiceHost && serviceAppScoped && endpoint === undefined) ||
       (endpoint !== undefined && !isAllowedEndpoint(endpoint, allowedEndpoints))
@@ -379,10 +386,18 @@ export async function handleRequest<ResponseType>(
   const userAgent = singleHeaderValue(behavior.getHeader("user-agent"));
   const accept =
     singleHeaderValue(behavior.getHeader("accept")) ?? "application/json";
-  const body =
-    behavior.method?.toUpperCase() === "GET"
-      ? undefined
-      : await readRequestBody();
+  let body: ProxyRequestBody;
+  try {
+    body =
+      behavior.method?.toUpperCase() === "GET"
+        ? undefined
+        : await readRequestBody();
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return behavior.respondWith(error.status, error.message);
+    }
+    throw error;
+  }
   // The incoming content-type is forwarded when present. When absent, string bodies keep the
   // historical application/json default (bare `fetch(proxy, { body: JSON.stringify(x) })` callers
   // relied on the old rewrite, and browsers would otherwise label them text/plain) — while raw

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -4,8 +4,8 @@ import {
   DEFAULT_ALLOWED_URL_PATTERNS,
   type ProxyConfig,
 } from "./config";
-import type { HeaderValue, ProxyBehavior } from "./types";
-import { singleHeaderValue } from "./utils";
+import type { HeaderValue, ProxyBehavior, ProxyRequestBody } from "./types";
+import { isParserProducedByteBody, singleHeaderValue } from "./utils";
 
 export {
   createUrlMatcher,
@@ -13,7 +13,11 @@ export {
   resolveProxyConfig,
   type ProxyConfig,
 } from "./config";
-export { type HeaderValue, type ProxyBehavior } from "./types";
+export {
+  type HeaderValue,
+  type ProxyBehavior,
+  type ProxyRequestBody,
+} from "./types";
 
 export const TARGET_URL_HEADER = "x-fal-target-url";
 
@@ -51,13 +55,68 @@ function getUrlWithoutScheme(targetUrl: string): string {
 }
 
 /**
- * Checks if the URL is on the fal.ai domain or any of its subdomains.
- * @param targetUrl the full URL including scheme.
- * @returns true if the URL is on *.fal.ai domain.
+ * fal service hosts that serve no customer app, and therefore have no app id to match.
+ *
+ * Kept as an explicit set so adding one is a deliberate act. A host belongs here only if every path
+ * on it is fal's own — `wma.fal.run` is signalling, with paths like `session` and `session/heartbeat`.
  */
-function isFalAiDomain(targetUrl: string): boolean {
+const FAL_SERVICE_HOSTS = new Set(["wma.fal.run"]);
+const WMA_APP_SCOPED_PATHS = new Set(["/ice", "/session"]);
+
+/** Is this fal's own service infrastructure, carrying no customer app? */
+function isFalServiceHost(targetUrl: string): boolean {
   const url = new URL(targetUrl);
-  return url.host === "fal.ai" || url.host.endsWith(".fal.ai");
+  return url.protocol === "https:" && FAL_SERVICE_HOSTS.has(url.host);
+}
+
+function isWmaAppScopedRoute(targetUrl: string): boolean {
+  const url = new URL(targetUrl);
+  if (!isFalServiceHost(targetUrl)) return false;
+  let path: string;
+  try {
+    // URL.pathname keeps percent escapes intact, while the upstream router decodes them. Apply the
+    // same normalization before deciding whether the route carries app authority in its JSON body.
+    path = decodeURIComponent(url.pathname).replace(/\/{2,}/g, "/");
+  } catch {
+    // A malformed escape must not turn a potentially app-scoped service route into an exemption.
+    return true;
+  }
+  path = path.replace(/\/+$/, "") || "/";
+  return WMA_APP_SCOPED_PATHS.has(path);
+}
+
+function appIdFromRequestBody(body: string | undefined): string | undefined {
+  if (!body) return undefined;
+  try {
+    const value = JSON.parse(body) as { app_id?: unknown };
+    return typeof value.app_id === "string" ? value.app_id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Hosts that are fal's own infrastructure rather than a customer's app.
+ *
+ * `allowedEndpoints` restricts WHICH OF YOUR APPS may be called, so applying it to fal's own service
+ * hosts is a category error: those paths are not app identifiers and can never match an app pattern.
+ *
+ * `fal.ai` subdomains and the explicitly enumerated service hosts share this treatment regardless of
+ * their DNS suffix. `wma.fal.run/session`, for example, is signalling infrastructure; reducing its
+ * path to `"session"` and comparing it with customer app ids would reject every valid bridge call.
+ *
+ * @param targetUrl the full URL including scheme.
+ * @returns true when the host is fal's own service infrastructure.
+ */
+function isFalInfrastructure(targetUrl: string): boolean {
+  const { host } = new URL(targetUrl);
+  // Enumerated, NOT a suffix rule on `.fal.run`. `fal.run` and `queue.fal.run` serve customer apps,
+  // and `getEndpoint()` on those yields an app id — which is exactly what `allowedEndpoints` is for.
+  // Exempting the whole domain would leave that option restricting nothing on its main path, so the
+  // widening has to name the service hosts rather than the domain they happen to share.
+  return (
+    host === "fal.ai" || host.endsWith(".fal.ai") || isFalServiceHost(targetUrl)
+  );
 }
 
 /**
@@ -101,6 +160,28 @@ function getFalKey(): string | undefined {
 
 const EXCLUDED_HEADERS = ["content-length", "content-encoding"];
 
+// Request headers that are never forwarded, even when explicitly listed in
+// `forwardRequestHeaders`: credentials addressed to the proxy host and hop-by-hop headers the
+// upstream fetch manages itself.
+// `content-encoding` is deliberately NOT here: it is end-to-end metadata for the raw-bytes body
+// path, and an operator who names it in `forwardRequestHeaders` is labeling compressed bytes the
+// proxy forwards unchanged. It still never travels by default.
+const NEVER_FORWARDED_REQUEST_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "host",
+  "content-length",
+  "connection",
+  "transfer-encoding",
+  "keep-alive",
+  "upgrade",
+  "te",
+  "trailer",
+  "expect",
+  "accept-encoding",
+  "proxy-authorization",
+]);
+
 /**
  * A request handler that proxies the request to the fal API
  * endpoint. This is useful so client-side calls to the fal endpoint
@@ -118,7 +199,12 @@ export async function handleRequest<ResponseType>(
 ) {
   const targetUrl = singleHeaderValue(behavior.getHeader(TARGET_URL_HEADER));
   if (!targetUrl) {
-    return behavior.respondWith(400, "Invalid request");
+    // Names the missing header. This one is purely about request SHAPE — no configuration is being
+    // disclosed by saying so, and a caller who forgot a header should be told which.
+    return behavior.respondWith(
+      400,
+      `Invalid request: missing ${TARGET_URL_HEADER} header`,
+    );
   }
 
   // Check if config is already resolved (has all required fields with non-undefined values)
@@ -130,21 +216,85 @@ export async function handleRequest<ResponseType>(
   const resolvedConfig = isResolved
     ? (config as ProxyConfig)
     : applyProxyConfig(config);
+  let requestBody: ProxyRequestBody;
+  let requestBodyRead = false;
+  const readRequestBody = async () => {
+    if (!requestBodyRead) {
+      requestBody = await behavior.getRequestBody();
+      requestBodyRead = true;
+    }
+    return requestBody;
+  };
+  // The forwarded body stays raw bytes — decoding a multipart payload corrupts its file parts.
+  // Only the WMA app-id extraction needs text, and those routes carry JSON.
+  const readRequestBodyText = async (): Promise<string | undefined> => {
+    const body = await readRequestBody();
+    if (typeof body === "string") {
+      return body;
+    }
+    if (body === undefined) {
+      return undefined;
+    }
+    return new TextDecoder().decode(body);
+  };
 
   const urlToValidate = getUrlWithoutScheme(targetUrl);
-  if (!isAllowedUrl(urlToValidate, resolvedConfig.allowedUrlPatterns)) {
-    return behavior.respondWith(400, "Invalid request");
+  // fal's own SERVICE hosts skip the URL allowlist entirely, and are deliberately absent from
+  // DEFAULT_ALLOWED_URL_PATTERNS: this short-circuit runs first, so a default entry could never be
+  // the thing that admits them. Supplying `allowedUrlPatterns` REPLACES the defaults, so an entry
+  // there would only help callers who never narrow the list — and narrowing it is the careful thing
+  // to do. Anyone scoping the proxy to their two apps would lose signalling and have no way to know
+  // why, which is the failure this exists to remove.
+  //
+  // Deliberately the enumerated service set and NOT `.fal.ai`: fal.ai is not allowed by default today
+  // and this must not quietly start permitting it. Service hosts carry no customer-app authority —
+  // `wma.fal.run` only signals — so allowing them is equivalent to allowing realtime sessions at all.
+  if (
+    !isFalServiceHost(targetUrl) &&
+    !isAllowedUrl(urlToValidate, resolvedConfig.allowedUrlPatterns)
+  ) {
+    // Names the OPTION, never its contents. Which check rejected you is something a blocked caller
+    // can already infer; the configured patterns would hand them a map of what this proxy may reach.
+    return behavior.respondWith(
+      400,
+      "Invalid request: target URL is not permitted by allowedUrlPatterns",
+    );
   }
 
-  // Check allowed endpoints for POST requests only, skip for *.fal.ai domains
-  if (behavior.method?.toUpperCase() === "POST" && !isFalAiDomain(targetUrl)) {
-    const endpoint = getEndpoint(targetUrl);
-    if (!isAllowedEndpoint(endpoint, resolvedConfig.allowedEndpoints ?? [])) {
-      return behavior.respondWith(400, "Invalid request");
+  // App-serving POST paths carry the app id in the URL. WMA's app-scoped infrastructure routes
+  // carry it in JSON instead, so both must enforce the same endpoint policy.
+  const allowedEndpoints = resolvedConfig.allowedEndpoints ?? [];
+  const restrictEndpoints =
+    behavior.method?.toUpperCase() === "POST" && allowedEndpoints.length > 0;
+  const wmaAppScoped = restrictEndpoints && isWmaAppScopedRoute(targetUrl);
+  let isAuthenticated: boolean | undefined;
+  if (wmaAppScoped) {
+    isAuthenticated =
+      (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
+    if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
+      return behavior.respondWith(401, "Unauthorized");
     }
   }
 
-  const isAuthenticated =
+  if (restrictEndpoints) {
+    const endpoint = wmaAppScoped
+      ? appIdFromRequestBody(await readRequestBodyText())
+      : isFalInfrastructure(targetUrl)
+        ? undefined
+        : getEndpoint(targetUrl);
+    if (
+      (wmaAppScoped && endpoint === undefined) ||
+      (endpoint !== undefined && !isAllowedEndpoint(endpoint, allowedEndpoints))
+    ) {
+      // The URL is allowlisted and the path is not, which is a different option and a different fix.
+      return behavior.respondWith(
+        400,
+        "Invalid request: target path is not permitted by allowedEndpoints",
+      );
+    }
+  }
+
+  isAuthenticated ??=
     (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
   if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
     return behavior.respondWith(401, "Unauthorized");
@@ -157,30 +307,69 @@ export async function handleRequest<ResponseType>(
     return behavior.respondWith(401, "Unauthorized");
   }
 
-  // pass over headers prefixed with x-fal-*
+  // Forward an ALLOWLIST, never a pass-through: applications authenticate their own proxy route
+  // with custom headers (session tokens, API keys, CSRF tokens) that no denylist can enumerate,
+  // and forwarding them would leak user credentials to the upstream on every call. `x-fal-*`
+  // always travels; `accept` and `content-type` shape the request; anything else — say a realtime
+  // extension's provider-specific header — is forwarded only when the operator names it in
+  // `forwardRequestHeaders`. The proxy-owned values are applied after the spread, so a caller
+  // cannot override them.
+  const forwarded = new Set(
+    (resolvedConfig.forwardRequestHeaders ?? []).map((name) =>
+      name.toLowerCase(),
+    ),
+  );
   const headers: Record<string, HeaderValue> = {};
   Object.keys(behavior.getHeaders()).forEach((key) => {
-    if (key.toLowerCase().startsWith("x-fal-")) {
-      headers[key.toLowerCase()] = behavior.getHeader(key);
+    const name = key.toLowerCase();
+    if (NEVER_FORWARDED_REQUEST_HEADERS.has(name)) {
+      return;
+    }
+    if (name.startsWith("x-fal-") || forwarded.has(name)) {
+      headers[name] = behavior.getHeader(key);
     }
   });
 
   const proxyUserAgent = `@fal-ai/server-proxy/${behavior.id}`;
   const userAgent = singleHeaderValue(behavior.getHeader("user-agent"));
+  const accept =
+    singleHeaderValue(behavior.getHeader("accept")) ?? "application/json";
+  const body =
+    behavior.method?.toUpperCase() === "GET"
+      ? undefined
+      : await readRequestBody();
+  // The incoming content-type is forwarded when present. When absent, string bodies keep the
+  // historical application/json default (bare `fetch(proxy, { body: JSON.stringify(x) })` callers
+  // relied on the old rewrite, and browsers would otherwise label them text/plain) — while raw
+  // binary bodies stay label-free, matching direct-fetch semantics.
+  const incomingContentType = singleHeaderValue(
+    behavior.getHeader("content-type"),
+  );
+  const contentType =
+    incomingContentType ??
+    (typeof body === "string" ? "application/json" : undefined);
+  // An explicitly forwarded content-encoding only describes bytes read from the RAW STREAM.
+  // Parser output no longer matches it: parsers inflate compressed requests before parsing, so
+  // both a re-serialized string and a parser-produced buffer (express.raw's default inflation)
+  // are already identity-encoded, and forwarding the original label would make the upstream try
+  // to decompress plain bytes.
+  if (
+    (typeof body === "string" || isParserProducedByteBody(body)) &&
+    "content-encoding" in headers
+  ) {
+    delete headers["content-encoding"];
+  }
   const res = await fetch(targetUrl, {
     method: behavior.method,
     headers: {
       ...headers,
       authorization,
-      accept: "application/json",
-      "content-type": "application/json",
+      accept,
+      ...(contentType !== undefined ? { "content-type": contentType } : {}),
       "user-agent": userAgent,
       "x-fal-client-proxy": proxyUserAgent,
     } as HeadersInit,
-    body:
-      behavior.method?.toUpperCase() === "GET"
-        ? undefined
-        : await behavior.getRequestBody(),
+    body,
   });
 
   // copy headers from fal to the proxied response

--- a/libs/proxy/src/nextjs.ts
+++ b/libs/proxy/src/nextjs.ts
@@ -46,6 +46,12 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
             request.headers["content-type"] ?? ""
           ).toLowerCase();
           const jsonBody = isJsonContentType(contentType);
+          const mediaType = contentType.split(";", 1)[0].trim();
+          // Next's pages parser only JSON-parses these two media types. Other structured-suffix
+          // JSON types remain raw text, even though they are still JSON on the wire.
+          const parsedByNextAsJson =
+            mediaType === "application/json" ||
+            mediaType === "application/ld+json";
           const losslesslyParsed =
             jsonBody ||
             contentType.startsWith("application/x-www-form-urlencoded") ||
@@ -69,9 +75,13 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
           // JSON text — it must re-encode ("hello" → "\"hello\"") or the upstream receives
           // invalid JSON under a JSON content type. (Express is different: its string bodies are
           // raw text and pass through.)
-          if (jsonBody && typeof request.body === "string") {
+          if (parsedByNextAsJson && typeof request.body === "string") {
             assertUtf8ParsedBody(contentType);
             return JSON.stringify(request.body);
+          }
+          if (jsonBody && typeof request.body === "string") {
+            assertUtf8ParsedBody(contentType);
+            return request.body;
           }
           const parsed = serializeParsedBody(
             request.body,

--- a/libs/proxy/src/nextjs.ts
+++ b/libs/proxy/src/nextjs.ts
@@ -7,6 +7,12 @@ import {
   handleRequest,
   responsePassthrough,
 } from "./index";
+import {
+  isJsonContentType,
+  readUnconsumedRequestBody,
+  readWebRequestBody,
+  serializeParsedBody,
+} from "./utils";
 
 /**
  * The default Next API route for the fal.ai client proxy.
@@ -29,7 +35,51 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
       {
         id: "nextjs-page-router",
         method: request.method || "POST",
-        getRequestBody: async () => JSON.stringify(request.body),
+        getRequestBody: async () => {
+          // Next's DEFAULT bodyParser drains every request and stringifies unknown content types
+          // through UTF-8 — so a multipart or binary body reaching this adapter as a string is
+          // already corrupted (invalid sequences replaced), and the original bytes are gone.
+          // Forwarding it under an intact multipart boundary would hand the upstream garbage that
+          // parses as a valid request; failing loudly is the only honest option.
+          const contentType = (
+            request.headers["content-type"] ?? ""
+          ).toLowerCase();
+          const jsonBody = isJsonContentType(contentType);
+          const losslesslyParsed =
+            jsonBody ||
+            contentType.startsWith("application/x-www-form-urlencoded") ||
+            contentType.startsWith("text/");
+          // No content type is NOT an exemption: Next text-decodes those bodies too, and binary
+          // bytes posted without a label would be forwarded corrupted (and then labeled JSON by
+          // the string default). Only a genuinely empty body is safe to pass.
+          if (
+            typeof request.body === "string" &&
+            request.body !== "" &&
+            !losslesslyParsed
+          ) {
+            throw new Error(
+              `The fal proxy cannot forward a ${contentType || "untyped"} body that Next's default bodyParser ` +
+                "already decoded as text — the bytes are irreversibly corrupted. Disable body " +
+                "parsing for this route (export const config = { api: { bodyParser: false } }) " +
+                "so the proxy can forward the raw request stream.",
+            );
+          }
+          // Next PARSES json bodies, so a string here is a top-level JSON string VALUE, not raw
+          // JSON text — it must re-encode ("hello" → "\"hello\"") or the upstream receives
+          // invalid JSON under a JSON content type. (Express is different: its string bodies are
+          // raw text and pass through.)
+          if (jsonBody && typeof request.body === "string") {
+            return JSON.stringify(request.body);
+          }
+          const parsed = serializeParsedBody(
+            request.body,
+            request.headers["content-type"],
+          );
+          // With bodyParser disabled the body is unset and the stream unread — forward raw bytes.
+          return parsed !== undefined
+            ? parsed
+            : readUnconsumedRequestBody(request);
+        },
         getHeaders: () => request.headers,
         getHeader: (name) => request.headers[name],
         sendHeader: (name, value) => response.setHeader(name, value),
@@ -38,7 +88,12 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
           if (res.headers.get("content-type")?.includes("application/json")) {
             return response.status(res.status).json(await res.json());
           }
-          return response.status(res.status).send(await res.text());
+          // Bytes, not text(): a forwarded accept header can make the upstream answer with a
+          // binary payload (an image, an octet-stream), and decoding it through UTF-8 corrupts
+          // it before it reaches the caller.
+          return response
+            .status(res.status)
+            .send(Buffer.from(await res.arrayBuffer()));
         },
       },
       resolvedConfig,
@@ -91,7 +146,7 @@ export const createRouteHandler = (config: Partial<ProxyConfig> = {}) => {
       {
         id: "nextjs-app-router",
         method: request.method,
-        getRequestBody: async () => request.text(),
+        getRequestBody: async () => readWebRequestBody(request),
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => responseHeaders.set(name, value),

--- a/libs/proxy/src/nextjs.ts
+++ b/libs/proxy/src/nextjs.ts
@@ -8,6 +8,7 @@ import {
   responsePassthrough,
 } from "./index";
 import {
+  assertUtf8ParsedBody,
   isJsonContentType,
   readUnconsumedRequestBody,
   readWebRequestBody,
@@ -69,6 +70,7 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
           // invalid JSON under a JSON content type. (Express is different: its string bodies are
           // raw text and pass through.)
           if (jsonBody && typeof request.body === "string") {
+            assertUtf8ParsedBody(contentType);
             return JSON.stringify(request.body);
           }
           const parsed = serializeParsedBody(

--- a/libs/proxy/src/nextjs.ts
+++ b/libs/proxy/src/nextjs.ts
@@ -75,6 +75,13 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
             request.body,
             request.headers["content-type"],
           );
+          if (parsed === undefined && request.readableDidRead) {
+            throw new Error(
+              "The request body was partially consumed before the fal proxy ran. Exclude " +
+                "body-consuming middleware from the proxy route so the complete raw stream " +
+                "reaches the proxy.",
+            );
+          }
           // With bodyParser disabled the body is unset and the stream unread — forward raw bytes.
           return parsed !== undefined
             ? parsed
@@ -149,7 +156,8 @@ export const createRouteHandler = (config: Partial<ProxyConfig> = {}) => {
       {
         id: "nextjs-app-router",
         method: request.method,
-        getRequestBody: async () => readWebRequestBody(request),
+        getRequestBody: async () =>
+          readWebRequestBody(request, resolvedConfig.maxRequestBodyBytes),
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => responseHeaders.set(name, value),

--- a/libs/proxy/src/nextjs.ts
+++ b/libs/proxy/src/nextjs.ts
@@ -78,7 +78,10 @@ export const createPageRouterHandler = (config: Partial<ProxyConfig> = {}) => {
           // With bodyParser disabled the body is unset and the stream unread — forward raw bytes.
           return parsed !== undefined
             ? parsed
-            : readUnconsumedRequestBody(request);
+            : readUnconsumedRequestBody(
+                request,
+                resolvedConfig.maxRequestBodyBytes,
+              );
         },
         getHeaders: () => request.headers,
         getHeader: (name) => request.headers[name],

--- a/libs/proxy/src/remix.ts
+++ b/libs/proxy/src/remix.ts
@@ -53,7 +53,8 @@ export function createProxy({
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => responseHeaders.set(name, value),
-        getRequestBody: async () => readWebRequestBody(request),
+        getRequestBody: async () =>
+          readWebRequestBody(request, resolvedConfig.maxRequestBodyBytes),
         sendResponse: responsePassthrough,
         resolveApiKey,
       },

--- a/libs/proxy/src/remix.ts
+++ b/libs/proxy/src/remix.ts
@@ -12,6 +12,7 @@ import {
   resolveApiKeyFromEnv,
   responsePassthrough,
 } from "./index";
+import { readWebRequestBody } from "./utils";
 
 export type FalRemixProxy = {
   action: ActionFunction;
@@ -52,7 +53,7 @@ export function createProxy({
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => responseHeaders.set(name, value),
-        getRequestBody: async () => JSON.stringify(await request.json()),
+        getRequestBody: async () => readWebRequestBody(request),
         sendResponse: responsePassthrough,
         resolveApiKey,
       },

--- a/libs/proxy/src/svelte.ts
+++ b/libs/proxy/src/svelte.ts
@@ -37,7 +37,8 @@ export const createRequestHandler = ({
       {
         id: "svelte-app-router",
         method: request.method,
-        getRequestBody: async () => readWebRequestBody(request),
+        getRequestBody: async () =>
+          readWebRequestBody(request, resolvedConfig.maxRequestBodyBytes),
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),

--- a/libs/proxy/src/svelte.ts
+++ b/libs/proxy/src/svelte.ts
@@ -1,6 +1,7 @@
 import { type RequestHandler } from "@sveltejs/kit";
 import { ProxyConfig, resolveProxyConfig } from "./config";
 import { fromHeaders, handleRequest, resolveApiKeyFromEnv } from "./index";
+import { readWebRequestBody } from "./utils";
 
 type RequestHandlerParams = Partial<ProxyConfig> & {
   /**
@@ -36,7 +37,7 @@ export const createRequestHandler = ({
       {
         id: "svelte-app-router",
         method: request.method,
-        getRequestBody: async () => request.text(),
+        getRequestBody: async () => readWebRequestBody(request),
         getHeaders: () => fromHeaders(request.headers),
         getHeader: (name) => request.headers.get(name),
         sendHeader: (name, value) => (responseHeaders[name] = value),

--- a/libs/proxy/src/types.ts
+++ b/libs/proxy/src/types.ts
@@ -1,6 +1,16 @@
 export type HeaderValue = string | string[] | undefined | null;
 
 /**
+ * The raw request payload a framework adapter hands to the proxy.
+ *
+ * Bytes, not only text: a multipart body (a `FormData` upload) is binary, and decoding it to a
+ * string corrupts file parts before they reach fal. Adapters should return the request's bytes
+ * (`ArrayBuffer` or `Uint8Array`, which includes Node's `Buffer`) whenever the framework exposes
+ * them; a string remains valid for adapters that only ever see parsed JSON.
+ */
+export type ProxyRequestBody = string | ArrayBuffer | Uint8Array | undefined;
+
+/**
  * The proxy behavior that is passed to the proxy handler. This is a subset of
  * request objects that are used by different frameworks, like Express and NextJS.
  */
@@ -13,7 +23,7 @@ export interface ProxyBehavior<ResponseType> {
   getHeaders(): Record<string, HeaderValue>;
   getHeader(name: string): HeaderValue;
   sendHeader(name: string, value: string): void;
-  getRequestBody(): Promise<string | undefined>;
+  getRequestBody(): Promise<ProxyRequestBody>;
   /** @deprecated Use `resolveFalAuth` in `ProxyConfig` instead. */
   resolveApiKey?: () => Promise<string | undefined>;
 }

--- a/libs/proxy/src/utils.ts
+++ b/libs/proxy/src/utils.ts
@@ -186,18 +186,32 @@ export function serializeParsedBody(
  *
  * @private
  */
+/** The raw-stream path buffers whole bodies; parser-backed paths have the parser's own limits. */
+export const DEFAULT_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
+
+const streamChunkEncoder = new TextEncoder();
+
 export async function readUnconsumedRequestBody(
   stream: AsyncIterable<unknown>,
+  maxBytes: number = DEFAULT_MAX_REQUEST_BODY_BYTES,
 ): Promise<ProxyRequestBody> {
   const chunks: Uint8Array[] = [];
   let total = 0;
   for await (const chunk of stream) {
     const bytes =
       typeof chunk === "string"
-        ? new TextEncoder().encode(chunk)
+        ? streamChunkEncoder.encode(chunk)
         : (chunk as Uint8Array);
     chunks.push(bytes);
     total += bytes.byteLength;
+    if (total > maxBytes) {
+      // Bounded, or the one unparsed path (multipart/binary — the LARGEST bodies) would be the
+      // only one an oversized or hostile request could use to exhaust the server's memory.
+      throw new Error(
+        `The request body exceeded ${maxBytes} bytes; the proxy buffers raw bodies whole. ` +
+          "Raise maxRequestBodyBytes in the proxy config if this size is intended.",
+      );
+    }
   }
   if (total === 0) {
     return undefined;

--- a/libs/proxy/src/utils.ts
+++ b/libs/proxy/src/utils.ts
@@ -113,6 +113,27 @@ export function isJsonContentType(contentType: HeaderValue): boolean {
   );
 }
 
+/**
+ * Parsed strings and objects are serialized as UTF-8 by fetch. Keeping a different declared
+ * charset would make the upstream decode different bytes than the caller sent.
+ *
+ * @private
+ */
+export function assertUtf8ParsedBody(contentType: HeaderValue): void {
+  const declared = singleHeaderValue(contentType) ?? "";
+  const match = /(?:^|;)\s*charset\s*=\s*(?:"([^"]*)"|([^;\s]*))/i.exec(
+    declared,
+  );
+  const charset = (match?.[1] ?? match?.[2])?.toLowerCase();
+  if (charset && charset !== "utf-8" && charset !== "utf8") {
+    throw new Error(
+      `The fal proxy cannot faithfully re-encode a parsed ${charset} request body because ` +
+        "fetch serializes strings as UTF-8. Disable body parsing for this route so the raw " +
+        "request bytes reach the proxy.",
+    );
+  }
+}
+
 // Provenance brand for byte bodies. Body-parser middleware inflates compressed requests before
 // handing bytes to the route (express.raw's default `inflate: true`), so a parser-produced
 // Uint8Array/Buffer no longer matches the request's declared content-encoding — while bytes read
@@ -152,6 +173,13 @@ export function serializeParsedBody(
   }
   const declared = singleHeaderValue(contentType)?.toLowerCase() ?? "";
   const jsonDeclared = isJsonContentType(declared);
+  if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
+    // Parser output, not stream bytes: express.raw() inflated any compressed request before
+    // producing this buffer, so brand it for the content-encoding strip in handleRequest.
+    parserProducedByteBodies.add(body);
+    return body;
+  }
+  assertUtf8ParsedBody(declared);
   if (body === null) {
     // Only `undefined` means "the parser had nothing". A parsed JSON body can legitimately BE
     // null, and treating it as absent would fall back to an already-consumed stream and forward
@@ -176,12 +204,6 @@ export function serializeParsedBody(
           "parser, or strict JSON objects) so the payload reaches the proxy unambiguously.",
       );
     }
-    return body;
-  }
-  if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
-    // Parser output, not stream bytes: express.raw() inflated any compressed request before
-    // producing this buffer, so brand it for the content-encoding strip in handleRequest.
-    parserProducedByteBodies.add(body);
     return body;
   }
   if (declared.startsWith("multipart/")) {

--- a/libs/proxy/src/utils.ts
+++ b/libs/proxy/src/utils.ts
@@ -1,4 +1,4 @@
-import { HeaderValue } from "./types";
+import { HeaderValue, ProxyRequestBody } from "./types";
 
 /**
  * Utility to get a header value as `string` from a Headers object.
@@ -15,4 +15,198 @@ export function singleHeaderValue(value: HeaderValue): string | undefined {
     return value[0];
   }
   return value;
+}
+
+/**
+ * Read a Fetch-API request's payload as raw bytes.
+ *
+ * Bytes rather than `text()`: a multipart body (a `FormData` upload) is binary, and decoding it
+ * through UTF-8 corrupts its file parts before they reach fal.
+ *
+ * @private
+ */
+export async function readWebRequestBody(request: {
+  arrayBuffer(): Promise<ArrayBuffer>;
+}): Promise<ProxyRequestBody> {
+  const body = await request.arrayBuffer();
+  return body.byteLength > 0 ? body : undefined;
+}
+
+/**
+ * JSON by media type: `application/json` itself plus structured-suffix types
+ * (`application/ld+json`, `application/hal+json`, …), which carry JSON payloads under RFC 6839.
+ *
+ * @private
+ */
+export function isJsonContentType(contentType: HeaderValue): boolean {
+  const declared = singleHeaderValue(contentType)?.toLowerCase() ?? "";
+  // Exact media type only, parameters aside: a prefix match would also capture non-document
+  // types like application/json-seq (RFC 7464 record-separated sequences), whose payloads must
+  // not be treated as a single JSON value.
+  const mediaType = declared.split(";", 1)[0].trim();
+  return (
+    mediaType === "application/json" ||
+    /^application\/[^\s/;]+\+json$/.test(mediaType)
+  );
+}
+
+// Provenance brand for byte bodies. Body-parser middleware inflates compressed requests before
+// handing bytes to the route (express.raw's default `inflate: true`), so a parser-produced
+// Uint8Array/Buffer no longer matches the request's declared content-encoding — while bytes read
+// from the unconsumed stream still do. A WeakSet brand lets handleRequest strip the header for
+// the former without widening the public ProxyRequestBody type.
+const parserProducedByteBodies = new WeakSet<object>();
+
+/**
+ * Whether a byte body came out of a body parser (already inflated) rather than the raw request
+ * stream. String bodies are always parser output and never need this check.
+ *
+ * @private
+ */
+export function isParserProducedByteBody(body: ProxyRequestBody): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    parserProducedByteBodies.has(body)
+  );
+}
+
+/**
+ * Turn a framework-parsed request body (Express, Next.js pages router) back into a forwardable
+ * payload. Raw bytes and strings pass through unchanged — re-encoding is only for bodies the
+ * framework already parsed into an object, and it must match the request's declared content type:
+ * the proxy forwards that header verbatim, so serializing a parsed form body as JSON would send
+ * JSON bytes labeled `application/x-www-form-urlencoded` to the upstream.
+ *
+ * @private
+ */
+export function serializeParsedBody(
+  body: unknown,
+  contentType?: HeaderValue,
+): ProxyRequestBody {
+  if (body === undefined) {
+    return undefined;
+  }
+  const declared = singleHeaderValue(contentType)?.toLowerCase() ?? "";
+  const jsonDeclared = isJsonContentType(declared);
+  if (body === null) {
+    // Only `undefined` means "the parser had nothing". A parsed JSON body can legitimately BE
+    // null, and treating it as absent would fall back to an already-consumed stream and forward
+    // no body at all. Outside JSON, null still reads as absent.
+    return jsonDeclared ? "null" : undefined;
+  }
+  if (typeof body === "string") {
+    if (jsonDeclared) {
+      // A string under a JSON content type has NO decidable provenance here: raw text
+      // (express.text on a JSON route) and a parser-produced top-level string value
+      // (express.json({ strict: false })) are indistinguishable whether the string parses —
+      // `{"a":1}` could be an object's raw text or the string value "{\"a\":1}" — or does not —
+      // `not json` could be a malformed raw request (which must stay an upstream error) or a
+      // legitimate parsed string value. Forwarding either guess silently rewrites the request,
+      // so every case fails loudly. Adapters that KNOW their parser (Next's pages router
+      // re-encodes parsed values itself) never reach this branch; Express routes should feed
+      // the proxy raw bytes (no parser or express.raw) or strict-parsed objects.
+      throw new Error(
+        "The fal proxy cannot tell whether this JSON-typed string body is raw request text or " +
+          "a parser-produced value — text/lenient JSON parsers make them indistinguishable. " +
+          "Exclude the proxy route from text and lenient JSON parsing (use express.raw, no " +
+          "parser, or strict JSON objects) so the payload reaches the proxy unambiguously.",
+      );
+    }
+    return body;
+  }
+  if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
+    // Parser output, not stream bytes: express.raw() inflated any compressed request before
+    // producing this buffer, so brand it for the content-encoding strip in handleRequest.
+    parserProducedByteBodies.add(body);
+    return body;
+  }
+  if (declared.startsWith("multipart/")) {
+    // A parsed OBJECT under a multipart content type means a multipart parser (multer,
+    // formidable, …) consumed the stream: the original bytes and boundary framing are gone, and
+    // JSON-encoding the text fields while forwarding the multipart header would hand the upstream
+    // an unparseable request — with any file parts silently dropped. Nothing faithful can be
+    // reconstructed, so fail loudly.
+    throw new Error(
+      "The fal proxy cannot forward a multipart body that a parser (multer, formidable, …) has " +
+        "already consumed — the original bytes are gone. Exclude the proxy route from the " +
+        "multipart parser so the raw request stream reaches the proxy.",
+    );
+  }
+  if (declared.startsWith("application/x-www-form-urlencoded")) {
+    // Entry by entry rather than the URLSearchParams record constructor: parsers represent a
+    // repeated field (`tag=a&tag=b`) as an array and a bracketed field (`user[name]=alice`, from
+    // extended urlencoded parsing) as a nested object. The record form would stringify those to
+    // one comma-joined value or "[object Object]", changing the request's semantics upstream.
+    const params = new URLSearchParams();
+    const append = (key: string, value: unknown) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (Array.isArray(value)) {
+        value.forEach((entry, index) => {
+          // Structured entries keep their index (`users[0][name]=alice`), or two objects would
+          // collapse into one on reparse; scalar arrays stay repeated keys (`tag=a&tag=b`),
+          // matching how the parser produced them.
+          if (entry !== null && typeof entry === "object") {
+            append(`${key}[${index}]`, entry);
+          } else {
+            append(key, entry);
+          }
+        });
+        return;
+      }
+      if (typeof value === "object") {
+        for (const [nestedKey, nestedValue] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          append(`${key}[${nestedKey}]`, nestedValue);
+        }
+        return;
+      }
+      params.append(key, String(value));
+    };
+    for (const [key, value] of Object.entries(
+      body as Record<string, unknown>,
+    )) {
+      append(key, value);
+    }
+    return params.toString();
+  }
+  return JSON.stringify(body);
+}
+
+/**
+ * Read the raw bytes of a request stream the framework's body parser did not consume.
+ *
+ * `express.json()` and Next's pages-router parser only handle the content types they are
+ * configured for; a multipart or binary request leaves `request.body` unset and the stream
+ * unread. Forwarding "no body" while preserving the multipart content type and boundary would
+ * hand the upstream an unparseable request, so the adapter falls back to the raw stream.
+ *
+ * @private
+ */
+export async function readUnconsumedRequestBody(
+  stream: AsyncIterable<unknown>,
+): Promise<ProxyRequestBody> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const bytes =
+      typeof chunk === "string"
+        ? new TextEncoder().encode(chunk)
+        : (chunk as Uint8Array);
+    chunks.push(bytes);
+    total += bytes.byteLength;
+  }
+  if (total === 0) {
+    return undefined;
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
 }

--- a/libs/proxy/src/utils.ts
+++ b/libs/proxy/src/utils.ts
@@ -1,5 +1,21 @@
 import { HeaderValue, ProxyRequestBody } from "./types";
 
+/** The raw-body paths buffer whole requests, so all adapters share one conservative ceiling. */
+export const DEFAULT_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
+
+export class RequestBodyTooLargeError extends Error {
+  readonly status = 413;
+  readonly statusCode = 413;
+
+  constructor(maxBytes: number) {
+    super(
+      `The request body exceeded ${maxBytes} bytes; the proxy buffers raw bodies whole. ` +
+        "Raise maxRequestBodyBytes in the proxy config if this size is intended.",
+    );
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
 /**
  * Utility to get a header value as `string` from a Headers object.
  *
@@ -25,10 +41,57 @@ export function singleHeaderValue(value: HeaderValue): string | undefined {
  *
  * @private
  */
-export async function readWebRequestBody(request: {
-  arrayBuffer(): Promise<ArrayBuffer>;
-}): Promise<ProxyRequestBody> {
+export async function readWebRequestBody(
+  request: {
+    arrayBuffer(): Promise<ArrayBuffer>;
+    body?: ReadableStream<Uint8Array> | null;
+    headers?: { get(name: string): string | null };
+  },
+  maxBytes: number = DEFAULT_MAX_REQUEST_BODY_BYTES,
+): Promise<ProxyRequestBody> {
+  const declaredLength = Number(request.headers?.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new RequestBodyTooLargeError(maxBytes);
+  }
+
+  // Read the stream incrementally when it is available. `arrayBuffer()` allocates the complete
+  // request before its size can be checked, defeating the memory bound this option promises.
+  if (request.body && !request.body.locked) {
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > maxBytes) {
+          // Cancellation is best-effort. A source's broken cancel hook must not replace the
+          // useful 413 with an unrelated transport error.
+          await reader.cancel().catch(() => undefined);
+          throw new RequestBodyTooLargeError(maxBytes);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    if (total === 0) return undefined;
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return body;
+  }
+
+  // Framework caches (notably Hono's) expose only arrayBuffer(). They may already have allocated
+  // the body, but the post-read check still prevents an oversized payload from being forwarded.
   const body = await request.arrayBuffer();
+  if (body.byteLength > maxBytes) {
+    throw new RequestBodyTooLargeError(maxBytes);
+  }
   return body.byteLength > 0 ? body : undefined;
 }
 
@@ -173,7 +236,15 @@ export function serializeParsedBody(
     }
     return params.toString();
   }
-  return JSON.stringify(body);
+  if (declared === "" || jsonDeclared) {
+    return JSON.stringify(body);
+  }
+  const mediaType = declared.split(";", 1)[0].trim();
+  throw new Error(
+    `The fal proxy cannot reconstruct a parsed ${mediaType} request body without changing its ` +
+      "wire format. Exclude the proxy route from that body parser so the raw request stream " +
+      "reaches the proxy.",
+  );
 }
 
 /**
@@ -186,9 +257,6 @@ export function serializeParsedBody(
  *
  * @private
  */
-/** The raw-stream path buffers whole bodies; parser-backed paths have the parser's own limits. */
-export const DEFAULT_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
-
 const streamChunkEncoder = new TextEncoder();
 
 export async function readUnconsumedRequestBody(
@@ -207,10 +275,7 @@ export async function readUnconsumedRequestBody(
     if (total > maxBytes) {
       // Bounded, or the one unparsed path (multipart/binary — the LARGEST bodies) would be the
       // only one an oversized or hostile request could use to exhaust the server's memory.
-      throw new Error(
-        `The request body exceeded ${maxBytes} bytes; the proxy buffers raw bodies whole. ` +
-          "Raise maxRequestBodyBytes in the proxy config if this size is intended.",
-      );
+      throw new RequestBodyTooLargeError(maxBytes);
     }
   }
   if (total === 0) {


### PR DESCRIPTION
## What this PR actually is

This is **not only a WMA PR**. It contains three kinds of work:

| Scope | What it contains | Does WMA need it? |
|---|---|---|
| WMA support | Recognize `wma.fal.run` as fal infrastructure, allow only its known routes, and apply `allowedEndpoints` to the `app_id` inside WMA JSON | **Yes — direct requirement** |
| Shared plumbing | Let policy/authentication inspect a request body without consuming the only copy before it is forwarded | **Yes — supporting requirement** |
| General proxy hardening | Correct body bytes, headers, size limits, framework parser behavior, response status/bytes, and error propagation | **No — independent bugs found in the same proxy code** |

The honest answer to “why is `maxRequestBodyBytes` or `forwardRequestHeaders` in a WMA change?” is: **those are not WMA features.** The WMA work led to a full audit of the shared proxy path, and that audit exposed existing correctness and security problems across every adapter. They are fixed here, but the description does not pretend WMA depends on them.

If this must be a minimal WMA-only diff, the rows marked **No** below can be split into separate hardening PRs. As written, this PR delivers WMA support and the audited proxy behavior together.

## The proxy in human terms

A browser cannot safely hold a fal API key, so the application mounts `@fal-ai/server-proxy` on its own server:

```mermaid
sequenceDiagram
    participant B as Browser (no fal key)
    participant P as Application server proxy
    participant F as fal
    B->>P: Request + “please send this to this fal URL”
    P->>P: Authenticate caller and check destination/app
    P->>F: Same request + server-side fal credential
    F-->>P: Response
    P-->>B: Same response
```

Three terms used below:

- **Headers** are labels on the package: what the body is, what response is accepted, routing hints, and sometimes credentials.
- **The body** is the package itself: JSON, text, an image, or a multipart form containing files.
- **A body parser** is framework middleware that opens the package and turns it into a JavaScript value. Once it does that, the exact original bytes may be impossible to recover.

The governing rule is: **forward the original package when it still exists; repack it only when that is lossless; otherwise reject instead of silently sending a different request.**

## 1. WMA-specific changes

These are the changes that actually enable WMA.

| Change | Human explanation | WMA relationship |
|---|---|---|
| Add `serviceHosts` | Normal fal URLs look like `fal.run/owner/app`. WMA uses `wma.fal.run/session`, where `session` is infrastructure—not an app name. `serviceHosts` gives the proxy a separate, explicit bucket for that kind of fal-owned host. It defaults to `wma.fal.run`; `[]` disables it. | **Direct** |
| Service hosts bypass `allowedUrlPatterns` | A proxy restricted to a few app URLs would otherwise reject WMA because its hostname/path has a different shape. Only an exact configured service host gets this treatment; there is no broad `*.fal.run` exemption. | **Direct** |
| Require HTTPS | A configured service host is special only over HTTPS. `http://wma.fal.run` does not receive the bypass. | **Direct safety rule** |
| Allow only known POST routes | Service hosts can receive credentials, so the proxy does not forward arbitrary paths or methods. It knows `/session`, `/ice`, and `/session/heartbeat`; everything else is rejected. | **Direct safety rule** |
| Normalize the service path | Percent escapes are decoded, duplicate slashes are collapsed, and trailing slashes are removed before route matching. Alternate spellings cannot sneak around the known-route check. Invalid escapes fail closed. | **Direct safety rule** |
| Read `app_id` from WMA JSON | `/session` and `/ice` identify the fal app in the body instead of the URL. The proxy reads that value so existing `allowedEndpoints` restrictions still mean “this proxy may call only these apps.” | **Direct** |
| Keep heartbeat session-scoped | `/session/heartbeat` operates on an existing session and has no `app_id`, so it is allowed without inventing an app identity. Authentication still applies. | **Direct** |
| Reject duplicate `app_id` keys | Different JSON parsers can choose different winners for duplicate keys. The proxy rejects duplicates—including escaped spellings such as `app_\u0069d`—so it cannot approve one app while WMA reads another. | **Direct safety rule** |

## 2. Shared body plumbing WMA relies on

WMA policy must inspect `app_id`, but request streams are one-shot—like a straw that can be emptied only once.

| Change | Human explanation | WMA relationship |
|---|---|---|
| Cache one body-read promise | Authentication, the WMA app check, and the final upstream request all receive the same cached result. None can accidentally consume the body before the others. | **Supporting** |
| Give auth callbacks the cached reader | Custom `isAuthenticated` or `resolveFalAuth` callbacks may verify a signature over the body. They now see the same reusable read instead of the original one-shot method. | **Supporting** |
| Preserve class-based adapter methods | The wrapper binds other adapter methods back to their original object, so custom `ProxyBehavior` classes using private fields continue to work. | **Supporting compatibility** |
| Map body-limit failures during auth/policy to 413 | If auth or WMA inspection is the first code to discover an oversized body, the caller gets “payload too large,” not a generic server error. | **Supporting error handling** |

## 3. Public proxy API and configuration changes

These are general proxy changes, not WMA requirements.

| Change | Human explanation | WMA relationship |
|---|---|---|
| `ProxyRequestBody` accepts bytes | Adapters may now hand the core a string, `ArrayBuffer`, `Uint8Array`/Node `Buffer`, or no body. Previously the contract assumed text, which cannot represent arbitrary files safely. | **No** |
| `maxRequestBodyBytes` | Raw bodies are buffered in memory before forwarding. The new option caps that buffer at 32 MiB by default so a huge upload cannot exhaust the server. It must be a non-negative safe integer. Set a larger value if the application intentionally proxies larger files. | **No; guardrail for raw-body support** |
| `forwardRequestHeaders` | By default the proxy forwards fal headers plus the request's `accept` and `content-type`. If an integration genuinely needs another header, the server owner can opt it in by lowercase name. This is an escape hatch, not something WMA currently needs. | **No** |
| `serviceHosts` | Public configuration for the WMA behavior described above. It can also enumerate a future fal-operated service host deliberately. | **Yes** |

### What `forwardRequestHeaders` does—and does not do

Suppose the browser sends `x-provider-ticket: abc` and fal needs it. The proxy will drop it by default. The server owner can configure:

```ts
forwardRequestHeaders: ["x-provider-ticket"]
```

That does **not** turn the proxy into a pass-through. Sensitive or transport-level headers are still never forwarded, even if listed: `authorization`, `cookie`, `host`, `content-length`, `connection`, `transfer-encoding`, `keep-alive`, `upgrade`, `te`, `trailer`, `expect`, `accept-encoding`, and `proxy-authorization`.

The reason is simple: those values belong to the browser-to-application-server connection. Sending them onward could leak the application's session cookie or confuse the upstream HTTP client.

### What `maxRequestBodyBytes` does

The proxy cannot stream a request straight through because authentication and policy may need to inspect it first. It therefore keeps a copy in memory. `maxRequestBodyBytes` puts a ceiling on that copy:

- A declared `content-length` above the limit is rejected before reading.
- Fetch/WHATWG streams are counted chunk by chunk and cancelled after crossing the limit.
- Node/Express streams are counted chunk by chunk.
- A framework cache that has already allocated the body is checked before forwarding.
- Every path returns HTTP 413 for this condition.

This is unrelated to WMA payload size. It exists because supporting raw multipart/binary bodies safely requires a memory bound.

## 4. Core request-policy changes

| Change | Human explanation | WMA relationship |
|---|---|---|
| Parse the target URL once | A malformed `x-fal-target-url` now reaches one controlled 400 response instead of whichever helper happens to throw first. It also avoids parsing the same URL repeatedly. | **No** |
| Name the failed check | Missing target header, invalid URL, URL allowlist rejection, endpoint rejection, unknown service route, and wrong service method produce distinct messages. The messages name the relevant option but never reveal its configured contents. | **No** |
| Authenticate first and once | An unauthenticated caller gets 401 before learning which endpoints are configured, and custom authentication cannot run twice with different results. | **No; security hardening** |
| Keep `allowedEndpoints` on normal app URLs | POSTs to app-serving `fal.run`/`queue.fal.run` URLs still extract the app path and enforce the existing endpoint patterns. The service-host exception does not weaken the ordinary route. | **Protects the WMA exception** |
| Cache compiled allowlist matchers | Glob patterns are compiled once instead of on every request. The cache includes the array's current contents, so mutating an existing pattern array cannot leave an obsolete policy active. | **No** |

## 5. Request-header behavior

| Change | Human explanation | WMA relationship |
|---|---|---|
| Stop forcing every request to JSON | The proxy used to overwrite `accept` and `content-type` with `application/json`. It now preserves what the caller actually sent. A file upload remains a file upload instead of “JSON” containing file bytes. | **No** |
| Always forward `x-fal-*` request headers | Fal-specific routing and request options continue through the proxy. | **No** |
| Fix Hono's incoming-header source | Hono was enumerating the empty response-header accumulator instead of the incoming request, so every `x-fal-*` header except the separately-read target URL vanished. It now reads the real request headers. | **No; pre-existing Hono bug** |
| Default only unlabeled string bodies to JSON | This preserves compatibility for callers that send `JSON.stringify(...)` without a content type. Unlabeled byte bodies stay unlabeled instead of being falsely called JSON. | **No** |
| Preserve `content-encoding` only for original bytes | If a parser already decompressed gzip and the proxy rebuilt the body, the old `content-encoding: gzip` label is now removed. Otherwise fal would try to decompress plain bytes. Raw untouched compressed bytes may keep it when explicitly allowed. | **No** |

## 6. Shared body-reading and reconstruction rules

| Change | Human explanation | WMA relationship |
|---|---|---|
| Read Fetch requests as bytes | Next app router, Remix, SvelteKit, and untouched Hono requests use raw bytes instead of `.text()`/`.json()`. Multipart boundaries and non-text file bytes survive. | **No** |
| Read Node streams as bytes | Untouched Express/Next pages streams are combined byte-for-byte rather than converted to text. | **No** |
| Recognize JSON media types accurately | `application/json` and `application/*+json` are JSON documents; `application/json-seq` is deliberately not treated as one JSON value. | **No** |
| Reject parsed non-UTF-8 text | JavaScript strings are re-encoded as UTF-8 by `fetch`. Keeping a header such as `charset=iso-8859-1` would lie about the new bytes, so the proxy asks the developer to preserve the raw stream instead. | **No** |
| Rebuild URL-encoded forms as URL-encoded forms | Parsed form objects no longer become JSON under a form header. Repeated keys and nested bracket notation are preserved rather than collapsing into comma strings or `[object Object]`. | **No** |
| Reject consumed multipart forms | Once multer, Formidable, or a framework `FormData` parser has removed the original multipart boundary/framing, the proxy cannot reconstruct the same package. It fails with instructions instead of dropping files or forwarding invalid bytes. | **No** |
| Reject unsupported parsed media types | A parsed XML/CBOR/custom object is not silently JSON-stringified while retaining its original media-type label. | **No** |
| Handle parsed JSON `null` correctly | JSON `null` remains the body `null`; it is not mistaken for “no body.” | **No** |
| Reject ambiguous Express JSON strings | After permissive/text middleware, the proxy cannot tell whether a JavaScript string is raw JSON text or a parsed top-level JSON string value. It rejects rather than guess and change meaning. | **No** |
| Track parser-produced byte buffers | `express.raw()` may already have decompressed a request. Those bytes are marked as parser output so the stale compression header can be removed. | **No** |

## 7. Framework-specific behavior

### Express

| Change | Human explanation |
|---|---|
| Let the stream decide whether parsing happened | `body-parser` may set `req.body = {}` even when it skipped the content type. If the stream is untouched, the proxy trusts the raw stream—not the presence of `req.body`. |
| Reject partially consumed streams | If middleware read only part of the request, forwarding the remainder would silently truncate it. The proxy stops and explains how to exclude the route from that middleware. |
| Reject opaque consumption | If something drained a declared body without leaving parser output, the proxy does not send an empty body under the original content type. |
| Serialize only reconstructable parsed bodies | JSON objects and URL-encoded forms are rebuilt according to their declared format; lossy/ambiguous formats fail as described above. |
| Route errors through `next(error)` | Express 4 does not catch rejected async handlers. Errors now reach normal Express error middleware instead of becoming unhandled rejections that leave the browser waiting forever. |

### Hono

| Change | Human explanation |
|---|---|
| Prefer an untouched raw request | `parseBody()` can cache a value even when it ignored the media type and never consumed the stream. If the original stream is still there, the proxy uses it. |
| Respect body-cache provenance | Hono can derive later representations from the first cached one. Only `arrayBuffer()` or `blob()` cached **first** proves original bytes survived; a later byte-shaped cache made from text/JSON/FormData does not. |
| Support faithful cached bytes | Multipart/binary bodies cached first as `ArrayBuffer` or `Blob` are forwarded byte-for-byte and still obey the size limit. |
| Support safe cached JSON/text | JSON and UTF-8 text caches are reconstructed only under compatible content types. Non-UTF-8 or binary-labeled text caches are rejected. |
| Support cached URL-encoded `FormData` | String fields are rebuilt with `URLSearchParams`, including repeated fields. File values are rejected because they cannot be URL-encoded faithfully. |
| Reject lossy cached multipart `FormData` | Hono would generate a new boundary while the proxy retained the old boundary header. The proxy detects that mismatch and fails instead. |
| Reject consumed bodies with no reusable cache | Middleware cannot make a body silently disappear before the proxy. |

### Next.js pages router

| Change | Human explanation |
|---|---|
| Match Next's real parser behavior | Next JSON-parses only `application/json` and `application/ld+json`; other `+json` types remain raw text. The proxy handles those cases differently so it does not double-encode them. |
| Re-encode top-level JSON strings | If Next parsed the JSON value `"hello"` into the JavaScript string `hello`, the proxy restores the quotes before forwarding. |
| Reject already-decoded multipart/binary/untyped bodies | Next's default parser may have irreversibly text-decoded those bytes. The error tells users to disable body parsing on the proxy route. |
| Use the raw stream when body parsing is disabled | Multipart and binary bodies can then be forwarded byte-for-byte and size-limited. |
| Reject partially consumed streams and non-UTF-8 parsed text | The proxy will not forward a truncated or mislabeled reconstruction. |

### Next.js app router, Remix, and SvelteKit

Their Fetch API `Request` bodies now go through the same bounded byte reader. The change is small in each file because the shared helper owns the actual logic.

## 8. Response and error fixes

These are independent pre-existing proxy bugs.

| Change | Human explanation | WMA relationship |
|---|---|---|
| Preserve Express streamed status codes | An upstream fal 401/422/429 with a stream used to leave Express at its default HTTP 200. The proxy now sets the upstream status before streaming. | **No** |
| Preserve binary response bytes | Express and Next pages no longer call `.text()` for every non-JSON response. Images and other binary responses are returned as bytes. | **No** |
| Keep upstream response headers except unsafe lengths/encoding | Response headers still propagate, while `content-length` and `content-encoding` are omitted because framework response handling may change transfer details. | Existing behavior retained |
| Return 413 consistently | Oversized raw/cached bodies produce a useful client error whether discovered during authentication, WMA policy, or final forwarding. | **No; shared guardrail** |

## 9. Behavior changes for consumers

1. `express.json({ strict: false })` plus a top-level JSON string is rejected because its provenance is ambiguous. Keep the proxy route raw or use an unambiguous parser.
2. URL-encoded form posts remain URL-encoded instead of silently becoming JSON.
3. Callers must label request bodies correctly; `accept` and `content-type` are no longer unconditionally overwritten with JSON.
4. Next pages routes that proxy multipart/binary data must disable the default body parser.
5. `wma.fal.run` is reachable through the default service-host policy; authentication and `allowedEndpoints` still protect it.
6. Authentication runs before endpoint-policy errors are returned.
7. Empty Express JSON requests remain empty instead of becoming `{}`.
8. Custom `ProxyBehavior` implementations must accept the wider byte-capable `ProxyRequestBody` return type.
9. Bodies larger than 32 MiB now receive 413 unless `maxRequestBodyBytes` is raised.
10. Extra non-fal request headers are dropped unless explicitly listed in `forwardRequestHeaders`, and sensitive headers cannot be opted in.

## 10. Where all the lines come from

The size is mostly regression coverage: **1,734 of 2,726 added lines (64%) are tests.** Production code accounts for 992 additions across the shared core and framework adapters.

| File | Added | Deleted | What those lines implement |
|---|---:|---:|---|
| `libs/proxy/src/index.spec.ts` | 1,734 | 1 | Cross-adapter regressions for URL/service policy, authentication order, headers, exact body bytes and caches, encodings, limits, response status/bytes, and failure modes |
| `libs/proxy/src/index.ts` | 345 | 40 | Authentication flow, target parsing, service-host routing, WMA `app_id` enforcement, header forwarding, shared body caching, and error/status mapping |
| `libs/proxy/src/utils.ts` | 296 | 1 | Bounded Node/Fetch body readers, parsed-body reconstruction, charset/media-type validation, duplicate JSON-key detection, and 413 errors |
| `libs/proxy/src/hono.ts` | 109 | 2 | Incoming headers, raw/cached body dispatch, first-cache provenance, multipart/FormData handling, and limits |
| `libs/proxy/src/express.ts` | 93 | 37 | Stream-vs-parser provenance, partial-consumption detection, binary responses, streamed status, and Express error integration |
| `libs/proxy/src/nextjs.ts` | 81 | 3 | Pages-parser-aware reconstruction/rejection, binary responses, and bounded app-router bodies |
| `libs/proxy/src/config.ts` | 51 | 1 | `serviceHosts`, `maxRequestBodyBytes`, `forwardRequestHeaders`, defaults, documentation, and validation |
| `libs/proxy/src/types.ts` | 11 | 1 | Byte-capable request-body contract |
| `libs/proxy/src/remix.ts` | 3 | 1 | Bounded byte-preserving Fetch request reads |
| `libs/proxy/src/svelte.ts` | 3 | 1 | Bounded byte-preserving Fetch request reads |
| **Total** | **2,726** | **88** | **992 production additions + 1,734 test additions** |

## Validation

The regression suite covers the shared core plus real adapter behavior, including Hono middleware cache interactions and Express/Next stream/parser states. Repository CI runs formatting, linting, tests, and TypeScript builds for the complete change.
