### PR TITLE
feat(client): add extensible realtime world-model sessions

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -1,2 +1,9 @@
+brainrot
+decart
+extensionless
+msgpack
+outstream
+pydantic
 quickstart
 runtimes
+sdxl

--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -46,6 +46,261 @@ const result = await fal.subscribe("my-function-id", {
 });
 ```
 
+## Protocol-aware realtime sessions
+
+> [!WARNING]
+>
+> **Experimental.** Everything reached through `fal.realtime.open()` — the
+> extension contract, the bundled `wma()`, `lucyRealtime()`, and `websocket()`
+> extensions, and the `/realtime/*` subpath exports — is experimental surface
+> area and may change in a minor release. `fal.realtime.connect()` keeps its
+> signature, with two behavioral fixes: when several `connect()` calls share a
+> `connectionKey`, the newest handle now owns the connection (a stale handle's
+> `send()`/`close()` no longer act on it), and a handle that was explicitly
+> `close()`d no longer reconnects on a later `send()` — both previously
+> delivered stale messages through connections they no longer owned.
+
+`fal.realtime.open()` opens a session with a named protocol extension. Models
+that need WebRTC signaling, provider SDKs, heartbeats, or another negotiation
+protocol expose that behavior as an application-installed extension, and fal's
+own WebSocket protocol is available through the same door as
+[`websocket()`](#fals-own-websocket-protocol-behind-open).
+
+`open()` returns **synchronously**, with negotiation already running eagerly
+behind the handle. You can render from `session.state`, call `send()`
+immediately — sends are queued in order (bounded) and flushed the moment the
+session is live — and hear about everything through callbacks:
+
+```ts
+import { fal } from "@fal-ai/client";
+import { lucyRealtime } from "@fal-ai/client/realtime";
+
+const lucy = fal.realtime.open(lucyRealtime(), {
+  input: {
+    prompt: "Turn me into a marble statue",
+    image_url: firstCameraFrame,
+  },
+  localStream: cameraStream,
+  tokenProvider: getRealtimeToken,
+  onMedia(stream) {
+    outputVideo.srcObject = stream;
+  },
+  onState: (state) => setStatus(state), // "opening" | "live" | "failed" | "closed"
+  onError: (error) => console.error(error), // the terminal failure, delivered once
+});
+
+lucy.send({ prompt: "Now make it cinematic" }); // queued if still opening
+await lucy.close();
+```
+
+Prefer the awaited style? `session.ready` resolves with the same handle once
+the session is live and rejects with the failure, so `const lucy = await
+fal.realtime.open(...).ready` gives the promise-shaped call site — but no
+caller is required to hold a promise: every failure `ready` can carry also
+reaches `onError` and `onState("failed")`, and an ignored `ready` never
+becomes an unhandled rejection. The handle is a small plain object: `state`,
+`send`, `close`, and `ready` work from the first tick, and `close()` during
+`"opening"` cancels the negotiation. Extension-specific members (like Lucy's
+`remoteStream`) live on `handle.session`, which is set once the session is
+live.
+
+Extensions are ordinary installed JavaScript, never code loaded from endpoint
+metadata. fal owns cancellation and idempotent cleanup; the extension owns its
+wire protocol and may return any model-specific session API:
+
+```ts
+import { defineRealtimeExtension, type RealtimeSession } from "@fal-ai/client/realtime";
+
+interface DragonSession extends RealtimeSession {
+  roar(intensity: number): void;
+}
+
+const dragonWorld = defineRealtimeExtension<{ prompt: string }, DragonSession>({
+  id: "acme/dragon-world",
+  defaultEndpoint: "acme/dragon-world",
+  async open(context, options) {
+    const connection = context.connect<Record<string, unknown>, Record<string, unknown>>(context.endpointId, { onResult: console.log });
+    context.addCleanup(() => connection.close());
+    connection.send({ prompt: options.prompt });
+
+    return {
+      roar: (intensity) => connection.send({ roar: intensity }),
+      close() {},
+    };
+  },
+});
+
+// The typed session surface (roar) via the awaited style:
+const world = await fal.realtime.open(dragonWorld, {
+  prompt: "A storm above a ruined castle",
+}).ready;
+world.session.roar(11); // typed as present after `await .ready` — no optional chain
+```
+
+Which extension opens a session is always named at the call site. There is no
+registry and no selection by endpoint name, because an endpoint id does not say
+which protocol it speaks — `fal-ai/wma-outstream` looks exactly like an endpoint
+with no realtime path at all. A surface that discovers models at runtime should
+route on the model's published `x-fal-realtime` contract, which states its
+transport, rather than on a guess from the name.
+
+An extension that _does_ own a closed set of endpoints can add an optional
+`supports(endpointId)` to reject a stale or mistyped id before negotiation
+starts. It is a guard, not a router; most protocols have no such set and should
+omit it.
+
+### fal's own WebSocket protocol, behind `open()`
+
+`websocket()` speaks the same wire protocol as `fal.realtime.connect()` —
+msgpack over a fal WebSocket, through the same functions — and differs only in
+_when_ the socket opens:
+
+```ts
+import { websocket } from "@fal-ai/client/realtime";
+
+const session = fal.realtime.open(websocket("fal-ai/fast-lightning-sdxl"), {
+  tokenProvider: getRealtimeToken,
+  onResult: (result) => setImage(result.images[0].url),
+  onState: (state) => setStatus(state),
+  onError: (error) => setError(error),
+});
+
+session.send({ prompt: "a moonlit harbour" }); // queued until the socket is live
+await session.close();
+```
+
+`connect()` is lazy: nothing happens until the first `send()`, so a wrong key or
+a missing endpoint looks exactly like a model that has not answered yet. Here
+the socket opens **eagerly** — negotiation starts the moment `open()` returns —
+while the handle stays synchronous: sends queue in order until the socket is
+live, a failed handshake is reported once through `onError` (and rejects
+`session.ready` for awaited call sites) instead of a callback that may never
+fire, and `state` reads `"live"` only when the transport agrees.
+
+Two behaviors are deliberately not carried over:
+
+- **Implicit reconnect.** `connect()` reconnects on the next `send()` after any
+  failure, which falls out of its transitions rather than having been designed.
+  Here a dead socket surfaces as `state: "failed"`, and you reopen — because an
+  application that can see the failure can say something true about it, instead
+  of appearing to work while dropping every send.
+- **Token refresh.** `connect()` refreshes at 90% of expiry, but nothing sends a
+  token over an already-open socket and every exit from its active state
+  discards the fetched value, so the refreshed token reaches nothing. Whether
+  that is dead code or a missing feature turns on whether the server enforces
+  expiry mid-connection, which is not answerable from the client. Copying a
+  mechanism with no demonstrated effect would only make it harder to add the
+  real one later.
+
+`tokenProvider` is required here, where `connect()` makes it optional and falls
+back to minting from your long-lived credentials. That fallback already warns
+that it is deprecated and points at `tokenProvider`; the eager API requires the
+supported short-lived-token path explicitly.
+
+Results arrive through `onResult` rather than the shared `onData`, because this
+is the one transport that knows its own framing: messages are msgpack and are
+decoded before anything else looks at them, so handing back a re-serialized
+string would throw that away.
+
+`connect()` keeps its signature and its behavior. This is an additional door
+onto one protocol, not a replacement.
+
+### Session lifecycle and reporting
+
+Every session reports the same coarse lifecycle regardless of protocol, so an application offering more
+than one model renders one status indicator rather than one per extension:
+
+```ts
+const session = fal.realtime.open(lucyRealtime(), {
+  input: { prompt: "a storm over a ruined castle" },
+  onState: (state) => setStatus(state), // "opening" | "live" | "failed" | "closed"
+  onDiagnostic: (event) => {
+    if (event.kind === "failure") setError(event.message);
+  },
+});
+
+session.state; // the same value, readable at any time — "opening" from the first tick
+```
+
+Four states, deliberately. Anything finer is protocol detail: `negotiating` means something specific in
+one model and nothing in a world that spends thirty seconds building.
+
+`failed` and `closed` are both terminal, and **`failed` wins**. A session that dies reports `"failed"`
+and stays there while its resources are released — it does not decay into `"closed"`, because teardown
+happens either way and reporting it would erase the only thing separating a dead transport from a user
+who pressed disconnect.
+
+Detail belongs in diagnostics:
+
+```ts
+type RealtimeDiagnostic = { kind: "progress"; phase: string; detail?: Record<string, number | string> } | { kind: "warning"; message: string; detail?: Record<string, number | string> } | { kind: "failure"; message: string; observed?: Record<string, number | string> };
+```
+
+`phase` and the free-form `detail` bag are deliberately not shaped around any one protocol — useful
+progress is `"world building"` for one model and `"3 of 4 TURN servers answered"` for another.
+
+**A `failure` reports what was observed, never what was inferred.** This is a convention rather than a
+type, and it is the difference between a diagnostic that helps and one that misleads. No relay
+candidate can result from NAT behavior, blocked UDP, invalid credentials, or a failed TURN server;
+the client reports candidate counts and per-server errors rather than guessing which cause applies.
+
+### Inbound media and data
+
+Whatever comes back arrives through two callbacks named once, by the client, rather than once per
+extension:
+
+```ts
+const session = fal.realtime.open(wma("fal-ai/wma-outstream"), {
+  onMedia: (stream) => {
+    videoEl.srcObject = stream;
+  },
+  onData: (raw) => setScore(JSON.parse(raw)),
+});
+```
+
+`onMedia` fires once per inbound stream; `onData` once per message on the extension's data channel.
+Naming them here is the same argument as `onState`: "a remote stream arrived" means the same thing in
+every protocol, so if each extension named it, an application offering two models would branch per
+protocol just to attach a video element.
+
+`onData` hands you a raw string on purpose. The client cannot know a model's schema, and parsing on its
+behalf would put one protocol's vocabulary in the transport — so the extension delivers and you parse.
+
+Both are optional on both sides. An extension need not call them, and plenty do not: an app can send a
+camera up and get its answer back as data with no inbound media at all, and an extension that hands a
+video element to a provider SDK never sees a `MediaStream` to publish. Neither callback can break a
+session — a throw from your handler is swallowed, because these fire inside browser event handlers
+where nothing upstream could catch it, and a render bug should not kill the connection.
+
+### What an extension is given
+
+`open(context, options)` receives these primitives:
+
+| Member                 | For                                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `context.run()`        | a fal **endpoint**, with the parent client's auth, proxy and retries                                                                                                                 |
+| `context.connect()`    | the fal realtime WebSocket                                                                                                                                                           |
+| `context.fetch()`      | fal infrastructure that is **not** an endpoint — a shared bridge or control plane. Uses JSON string request bodies so every proxy adapter preserves them; returns the raw `Response` |
+| `context.gatherIce()`  | ICE gathering for browser WebRTC: sufficient set, then a quiet period, under a hard bound                                                                                            |
+| `context.diagnostic()` | progress and failure reports; safe to call with no `onDiagnostic` supplied                                                                                                           |
+| `context.media()`      | publish an inbound stream to `onMedia`                                                                                                                                               |
+| `context.data()`       | publish one inbound message to `onData`                                                                                                                                              |
+| `context.fail()`       | end the session **because it failed**, as opposed to closing it                                                                                                                      |
+| `context.addCleanup()` | every resource acquired, released in reverse order                                                                                                                                   |
+| `context.signal`       | cancellation                                                                                                                                                                         |
+| `context.endpointId`   | the endpoint this session was opened against                                                                                                                                         |
+| `context.close()`      | end the managed session from inside                                                                                                                                                  |
+
+`gatherIce` lives here rather than in an extension because both obvious strategies are wrong: waiting
+for `iceGatheringState === "complete"` pays a dead STUN server's full timeout, while a fixed short cap
+silently ships an offer with no relay candidate that can never form a relayed path — and fails with no
+error at all. A TURN configuration is not "sufficient" until a relay candidate exists, because that is
+the reason TURN was configured.
+
+`fail` exists because `close()` cannot express the difference between a transport that died and a user
+who disconnected. Both would arrive as `"closed"`, and those are the two cases a status UI most needs to
+tell apart.
+
 ## More features
 
 The client library offers a plethora of features designed to simplify your journey with `fal.ai`. Dive into the [official documentation](https://fal.ai/docs) for a comprehensive guide.

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.10.1",
+  "version": "1.11.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -17,15 +17,44 @@
   ],
   "exports": {
     ".": "./src/index.js",
-    "./endpoints": "./src/types/endpoints.js"
+    "./endpoints": "./src/types/endpoints.js",
+    "./realtime": "./src/realtime/index.js",
+    "./realtime/extension": "./src/realtime/extension.js",
+    "./realtime/ice": "./src/realtime/ice.js",
+    "./realtime/lucy": "./src/realtime/lucy.js",
+    "./realtime/testing": "./src/realtime/testing.js",
+    "./realtime/websocket": "./src/realtime/websocket.js",
+    "./realtime/wma": "./src/realtime/wma.js"
   },
   "typesVersions": {
     "*": {
       "endpoints": [
         "src/types/endpoints.d.ts"
+      ],
+      "realtime": [
+        "src/realtime/index.d.ts"
+      ],
+      "realtime/extension": [
+        "src/realtime/extension.d.ts"
+      ],
+      "realtime/ice": [
+        "src/realtime/ice.d.ts"
+      ],
+      "realtime/lucy": [
+        "src/realtime/lucy.d.ts"
+      ],
+      "realtime/testing": [
+        "src/realtime/testing.d.ts"
+      ],
+      "realtime/websocket": [
+        "src/realtime/websocket.d.ts"
+      ],
+      "realtime/wma": [
+        "src/realtime/wma.d.ts"
       ]
     }
   },
+  "sideEffects": false,
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {

--- a/libs/client/src/client.ts
+++ b/libs/client/src/client.ts
@@ -96,8 +96,8 @@ export function createFalClient(userConfig: Config = {}): FalClient {
   const storage = createStorageClient({ config });
   const queue = createQueueClient({ config, storage });
   const streaming = createStreamingClient({ config, storage });
-  const realtime = createRealtimeClient({ config });
-  return {
+  const realtime = createRealtimeClient({ config, getClient: () => client });
+  const client: FalClient = {
     queue,
     realtime,
     storage,
@@ -142,4 +142,5 @@ export function createFalClient(userConfig: Config = {}): FalClient {
       return queue.result(endpointId, { requestId });
     },
   };
+  return client;
 }

--- a/libs/client/src/index.ts
+++ b/libs/client/src/index.ts
@@ -15,7 +15,29 @@ export type {
   RequestProxyConfig,
 } from "./middleware";
 export type { QueueClient } from "./queue";
-export type { RealtimeClient } from "./realtime";
+export type {
+  RealtimeClient,
+  RealtimeConnection,
+  RealtimeConnectionHandler,
+} from "./realtime";
+export {
+  defineRealtimeExtension,
+  type AnyRealtimeExtension,
+  type IceGatheringOptions,
+  type IceGatheringResult,
+  type ManagedRealtimeSession,
+  type RealtimeDiagnostic,
+  type RealtimeExtension,
+  type RealtimeExtensionContext,
+  type RealtimeExtensionOptions,
+  type RealtimeExtensionSession,
+  // Exported from the root because `open()`'s own signature references it: without this, a caller
+  // importing only from "@fal-ai/client" could pass `onState`/`onDiagnostic`/`onMedia` but could not
+  // name the type of the handler they were writing.
+  type RealtimeOpenOptions,
+  type RealtimeSession,
+  type RealtimeState,
+} from "./realtime/extension";
 export { ApiError, ValidationError } from "./response";
 export type { ResponseHandler } from "./response";
 export { isRetryableError } from "./retry";

--- a/libs/client/src/realtime-extension.spec.ts
+++ b/libs/client/src/realtime-extension.spec.ts
@@ -1,0 +1,2199 @@
+import { createConfig } from "./config";
+import { createRealtimeClient } from "./realtime";
+import {
+  defineRealtimeExtension,
+  type ManagedRealtimeSession,
+  type RealtimeExtensionContext,
+  type RealtimeSession,
+} from "./realtime/extension";
+
+describe("realtime extensions", () => {
+  beforeAll(() => {
+    global.fetch = jest.fn() as any;
+  });
+
+  function extension(cleanup = jest.fn()) {
+    return defineRealtimeExtension<
+      { endpointId?: string; label: string; abortSignal?: AbortSignal },
+      RealtimeSession & { label: string }
+    >({
+      id: "test/world",
+      defaultEndpoint: "test/world",
+      supports: (endpointId) => endpointId === "test/world",
+      async open(context, options) {
+        context.addCleanup(cleanup);
+        return {
+          label: options.label,
+          close: jest.fn(),
+        };
+      },
+    });
+  }
+
+  it("opens an explicitly supplied extension with its typed session", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const world = extension();
+
+    const session = await client.open(world, {
+      label: "hello",
+    }).ready;
+
+    // Extension-specific surface lives on `session`, not on the handle itself.
+    expect(session.session?.label).toBe("hello");
+  });
+
+  it("returns a usable handle synchronously and flushes queued sends in order", async () => {
+    // The whole point of the synchronous shape: the caller holds the handle immediately, renders
+    // from state, and sends without awaiting anything. Queued sends are delivered in order the
+    // moment the session is live, before any send issued from onState("live").
+    const delivered: string[] = [];
+    let releaseOpen!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const gated = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession & { send(message: string): void }
+    >({
+      id: "test/gated",
+      defaultEndpoint: "test/gated",
+      async open() {
+        await gate;
+        return {
+          send: (message: string) => delivered.push(message),
+          close: jest.fn(),
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const states: string[] = [];
+
+    const session = client.open(gated, {
+      onState: (next) => {
+        states.push(next);
+        if (next === "live") session.send("from-onstate");
+      },
+    });
+
+    expect(session.state).toBe("opening");
+    session.send("first");
+    session.send("second");
+    expect(delivered).toEqual([]);
+
+    releaseOpen();
+    await session.ready;
+
+    expect(delivered).toEqual(["first", "second", "from-onstate"]);
+    expect(session.state).toBe("live");
+    expect(states).toEqual(["live"]);
+    await session.close();
+  });
+
+  it("reports open failures through onError and a rejected ready", async () => {
+    const failure = new Error("negotiation exploded");
+    const broken = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/broken-open",
+      defaultEndpoint: "test/broken-open",
+      async open() {
+        throw failure;
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+    const states: string[] = [];
+    const diagnostics: Array<Record<string, unknown>> = [];
+
+    const session = client.open(broken, {
+      onError: (error) => errors.push(error),
+      onState: (next) => states.push(next),
+      onDiagnostic: (event) => diagnostics.push(event),
+    });
+
+    await expect(session.ready).rejects.toBe(failure);
+    expect(errors).toEqual([failure]);
+    expect(states).toEqual(["failed"]);
+    expect(session.state).toBe("failed");
+    expect(diagnostics).toContainEqual({
+      kind: "failure",
+      message: "negotiation exploded",
+    });
+    // Sends after a terminal state are dropped, mirroring a dead transport.
+    expect(() =>
+      (session as { send?: (message: string) => void }).send?.("late"),
+    ).not.toThrow();
+  });
+
+  it("reports an open failure without waiting for asynchronous cleanup", async () => {
+    const failure = new Error("negotiation failed promptly");
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const cleanup = jest.fn(() => cleanupGate);
+    const broken = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/slow-failed-cleanup",
+      defaultEndpoint: "test/slow-failed-cleanup",
+      async open(context) {
+        context.addCleanup(cleanup);
+        throw failure;
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+    const session = client.open(broken, {
+      onError: (error) => errors.push(error),
+    });
+
+    await expect(session.ready).rejects.toBe(failure);
+    expect(session.state).toBe("failed");
+    expect(errors).toEqual([failure]);
+
+    releaseCleanup();
+    await session.close();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not surface an ignored ready as an unhandled rejection", async () => {
+    const broken = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/ignored-ready",
+      defaultEndpoint: "test/ignored-ready",
+      async open() {
+        throw new Error("nobody is listening");
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+
+    // Callback-only consumption: ready is never touched.
+    const session = client.open(broken, { onError: (e) => errors.push(e) });
+    // Give the rejection a macrotask to become "unhandled" if it ever could.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(session.state).toBe("failed");
+    expect(errors).toHaveLength(1);
+  });
+
+  it("rejects ready when a queued send closes the session during flush", async () => {
+    // A flushed send can synchronously end the session (an extension send that closes on a
+    // protocol violation, say). ready must reject as a cancellation — never resolve a session
+    // that was terminal before it could report "live", and never call onError for it.
+    let captured!: RealtimeExtensionContext;
+    let releaseOpen!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const delivered: string[] = [];
+    const closing = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession & { send(message: string): void }
+    >({
+      id: "test/closing-send",
+      defaultEndpoint: "test/closing-send",
+      async open(context) {
+        captured = context;
+        await gate;
+        return {
+          send: (message) => {
+            delivered.push(message);
+            if (message === "first") void captured.close();
+          },
+          close: jest.fn(),
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+
+    const session = client.open(closing, { onError: (e) => errors.push(e) });
+    session.send("first");
+    session.send("second");
+    session.send("third");
+    releaseOpen();
+
+    await expect(session.ready).rejects.toBeDefined();
+    expect(session.state).toBe("closed");
+    expect(errors).toEqual([]);
+    expect(delivered).toEqual(["first"]);
+  });
+
+  it("reports an async delivery failure of a queued send as a diagnostic", async () => {
+    // send() is fire-and-forget by contract; a flushed queued message whose extension send
+    // rejects asynchronously must become a warning, not an unhandled rejection.
+    let releaseOpen!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const gated = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession & { send(message: string): void }
+    >({
+      id: "test/rejecting-send",
+      defaultEndpoint: "test/rejecting-send",
+      async open() {
+        await gate;
+        return {
+          send: (() =>
+            Promise.reject(new Error("delivery failed"))) as unknown as (
+            message: string,
+          ) => void,
+          close: jest.fn(),
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const warnings: string[] = [];
+
+    const session = client.open(gated, {
+      onDiagnostic: (event) => {
+        if (event.kind === "warning") warnings.push(event.message);
+      },
+    });
+    session.send("queued");
+    releaseOpen();
+    await session.ready;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(warnings).toEqual([
+      "A queued message could not be delivered to the session.",
+    ]);
+    await session.close();
+  });
+
+  it("reports an async delivery failure of a live send as a diagnostic", async () => {
+    // The same fire-and-forget rule after the session is live: the handle types send as void, so
+    // a rejecting extension send has no observer at the call site.
+    const failing = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession & { send(message: string): void }
+    >({
+      id: "test/rejecting-live-send",
+      defaultEndpoint: "test/rejecting-live-send",
+      async open() {
+        return {
+          send: (() =>
+            Promise.reject(new Error("live delivery failed"))) as unknown as (
+            message: string,
+          ) => void,
+          close: jest.fn(),
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const warnings: string[] = [];
+
+    const session = client.open(failing, {
+      onDiagnostic: (event) => {
+        if (event.kind === "warning") warnings.push(event.message);
+      },
+    });
+    await session.ready;
+    session.send("live");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(warnings).toEqual([
+      "A message could not be delivered to the session.",
+    ]);
+    await session.close();
+  });
+
+  it("bounds the pre-live send queue and warns once about drops", async () => {
+    const delivered: unknown[] = [];
+    let releaseOpen!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const gated = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession & { send(message: number): void }
+    >({
+      id: "test/queue-cap",
+      defaultEndpoint: "test/queue-cap",
+      async open() {
+        await gate;
+        return {
+          send: (message: number) => delivered.push(message),
+          close: jest.fn(),
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const warnings: string[] = [];
+
+    const session = client.open(gated, {
+      onDiagnostic: (event) => {
+        if (event.kind === "warning") warnings.push(event.message);
+      },
+    });
+    for (let i = 0; i < 70; i += 1) {
+      session.send(i);
+    }
+    releaseOpen();
+    await session.ready;
+
+    // Oldest-first eviction: the newest 64 survive.
+    expect(delivered).toHaveLength(64);
+    expect(delivered[0]).toBe(6);
+    expect(delivered[63]).toBe(69);
+    expect(warnings).toHaveLength(1);
+    await session.close();
+  });
+
+  it("releases the signal combination when a streamed body completes", async () => {
+    // Extensions may consume response.body directly (getReader/pipeTo/iteration) instead of the
+    // convenience methods; end-of-stream must release the request's signal combination too, or
+    // repeated streaming requests accumulate bookkeeping until the session closes.
+    let observed: AbortSignal | null | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async (_url: string, init: RequestInit = {}) => {
+          observed = init.signal;
+          return new Response("streamed-bytes");
+        }) as any,
+      }),
+    });
+    const requestLocal = new AbortController();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/streamed-body",
+      defaultEndpoint: "test/streamed-body",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/stream", {
+          signal: requestLocal.signal,
+        });
+        const reader = response.body!.getReader();
+        const chunks: Uint8Array[] = [];
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+        expect(new TextDecoder().decode(chunks[0])).toBe("streamed-bytes");
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await session.ready;
+    await session.close();
+
+    // The combination was released at end-of-stream, so session teardown no longer aborts it.
+    expect(observed?.aborted).toBe(false);
+  });
+
+  it("does not lock the response when body is merely accessed", async () => {
+    // "Inspect body, then call json()" is a normal pattern; property access must not acquire a
+    // reader on the native stream, or the later standard read rejects.
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response('{"ok":true}')) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/body-peek",
+      defaultEndpoint: "test/body-peek",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session");
+        expect(response.body).toBeTruthy(); // peek only
+        expect(await response.json()).toEqual({ ok: true });
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await expect(session.ready).resolves.toBeDefined();
+    await session.close();
+  });
+
+  it("detaches request-signal listeners at session close for unconsumed bodies", async () => {
+    // A long-lived request signal that outlives the session must not keep retaining the combined
+    // controller through an abort listener nobody will ever fire — the session-abort sweep
+    // removes the listener from the request signal, not only from its own bookkeeping.
+    const requestLocal = new AbortController();
+    const removed = jest.spyOn(requestLocal.signal, "removeEventListener");
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response("never-read")) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/unconsumed-body",
+      defaultEndpoint: "test/unconsumed-body",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session", {
+          signal: requestLocal.signal,
+        });
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await session.ready;
+    expect(removed).not.toHaveBeenCalled();
+    await session.close();
+
+    expect(removed).toHaveBeenCalledWith("abort", expect.any(Function));
+    removed.mockRestore();
+  });
+
+  it("keeps the original body readable after cloning", async () => {
+    // Native clone() re-points the original's body at a fresh tee branch; the monitored getter
+    // must follow it rather than a stale pre-tee capture, or reading the original throws
+    // "ReadableStream is locked" while both branches work on a native response.
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response('{"ok":true}')) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/original-after-clone",
+      defaultEndpoint: "test/original-after-clone",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session");
+        const clone = response.clone();
+        const reader = response.body!.getReader(); // the ORIGINAL, post-clone
+        const chunks: Uint8Array[] = [];
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+        expect(new TextDecoder().decode(chunks[0])).toBe('{"ok":true}');
+        expect(await clone.json()).toEqual({ ok: true });
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await expect(session.ready).resolves.toBeDefined();
+    await session.close();
+  });
+
+  it("rejects clone() once a reader holds the monitored body", async () => {
+    // Native fetch rejects cloning after a reader locks the body; the monitored wrapper defers
+    // locking the native stream, so the patched clone must enforce the same rule itself.
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response("locked")) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/clone-locked",
+      defaultEndpoint: "test/clone-locked",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session", {
+          signal: new AbortController().signal,
+        });
+        response.body!.getReader(); // hold, without reading
+        expect(() => response.clone()).toThrow(/disturbed or locked/);
+        // Body methods enforce the same native rule — a held reader cannot be bypassed.
+        await expect(response.json()).rejects.toThrow(/disturbed or locked/);
+        await expect(response.text()).rejects.toThrow(/disturbed or locked/);
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await expect(session.ready).resolves.toBeDefined();
+    await session.close();
+  });
+
+  it("releases the signal combination when a cloned body is consumed", async () => {
+    // clone() tees the underlying source, so fully consuming either branch means the network
+    // stream finished; a caller that parses only the clone must still release the combination.
+    let observed: AbortSignal | null | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async (_url: string, init: RequestInit = {}) => {
+          observed = init.signal;
+          return new Response('{"ok":true}');
+        }) as any,
+      }),
+    });
+    const requestLocal = new AbortController();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/cloned-body",
+      defaultEndpoint: "test/cloned-body",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session", {
+          signal: requestLocal.signal,
+        });
+        expect(await response.clone().json()).toEqual({ ok: true });
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await session.ready;
+    await session.close();
+
+    // Released at clone consumption, so teardown no longer aborts the combination.
+    expect(observed?.aborted).toBe(false);
+  });
+
+  it("keeps the combination alive when only a clone branch is cancelled", async () => {
+    // Cancelling ONE tee branch does not finish the underlying source; the shared combination
+    // must keep covering the still-streaming original until it completes or the session ends.
+    let observed: AbortSignal | null | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async (_url: string, init: RequestInit = {}) => {
+          observed = init.signal;
+          return new Response('{"ok":true}');
+        }) as any,
+      }),
+    });
+    const requestLocal = new AbortController();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/clone-cancel",
+      defaultEndpoint: "test/clone-cancel",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session", {
+          signal: requestLocal.signal,
+        });
+        const clone = response.clone();
+        // Cancel only the clone's branch; the original stays unconsumed and must remain covered.
+        void clone.body?.cancel();
+        await Promise.resolve();
+        await Promise.resolve();
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await session.ready;
+    await session.close();
+
+    // The combination was still active at teardown, so the session abort reached it.
+    expect(observed?.aborted).toBe(true);
+  });
+
+  it("cancels a still-opening session through close()", async () => {
+    const neverOpens = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/never-opens",
+      defaultEndpoint: "test/never-opens",
+      open: (context) =>
+        new Promise((_resolve, reject) => {
+          context.signal.addEventListener("abort", () =>
+            reject(context.signal.reason),
+          );
+        }),
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+
+    const session = client.open(neverOpens, { onError: (e) => errors.push(e) });
+    expect(session.state).toBe("opening");
+    await session.close();
+
+    // An orderly, caller-initiated ending: "closed", ready rejected so awaiters are released,
+    // and NO onError — a UI must not render a failure for its own disconnect button.
+    expect(session.state).toBe("closed");
+    await expect(session.ready).rejects.toBeDefined();
+    expect(errors).toEqual([]);
+  });
+
+  it("ignores a failure reported after managed teardown began", async () => {
+    // An extension's in-flight work can observe its own teardown and report it as a transport
+    // failure. After the caller closed, that report is stale: the lifecycle correctly reads
+    // "closed" and neither onError nor a failure diagnostic may fire for a user-ended session.
+    let captured!: RealtimeExtensionContext;
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/stale-fail",
+      defaultEndpoint: "test/stale-fail",
+      async open(context) {
+        captured = context;
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const errors: unknown[] = [];
+    const diagnostics: unknown[] = [];
+
+    const session = client.open(probe, {
+      onError: (e) => errors.push(e),
+      onDiagnostic: (event) => diagnostics.push(event),
+    });
+    await session.ready;
+    await session.close();
+
+    await captured.fail("stale transport death", { code: 1006 });
+
+    expect(session.state).toBe("closed");
+    expect(errors).toEqual([]);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('runs each cleanup exactly once when onState("closed") re-enters close()', async () => {
+    // setState("closed") fires the caller's onState synchronously; a handler that closes on
+    // seeing "closed" re-enters cleanup() — the teardown memo must already be published, and the
+    // release list is consumed destructively, so nothing runs twice.
+    const release = jest.fn();
+    const reentrant = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/onstate-reentry",
+      defaultEndpoint: "test/onstate-reentry",
+      async open(context) {
+        context.addCleanup(release);
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    // Assigned once after open() returns; the callback only reads it. prefer-const cannot see
+    // through the closure.
+    // eslint-disable-next-line prefer-const
+    let handle: { close(): Promise<void> } | undefined;
+    const session = client.open(reentrant, {
+      onState: (next) => {
+        if (next === "closed") void handle?.close();
+      },
+    });
+    handle = session;
+    await session.ready;
+    await session.close();
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps close() pending until a late-opening session is torn down", async () => {
+    // An extension mid-operation may not observe the abort promptly and can still hand back a
+    // resource-bearing session. An awaited close() must cover that late session's teardown
+    // rather than reporting completion while negotiation is still running.
+    const events: string[] = [];
+    let releaseOpen!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const stubborn = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/stubborn",
+      defaultEndpoint: "test/stubborn",
+      async open() {
+        await gate; // deliberately ignores context.signal
+        return {
+          close: () => {
+            events.push("session-closed");
+          },
+        };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const session = client.open(stubborn, {});
+    // The open task starts one microtask after open() returns; let the extension actually begin
+    // before closing, or the abort would win the race and the extension never opens at all.
+    await Promise.resolve();
+    const closing = session.close().then(() => {
+      events.push("close-resolved");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(events).toEqual([]); // close() is still pending on the open attempt
+
+    releaseOpen();
+    await closing;
+
+    expect(events).toEqual(["session-closed", "close-resolved"]);
+    expect(session.state).toBe("closed");
+  });
+
+  it("serves the monitored body as a byte stream usable with BYOB readers", async () => {
+    // Native fetch bodies are byte streams; context.fetch() promises a raw Response, so a BYOB
+    // reader that works on a native body must work on the monitored one.
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response("byob-bytes")) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/byob",
+      defaultEndpoint: "test/byob",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session");
+        const reader = (response.body as ReadableStream<Uint8Array>).getReader({
+          mode: "byob",
+        });
+        const collected: number[] = [];
+        let view = new Uint8Array(4);
+        for (;;) {
+          const { done, value } = await reader.read(view);
+          if (value) {
+            collected.push(...value);
+            view = new Uint8Array(4);
+          }
+          if (done) break;
+        }
+        expect(new TextDecoder().decode(new Uint8Array(collected))).toBe(
+          "byob-bytes",
+        );
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = client.open(probe, {});
+    await expect(session.ready).resolves.toBeDefined();
+    await session.close();
+  });
+
+  it("uses the extension default when endpointId is explicitly undefined", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const session = await client.open(extension(), {
+      endpointId: undefined,
+      label: "defaulted",
+    }).ready;
+
+    expect(session.session?.label).toBe("defaulted");
+  });
+
+  it("rejects an endpoint the extension declares it cannot open", () => {
+    // `supports` is an optional guard, not a routing registry: catch a stale or mistyped id at the
+    // call site rather than partway through a negotiation that cannot succeed. Misconfiguration is
+    // a programmer error, so the synchronous open() throws it synchronously.
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    expect(() =>
+      client.open(extension(), {
+        endpointId: "someone-else/world",
+        label: "wrong",
+      }),
+    ).toThrow(
+      'Realtime extension "test/world" does not support "someone-else/world".',
+    );
+  });
+
+  it("opens an extension that declares no endpoint constraint", async () => {
+    // Most protocols cannot recognize their own endpoints by name, so they omit `supports` entirely.
+    // Omitting it must not be read as refusing everything.
+    const anyEndpoint = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/unconstrained",
+      async open() {
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    await expect(
+      client.open(anyEndpoint, { endpointId: "anything/at-all" }).ready,
+    ).resolves.toBeDefined();
+  });
+
+  it("survives a cleanup release that awaits context.close()", async () => {
+    // The circular-await trap: a release awaiting close() from inside the teardown body would
+    // receive the memoized teardown promise that is itself awaiting the release. close() must
+    // resolve anyway.
+    let captured!: RealtimeExtensionContext;
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/reentrant-release",
+      defaultEndpoint: "test/reentrant-release",
+      async open(context) {
+        captured = context;
+        context.addCleanup(() => captured.close());
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(probe, {}).ready;
+
+    await expect(
+      Promise.race([
+        session.close().then(() => "closed"),
+        new Promise((resolve) => setTimeout(() => resolve("hung"), 250)),
+      ]),
+    ).resolves.toBe("closed");
+  });
+
+  it("resolves ready for a session that went live, even when a live callback closes it", async () => {
+    const world = extension();
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const handle = client.open(world, {
+      label: "probe",
+      onState: (next) => {
+        if (next === "live") void handle.close();
+      },
+    });
+    // It DID go live; a synchronous close from the live callback is an orderly ending that must
+    // not turn ready into a rejection.
+    await expect(handle.ready).resolves.toBe(handle);
+    expect(handle.state).toBe("closed");
+  });
+
+  it("runs cleanup exactly once when close is called repeatedly", async () => {
+    const cleanup = jest.fn();
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(extension(cleanup), {
+      endpointId: "test/world",
+      label: "cleanup",
+    }).ready;
+
+    await session.close();
+    await session.close();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes every concurrent close await the same teardown", async () => {
+    let finishCleanup!: () => void;
+    const cleanupDone = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const cleanup = jest.fn(() => cleanupDone);
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(extension(cleanup), {
+      endpointId: "test/world",
+      label: "concurrent-cleanup",
+    }).ready;
+
+    const first = session.close();
+    const second = session.close();
+    expect(second).toBe(first);
+
+    let secondFinished = false;
+    void second.then(() => {
+      secondFinished = true;
+    });
+    await Promise.resolve();
+    expect(secondFinished).toBe(false);
+
+    finishCleanup();
+    await Promise.all([first, second]);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares teardown with a synchronous abort-listener close", async () => {
+    const cleanup = jest.fn();
+    const extensionClose = jest.fn();
+    let finishLateCleanup!: () => void;
+    const lateCleanupDone = new Promise<void>((resolve) => {
+      finishLateCleanup = resolve;
+    });
+    const lateCleanup = jest.fn(() => lateCleanupDone);
+    let closeFromAbort: Promise<void> | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const reentrant = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/reentrant-cleanup",
+      defaultEndpoint: "test/reentrant-cleanup",
+      async open(context) {
+        context.addCleanup(cleanup);
+        context.signal.addEventListener("abort", () => {
+          context.addCleanup(lateCleanup);
+          closeFromAbort = context.close();
+        });
+        return { close: extensionClose };
+      },
+    });
+    const session = await client.open(reentrant, {}).ready;
+
+    const closeFromCaller = session.close();
+
+    // Both closes complete the same memoized teardown. They are no longer the identical promise:
+    // the caller's close additionally covers the opening task (see "keeps close() pending until a
+    // late-opening session is torn down"), while the extension-internal close deliberately does
+    // not — an extension awaiting context.close() from inside its own open() must not deadlock.
+    expect(closeFromAbort).toBeDefined();
+    let closeFinished = false;
+    let abortCloseFinished = false;
+    void closeFromCaller.then(() => {
+      closeFinished = true;
+    });
+    void closeFromAbort!.then(() => {
+      abortCloseFinished = true;
+    });
+    // The abort-registered late cleanup runs behind the session close hook and the LIFO
+    // releases — in order — so it needs the teardown body to reach its drain.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(lateCleanup).toHaveBeenCalledTimes(1);
+    expect(closeFinished).toBe(false);
+    expect(abortCloseFinished).toBe(false);
+
+    finishLateCleanup();
+    await closeFromCaller;
+    await closeFromAbort;
+    expect(extensionClose).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(closeFinished).toBe(true);
+    expect(abortCloseFinished).toBe(true);
+  });
+
+  it("does not await teardown through an extension close hook", async () => {
+    const cleanup = jest.fn();
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const reentrant = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/close-delegation",
+      defaultEndpoint: "test/close-delegation",
+      async open(context) {
+        context.addCleanup(cleanup);
+        return { close: () => context.close() };
+      },
+    });
+    const session = await client.open(reentrant, {}).ready;
+
+    await session.close();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes internal class close calls through managed teardown", async () => {
+    class SelfClosingSession implements RealtimeSession {
+      close = jest.fn();
+
+      stop() {
+        return this.close();
+      }
+    }
+    const cleanup = jest.fn();
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const selfClosing = defineRealtimeExtension<
+      Record<never, never>,
+      SelfClosingSession
+    >({
+      id: "test/self-closing",
+      defaultEndpoint: "test/self-closing",
+      async open(context) {
+        context.addCleanup(cleanup);
+        return new SelfClosingSession();
+      },
+    });
+    const session = await client.open(selfClosing, {}).ready;
+
+    await session.session?.stop();
+
+    expect(session.state).toBe("closed");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke an extension when opening was already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user left");
+    controller.abort(reason);
+    const world = extension();
+    const open = jest.spyOn(world, "open");
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    await expect(
+      client.open(world, {
+        label: "aborted",
+        abortSignal: controller.signal,
+      }).ready,
+    ).rejects.toBe(reason);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("closes a session that finishes opening after abort", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user left during setup");
+    const close = jest.fn().mockRejectedValue(new Error("late close failed"));
+    let finishSetup = () => undefined;
+    const setup = new Promise<void>((resolve) => {
+      finishSetup = resolve;
+    });
+    const late = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/late-session",
+      defaultEndpoint: "test/late-session",
+      async open() {
+        await setup;
+        return { close };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const handle = client.open(late, { abortSignal: controller.signal });
+    const opening = handle.ready;
+    // Let the deferred open task invoke the extension before aborting, so the abort lands on a
+    // genuinely in-flight setup rather than preempting it.
+    await Promise.resolve();
+    controller.abort(reason);
+    finishSetup();
+
+    // ready rejects promptly at the abort; the late session's teardown continues behind it and
+    // close() is the completion signal that awaits it.
+    await expect(opening).rejects.toBe(reason);
+    await handle.close();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("contains a rejecting session close hook during abort", async () => {
+    const controller = new AbortController();
+    const close = jest.fn().mockRejectedValue(new Error("close failed"));
+    const brokenClose = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/broken-close",
+      defaultEndpoint: "test/broken-close",
+      async open() {
+        return { close };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(brokenClose, {
+      abortSignal: controller.signal,
+    }).ready;
+
+    controller.abort(new Error("user left"));
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [
+      "throws",
+      () => {
+        throw new Error("late");
+      },
+    ],
+    ["rejects", () => Promise.reject(new Error("late"))],
+  ])("contains a late cleanup that %s after abort", async (_, cleanup) => {
+    const controller = new AbortController();
+    const reason = new Error("user left");
+    let finishSetup = () => undefined;
+    const setup = new Promise<void>((resolve) => {
+      finishSetup = resolve;
+    });
+    const late = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/late-cleanup",
+      defaultEndpoint: "test/late-cleanup",
+      async open(context) {
+        await setup;
+        context.addCleanup(cleanup);
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const opening = client.open(late, { abortSignal: controller.signal }).ready;
+    controller.abort(reason);
+    finishSetup();
+
+    await expect(opening).rejects.toBe(reason);
+    await Promise.resolve();
+  });
+
+  it("awaits an asynchronous cleanup registered after abort", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user left");
+    let finishSetup = () => undefined;
+    let finishCleanup = () => undefined;
+    const setup = new Promise<void>((resolve) => {
+      finishSetup = resolve;
+    });
+    const cleanupDone = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const cleanup = jest.fn(() => cleanupDone);
+    const late = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/await-late-cleanup",
+      defaultEndpoint: "test/await-late-cleanup",
+      async open(context) {
+        await setup;
+        context.addCleanup(cleanup);
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const handle = client.open(late, { abortSignal: controller.signal });
+    const opening = handle.ready;
+    await Promise.resolve(); // the deferred open task reaches the extension's setup await
+    controller.abort(reason);
+    finishSetup();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    // ready is the LIVENESS signal: it rejects promptly with the abort reason rather than
+    // waiting out teardown — a session that will never be live must say so immediately.
+    await expect(opening).rejects.toBe(reason);
+    // Resource release is what close() awaits: it stays pending on the late cleanup.
+    let closed = false;
+    const closing = handle.close().then(() => {
+      closed = true;
+    });
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(closed).toBe(false);
+    finishCleanup();
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("awaits a late cleanup when aborted extension setup rejects", async () => {
+    const controller = new AbortController();
+    const setupFailure = new Error("setup failed after abort");
+    let finishSetup = () => undefined;
+    let finishCleanup = () => undefined;
+    const setup = new Promise<void>((resolve) => {
+      finishSetup = resolve;
+    });
+    const cleanupDone = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const cleanup = jest.fn(() => cleanupDone);
+    const broken = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/reject-after-abort",
+      defaultEndpoint: "test/reject-after-abort",
+      async open(context) {
+        await setup;
+        context.addCleanup(cleanup);
+        throw setupFailure;
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const abortReason = new Error("user left");
+    const handle = client.open(broken, {
+      abortSignal: controller.signal,
+    });
+    const opening = handle.ready;
+    await Promise.resolve(); // the deferred open task reaches the extension's setup await
+    controller.abort(abortReason);
+    finishSetup();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    // The caller aborted; the extension's incidental setup failure after that abort stays out
+    // of the caller-facing channels (consistent with onError, which also never sees it).
+    await expect(opening).rejects.toBe(abortReason);
+    // The late cleanup is still awaited by close() before it reports released.
+    let closed = false;
+    const closing = handle.close().then(() => {
+      closed = true;
+    });
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(closed).toBe(false);
+    finishCleanup();
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("keeps a caller cancellation reported as closed when an abort listener fails", async () => {
+    // controller.abort() invokes extension listeners synchronously; one reacting with
+    // context.fail() must not relabel the user's own cancellation as a transport failure.
+    const controller = new AbortController();
+    const errors: unknown[] = [];
+    const states: string[] = [];
+    const reactive = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/fail-on-abort",
+      defaultEndpoint: "test/fail-on-abort",
+      async open(context) {
+        context.signal.addEventListener(
+          "abort",
+          () => void context.fail("transport died"),
+          { once: true },
+        );
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const handle = client.open(reactive, {
+      abortSignal: controller.signal,
+      onError: (e) => errors.push(e),
+      onState: (next) => states.push(next),
+    });
+    await handle.ready;
+
+    controller.abort(new Error("user left"));
+    await handle.close();
+
+    expect(handle.state).toBe("closed");
+    expect(states).toEqual(["live", "closed"]);
+    expect(errors).toEqual([]);
+  });
+
+  it("preserves the caller's abort reason while an extension is opening", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user left during negotiation");
+    const waiting = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/waiting",
+      defaultEndpoint: "test/waiting",
+      open(context) {
+        return new Promise((_, reject) => {
+          context.signal.addEventListener(
+            "abort",
+            () => reject(context.signal.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const opening = client.open(waiting, {
+      abortSignal: controller.signal,
+    }).ready;
+    controller.abort(reason);
+
+    await expect(opening).rejects.toBe(reason);
+  });
+
+  it("reports an extension that cannot name an endpoint to open", () => {
+    const noDefault = defineRealtimeExtension<
+      { endpointId?: string },
+      RealtimeSession
+    >({
+      id: "test/no-default",
+      async open() {
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    // Misconfiguration is a programmer error; the synchronous open() throws it synchronously.
+    expect(() => client.open(noDefault, {})).toThrow(
+      'Realtime extension "test/no-default" requires an endpointId option',
+    );
+  });
+});
+
+describe("realtime extension context additions", () => {
+  it("context.run rejects absolute destinations", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "secret-key" }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/untrusted-run",
+      defaultEndpoint: "test/untrusted-run",
+      async open(context) {
+        await context.run("  https://notfal.run/steal  ", { input: {} });
+        return { close: jest.fn() };
+      },
+    });
+
+    await expect(client.open(probe, {}).ready).rejects.toThrow(
+      "requires an app endpoint id",
+    );
+  });
+
+  it("context.fetch rejects methods other than GET and POST", async () => {
+    // The smallest surface the shipped extensions need, and the one every fal proxy adapter is
+    // guaranteed to route — widening it means widening three frameworks' adapter exports.
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "secret-key" }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/fetch-method",
+      defaultEndpoint: "test/fetch-method",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session", {
+          method: "DELETE",
+        });
+        return { close: jest.fn() };
+      },
+    });
+
+    await expect(client.open(probe, {}).ready).rejects.toThrow(
+      "supports GET and POST only",
+    );
+  });
+
+  it("context.fetch attaches the parent client's credentials", async () => {
+    // The point of this method existing: the extension makes the call, so the APPLICATION never has
+    // to inject a credentialed fetch and never handles a key.
+    const seen: Array<{ url: string; init: RequestInit }> = [];
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async (url: string, init: RequestInit) => {
+          seen.push({ url, init });
+          return new Response("{}", { status: 200 });
+        }) as any,
+      }),
+    });
+
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/fetch",
+      defaultEndpoint: "test/fetch",
+      async open(context) {
+        const response = await context.fetch("https://wma.fal.run/session", {
+          body: JSON.stringify({ app_id: "x" }),
+          headers: { "Content-Type": "application/json" },
+        });
+        expect(response.status).toBe(200);
+        return { close: jest.fn() };
+      },
+    });
+
+    await client.open(probe, {}).ready;
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("https://wma.fal.run/session");
+    const headers = new Headers(seen[0].init.headers);
+    expect(headers.get("authorization")).toBe("Key secret-key");
+    expect(headers.get("content-type")).toBe("application/json");
+    // Defaults to GET like native fetch, and the abort signal is wired without the extension
+    // asking. (This call carries a body only because the test reuses one shape; extensions that
+    // post name the method, as WMA does.)
+    expect(seen[0].init.method).toBe("GET");
+    expect(seen[0].init.signal).toBeDefined();
+  });
+
+  it("context.fetch aborts a request-local-signal fetch when the session aborts", async () => {
+    // A request-local signal (say, an extension's own fetch timeout) must not displace the managed
+    // session signal — aborting open() has to cancel the in-flight request, or open() stays stuck
+    // awaiting extension.open() despite the abortSignal contract.
+    let fetchStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      fetchStarted = resolve;
+    });
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: ((_url: string, init: RequestInit = {}) => {
+          fetchStarted();
+          return new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () =>
+              reject(
+                init.signal?.reason ??
+                  new DOMException("aborted", "AbortError"),
+              ),
+            );
+          });
+        }) as any,
+      }),
+    });
+    const requestLocal = new AbortController();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/fetch-session-abort",
+      defaultEndpoint: "test/fetch-session-abort",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session", {
+          signal: requestLocal.signal,
+        });
+        return { close: jest.fn() };
+      },
+    });
+
+    const controller = new AbortController();
+    const opening = client.open(probe, {
+      abortSignal: controller.signal,
+    }).ready;
+    const settled = opening.catch((error) => error);
+    await started;
+    const reason = new Error("session aborted");
+    controller.abort(reason);
+
+    expect(await settled).toBe(reason);
+    expect(requestLocal.signal.aborted).toBe(false);
+  });
+
+  it("keeps a request-local fetch signal combined while the body is consumed", async () => {
+    // fetch() resolves at headers, but its signal also cancels later body reads. Detaching the
+    // combined signal at resolution would leave a stalled body unaffected by session teardown.
+    let observed: AbortSignal | null | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async (_url: string, init: RequestInit = {}) => {
+          observed = init.signal;
+          return new Response("{}");
+        }) as any,
+      }),
+    });
+    const requestLocal = new AbortController();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/fetch-body-abort",
+      defaultEndpoint: "test/fetch-body-abort",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session", {
+          signal: requestLocal.signal,
+        });
+        return { close: jest.fn() };
+      },
+    });
+
+    const controller = new AbortController();
+    const session = await client.open(probe, {
+      abortSignal: controller.signal,
+    }).ready;
+    expect(observed?.aborted).toBe(false);
+
+    controller.abort(new Error("late abort"));
+    expect(observed?.aborted).toBe(true);
+    await session.close();
+  });
+
+  it("does not accumulate session-signal listeners across repeated fetches", async () => {
+    // A heartbeat-style extension completes a request every few seconds with a fresh
+    // request-local signal that never aborts. The session signal must carry one shared hook for
+    // all of them, and consuming the body must release each combination.
+    let sessionSignal: AbortSignal | undefined;
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: (async () => new Response('{"alive":true}')) as any,
+      }),
+    });
+    const listenersPerBeat: number[] = [];
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/heartbeats",
+      defaultEndpoint: "test/heartbeats",
+      async open(context) {
+        sessionSignal = context.signal;
+        const added = jest.spyOn(context.signal, "addEventListener");
+        for (let beat = 0; beat < 4; beat += 1) {
+          const local = new AbortController();
+          const response = await context.fetch(
+            "https://wma.fal.run/session/heartbeat",
+            { signal: local.signal },
+          );
+          await response.json();
+          listenersPerBeat.push(added.mock.calls.length);
+        }
+        added.mockRestore();
+        return { close: jest.fn() };
+      },
+    });
+
+    const session = await client.open(probe, {}).ready;
+    // The first request may install the one shared session hook; later requests add nothing.
+    expect(listenersPerBeat[3]).toBe(listenersPerBeat[0]);
+    await session.close();
+    expect(sessionSignal?.aborted).toBe(true);
+  });
+
+  it("awaits late cleanups registered by other late cleanups", async () => {
+    // A late cleanup that registers another one mid-flight must still be covered by the awaited
+    // close(); a single snapshot of the registrations would resolve before the nested one runs.
+    let captured!: RealtimeExtensionContext;
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/late-cleanups",
+      defaultEndpoint: "test/late-cleanups",
+      async open(context) {
+        captured = context;
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(probe, {}).ready;
+
+    const order: string[] = [];
+    const closing = session.close();
+    captured.addCleanup(async () => {
+      order.push("outer-start");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      captured.addCleanup(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        order.push("inner");
+      });
+      order.push("outer-end");
+    });
+    await closing;
+
+    expect(order).toEqual(["outer-start", "outer-end", "inner"]);
+  });
+
+  it("runs a late cleanup registered across detached teardown microtasks", async () => {
+    let captured!: RealtimeExtensionContext;
+    const lateCleanup = jest.fn();
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/detached-late-cleanup",
+      defaultEndpoint: "test/detached-late-cleanup",
+      async open(context) {
+        captured = context;
+        context.addCleanup(() => {
+          queueMicrotask(() => {
+            queueMicrotask(() => captured.addCleanup(lateCleanup));
+          });
+        });
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+    const session = await client.open(probe, {}).ready;
+
+    await session.close();
+    await Promise.resolve();
+
+    expect(lateCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("context.fetch rejects bodies the shared proxy contract cannot preserve", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: async () => new Response("{}"),
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/form-data",
+      defaultEndpoint: "test/form-data",
+      async open(context) {
+        const body = new FormData();
+        body.set("field", "payload");
+        await context.fetch("https://wma.fal.run/upload", { body } as never);
+        return { close: jest.fn() };
+      },
+    });
+
+    await expect(client.open(probe, {}).ready).rejects.toThrow(
+      "supports JSON string bodies only",
+    );
+  });
+
+  it("context.gatherIce honors extension-local cancellation", async () => {
+    const listeners: Record<string, EventListener[]> = {};
+    const pc = {
+      iceGatheringState: "gathering" as RTCIceGatheringState,
+      addEventListener(type: string, listener: EventListener) {
+        (listeners[type] ??= []).push(listener);
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners[type] = (listeners[type] ?? []).filter(
+          (candidate) => candidate !== listener,
+        );
+      },
+    };
+    const iceController = new AbortController();
+    const reason = new Error("extension stopped gathering");
+    let gatheringStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      gatheringStarted = resolve;
+    });
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/local-ice-cancel",
+      defaultEndpoint: "test/local-ice-cancel",
+      async open(context) {
+        const gathering = context.gatherIce(pc as RTCPeerConnection, {
+          signal: iceController.signal,
+          timeoutMs: 10_000,
+        });
+        gatheringStarted();
+        await gathering;
+        return { close: jest.fn() };
+      },
+    });
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "test-key" }),
+    });
+
+    const opening = client.open(probe, {}).ready;
+    await started;
+    iceController.abort(reason);
+
+    await expect(opening).rejects.toBe(reason);
+  });
+
+  it("context.fetch rejects extension-controlled non-fal destinations", async () => {
+    const fetch = jest.fn(async () => new Response("{}"));
+    const requestMiddleware = jest.fn(async (request) => request);
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        fetch: fetch as any,
+        requestMiddleware,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/untrusted-fetch",
+      defaultEndpoint: "test/untrusted-fetch",
+      async open(context) {
+        await context.fetch("https://attacker.example/collect");
+        return { close: jest.fn() };
+      },
+    });
+
+    await expect(client.open(probe, {}).ready).rejects.toThrow(
+      "restricted to fal-operated HTTPS hosts",
+    );
+    expect(requestMiddleware).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Headers", new Headers([["X-Trace", "from-headers"]])],
+    ["header tuples", [["X-Trace", "from-tuples"]] as [string, string][]],
+  ])("context.fetch preserves %s through middleware", async (_, headers) => {
+    const seen: RequestInit[] = [];
+    const requestMiddleware = jest.fn(async (request) => request);
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "secret-key",
+        requestMiddleware,
+        fetch: async (url, init = {}) => {
+          expect(url).toBe("https://wma.fal.run/session");
+          seen.push(init);
+          return new Response("{}");
+        },
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/header-shapes",
+      defaultEndpoint: "test/header-shapes",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session", { headers });
+        return { close: jest.fn() };
+      },
+    });
+
+    await client.open(probe, {}).ready;
+
+    expect(requestMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { "x-trace": expect.stringMatching(/^from-/) },
+      }),
+    );
+    expect(new Headers(seen[0].headers).get("x-trace")).toMatch(/^from-/);
+  });
+
+  it("routes context.media and context.data to the caller's handlers", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const stream = { id: "s" } as unknown as MediaStream;
+    const probe = defineRealtimeExtension<
+      // Record<never, never>, NOT Record<string, never>. The latter says "every string key maps to
+      // never", which makes `Options & RealtimeOpenOptions` contradictory and rejects onMedia/onState/
+      // onDiagnostic at the call site — an extension with no product inputs of its own would otherwise
+      // be unable to receive any kernel option.
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/channels",
+      defaultEndpoint: "test/channels",
+      async open(context) {
+        context.media(stream);
+        context.data('{"a":1}');
+        return { close: jest.fn() };
+      },
+    });
+
+    const media: MediaStream[] = [];
+    const data: string[] = [];
+    await client.open(probe, {
+      onMedia: (value) => media.push(value),
+      onData: (value) => data.push(value),
+    }).ready;
+    expect(media).toEqual([stream]);
+    expect(data).toEqual(['{"a":1}']);
+  });
+
+  it("drops media and data emitted after teardown begins", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    let emitMedia!: (stream: MediaStream) => void;
+    let emitData!: (raw: string) => void;
+    const probe = defineRealtimeExtension<
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/closed-channels",
+      defaultEndpoint: "test/closed-channels",
+      async open(context) {
+        emitMedia = context.media;
+        emitData = context.data;
+        return { close: jest.fn() };
+      },
+    });
+    const media = jest.fn();
+    const data = jest.fn();
+    const session = await client.open(probe, {
+      onMedia: media,
+      onData: data,
+    }).ready;
+
+    const closing = session.close();
+    emitMedia({ id: "late" } as unknown as MediaStream);
+    emitData("late");
+    await closing;
+
+    expect(media).not.toHaveBeenCalled();
+    expect(data).not.toHaveBeenCalled();
+  });
+
+  it("a throwing media or data handler cannot fail the session", async () => {
+    // These fire from inside pc.ontrack and channel.onmessage, where a throw lands in a browser event
+    // handler no caller can catch. An application whose render throws must not take the session down,
+    // and one unparseable payload must not end a stream that is still delivering frames.
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const probe = defineRealtimeExtension<
+      // Record<never, never>, NOT Record<string, never>. The latter says "every string key maps to
+      // never", which makes `Options & RealtimeOpenOptions` contradictory and rejects onMedia/onState/
+      // onDiagnostic at the call site — an extension with no product inputs of its own would otherwise
+      // be unable to receive any kernel option.
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/throwing",
+      defaultEndpoint: "test/throwing",
+      async open(context) {
+        context.media({ id: "s" } as unknown as MediaStream);
+        context.data("oops");
+        return { close: jest.fn(), reached: true } as never;
+      },
+    });
+
+    const session = await client.open(probe, {
+      onMedia: () => {
+        throw new Error("render exploded");
+      },
+      onData: () => {
+        throw new Error("parse exploded");
+      },
+    }).ready;
+    // open() resolved at all, which is the assertion: both throws were swallowed at the boundary.
+    expect((session.session as unknown as { reached: boolean }).reached).toBe(
+      true,
+    );
+    expect(session.state).toBe("live");
+  });
+
+  it("omitting the handlers is not an error an extension has to guard", async () => {
+    // So an extension can publish unconditionally instead of checking whether anyone is listening —
+    // brainrot returns no media at all, and the transform app returns no data.
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const probe = defineRealtimeExtension<
+      // Record<never, never>, NOT Record<string, never>. The latter says "every string key maps to
+      // never", which makes `Options & RealtimeOpenOptions` contradictory and rejects onMedia/onState/
+      // onDiagnostic at the call site — an extension with no product inputs of its own would otherwise
+      // be unable to receive any kernel option.
+      Record<never, never>,
+      RealtimeSession
+    >({
+      id: "test/silent",
+      defaultEndpoint: "test/silent",
+      async open(context) {
+        context.media({ id: "s" } as unknown as MediaStream);
+        context.data("ignored");
+        return { close: jest.fn() };
+      },
+    });
+    await expect(client.open(probe, {}).ready).resolves.toBeDefined();
+  });
+
+  it("context.fetch does not call the configured fetch as a method", async () => {
+    // A receiver-sensitive fetch, because native fetch is one: invoking it as config.fetch(...) sets
+    // `this` to the config object and throws "Illegal invocation". A plain jest.fn() has no opinion
+    // about its receiver and therefore cannot verify this constraint.
+    const picky = function (this: unknown, _url: string) {
+      if (this !== undefined && this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch': Illegal invocation");
+      }
+      return Promise.resolve(new Response("{}"));
+    };
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k", fetch: picky as any }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/receiver",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session");
+        return { close: jest.fn() };
+      },
+    });
+    await expect(
+      client.open(probe, { endpointId: "test/receiver" } as never).ready,
+    ).resolves.toBeDefined();
+  });
+
+  it("context.fetch honours the request middleware, so a proxied app stays proxied", async () => {
+    let target = "";
+    const client = createRealtimeClient({
+      config: createConfig({
+        credentials: "k",
+        requestMiddleware: async (request) => ({
+          ...request,
+          url: "https://proxy.example/forward",
+        }),
+        fetch: (async (url: string) => {
+          target = url;
+          return new Response("{}");
+        }) as any,
+      }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/proxy",
+      async open(context) {
+        await context.fetch("https://wma.fal.run/session");
+        return { close: jest.fn() };
+      },
+    });
+    await client.open(probe, { endpointId: "test/proxy" } as never).ready;
+    expect(target).toBe("https://proxy.example/forward");
+  });
+
+  it("reports a kernel-owned lifecycle the extension cannot contradict", async () => {
+    const states: string[] = [];
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/state",
+      // Claims to be live while the kernel is still opening; the kernel's value wins.
+      async open() {
+        return { close: jest.fn(), state: "live" as const };
+      },
+    });
+    const session = await client.open(probe, {
+      endpointId: "test/state",
+      onState: (next: string) => states.push(next),
+    } as never).ready;
+    expect(session.state).toBe("live");
+    await session.close();
+    expect(session.state).toBe("closed");
+    expect(states).toEqual(["live", "closed"]);
+  });
+
+  it("reports failed, not just closed, when opening throws", async () => {
+    const states: string[] = [];
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const broken = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/broken",
+      async open() {
+        throw new Error("negotiation failed");
+      },
+    });
+    await expect(
+      client.open(broken, {
+        endpointId: "test/broken",
+        onState: (next: string) => states.push(next),
+      } as never).ready,
+    ).rejects.toThrow("negotiation failed");
+    // "failed" and nothing after it. Teardown still runs, but reporting it would overwrite the only
+    // thing separating a crash from a clean teardown — and "closed" is what a caller would have seen
+    // anyway if this reported nothing at all.
+    expect(states).toEqual(["failed"]);
+  });
+
+  it("context.fail reports failed, not closed, and tears down", async () => {
+    // The distinction close() cannot express: a transport that died versus a user who disconnected.
+    // A status UI must be able to render those outcomes differently.
+    const states: string[] = [];
+    const events: unknown[] = [];
+    const cleanup = jest.fn();
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    let failFromInside: ((message: string) => Promise<void>) | undefined;
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/fail",
+      async open(context) {
+        context.addCleanup(cleanup);
+        failFromInside = (message) => context.fail(message, { relay: 0 });
+        return { close: jest.fn() };
+      },
+    });
+    const session = await client.open(probe, {
+      endpointId: "test/fail",
+      onState: (next: string) => states.push(next),
+      onDiagnostic: (event: unknown) => events.push(event),
+    } as never).ready;
+
+    await failFromInside!("peer connection died");
+    // "failed" latches over the teardown it triggers. Publishing "closed" afterward would erase the
+    // terminal cause, so anything rendering the latest value — a status pill or `session.state` —
+    // would misrepresent a dead transport as a clean disconnect.
+    expect(states).toEqual(["live", "failed"]);
+    expect(events).toEqual([
+      {
+        kind: "failure",
+        message: "peer connection died",
+        observed: { relay: 0 },
+      },
+    ]);
+    // Teardown really ran; failing is not a way to leak resources.
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(session.state).toBe("failed");
+
+    // And a close() afterwards cannot launder it into a clean ending.
+    await session.close();
+    expect(session.state).toBe("failed");
+    expect(states).toEqual(["live", "failed"]);
+  });
+
+  it("latches context.fail before a diagnostic callback can close", async () => {
+    const states: string[] = [];
+    const errors: unknown[] = [];
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    let failFromInside!: (message: string) => Promise<void>;
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/reentrant-fail-diagnostic",
+      async open(context) {
+        failFromInside = context.fail;
+        return { close: jest.fn() };
+      },
+    });
+    const sessionRef: { current?: ManagedRealtimeSession<RealtimeSession> } =
+      {};
+    const session = client.open(probe, {
+      endpointId: "test/reentrant-fail-diagnostic",
+      onState: (next: string) => states.push(next),
+      onError: (error: unknown) => errors.push(error),
+      onDiagnostic: (event: { kind: string }) => {
+        if (event.kind === "failure") void sessionRef.current?.close();
+      },
+    } as never);
+    sessionRef.current = session;
+    await session.ready;
+
+    await failFromInside("transport died");
+
+    expect(session.state).toBe("failed");
+    expect(states).toEqual(["live", "failed"]);
+    expect(errors).toEqual([
+      expect.objectContaining({ message: "transport died" }),
+    ]);
+  });
+
+  it("passes diagnostics through, and swallows a throwing callback", async () => {
+    const events: unknown[] = [];
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/diag",
+      async open(context) {
+        context.diagnostic({ kind: "progress", phase: "negotiating" });
+        context.diagnostic({
+          kind: "failure",
+          message: "no relay",
+          observed: { relay: 0 },
+        });
+        return { close: jest.fn() };
+      },
+    });
+    const session = await client.open(probe, {
+      endpointId: "test/diag",
+      onDiagnostic: (event: unknown) => {
+        events.push(event);
+        throw new Error("a caller's reporting bug must not fail the session");
+      },
+    } as never).ready;
+    expect(events).toEqual([
+      { kind: "progress", phase: "negotiating" },
+      { kind: "failure", message: "no relay", observed: { relay: 0 } },
+    ]);
+    await session.close();
+  });
+
+  it("an extension may report diagnostics with no onDiagnostic supplied", async () => {
+    const client = createRealtimeClient({
+      config: createConfig({ credentials: "k" }),
+    });
+    const probe = defineRealtimeExtension<
+      Record<string, never>,
+      RealtimeSession
+    >({
+      id: "test/quiet",
+      async open(context) {
+        // Must not throw: extensions report unconditionally rather than guarding every call.
+        context.diagnostic({ kind: "warning", message: "degraded" });
+        return { close: jest.fn() };
+      },
+    });
+    await expect(
+      client.open(probe, { endpointId: "test/quiet" } as never).ready,
+    ).resolves.toBeDefined();
+  });
+});

--- a/libs/client/src/realtime.spec.ts
+++ b/libs/client/src/realtime.spec.ts
@@ -24,6 +24,7 @@ class MockWebSocket {
 
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
+  static readonly CLOSED = 3;
 
   constructor(url: string) {
     this.url = url;
@@ -104,6 +105,230 @@ describe("createRealtimeClient", () => {
     expect(socket.url).toBe(
       "wss://fal.run/123/myapp/custom/path?fal_jwt_token=mock-token",
     );
+  });
+
+  it("evicts a closed connection and ignores its pending authentication", async () => {
+    let resolveToken: (token: string) => void = () => undefined;
+    const pendingToken = new Promise<string>((resolve) => {
+      resolveToken = resolve;
+    });
+    const tokenProvider = jest.fn(() => pendingToken);
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    first.send({ prompt: "start" });
+    await Promise.resolve();
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    first.close();
+    resolveToken("too-late");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(WebSocketMock).not.toHaveBeenCalled();
+
+    const nextTokenProvider = jest.fn().mockResolvedValue("fresh");
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider: nextTokenProvider,
+      onResult: jest.fn(),
+    });
+    second.send({ prompt: "restart" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(nextTokenProvider).toHaveBeenCalledTimes(1);
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a reused connection live when an older handle closes", async () => {
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    first.close();
+    second.send({ prompt: "still live" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+    second.close();
+  });
+
+  it("prevents an older reused handle from sending into the new owner", async () => {
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    first.send({ prompt: "stale" });
+    second.send({ prompt: "current" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(sockets).toHaveLength(1);
+    const socket = sockets[0];
+    socket.triggerOpen();
+    await Promise.resolve();
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(decode(socket.send.mock.calls[0][0])).toEqual({ prompt: "current" });
+    second.close();
+  });
+
+  it("lets the latest reused handle close despite a discarded older handle", async () => {
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    second.close();
+    first.send({ prompt: "must stay closed" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tokenProvider).not.toHaveBeenCalled();
+    expect(WebSocketMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers a trailing throttled send across a same-key reuse", async () => {
+    // A same-key reuse (a React re-render re-calling connect()) is the SAME logical consumer:
+    // its pending trailing sends must survive the re-render, or every send scheduled as a
+    // trailing timeout is silently dropped under continuous typing — the leading edge fires
+    // only once per connection lifetime, so that is effectively every send after the first.
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 20,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    first.send({ prompt: "leading" }); // leading edge goes through immediately
+    first.send({ prompt: "trailing" }); // scheduled before the re-render
+
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 20,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    jest.advanceTimersByTime(25); // the trailing send fires after the reuse
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sockets).toHaveLength(1);
+    const socket = sockets[0];
+    socket.triggerOpen();
+    await Promise.resolve();
+
+    // Both frames flow: the reuse did not orphan the pending trailing send.
+    const sent = socket.send.mock.calls.map((call: unknown[]) =>
+      decode(call[0] as Uint8Array),
+    );
+    expect(sent).toContainEqual({ prompt: "trailing" });
+    second.close();
+  });
+
+  it("drops a trailing throttled send after an explicit close", async () => {
+    // close() disposes the cache entry, and a trailing fire scheduled before it must not revive
+    // the connection or deliver through a machine the caller ended.
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const connection = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 20,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    connection.send({ prompt: "leading" });
+    connection.send({ prompt: "trailing after close" });
+    connection.close();
+    jest.advanceTimersByTime(25);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // close() lands before authentication completes: the disposed machine must not mint a
+    // socket at all, and the trailing fire must not revive it.
+    expect(sockets).toHaveLength(0);
+  });
+
+  it("drops a throttled send that was pending when the connection closed", async () => {
+    const tokenProvider = jest.fn(() => new Promise<string>(() => undefined));
+    const client = createRealtimeClient({ config });
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 20,
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    connection.send({ prompt: "starts auth" });
+    connection.send({ prompt: "must be dropped" });
+    await Promise.resolve();
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+
+    connection.close();
+    jest.advanceTimersByTime(25);
+    await Promise.resolve();
+
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(WebSocketMock).not.toHaveBeenCalled();
   });
 
   it("sends msgpack payloads by default", async () => {
@@ -204,6 +429,69 @@ describe("createRealtimeClient", () => {
     socket.onmessage?.({ data: JSON.stringify(result) });
     await Promise.resolve();
     expect(onResult).toHaveBeenCalledWith(result);
+  });
+
+  it("lets onClose reconnect: the idle transition lands before the callback", async () => {
+    // A consumer reacting to a clean remote goodbye by sending again must enter "connecting" —
+    // firing onClose while the machine is still "active" would strand the retry in the enqueued
+    // slot with no connection ever starting.
+    const tokenProvider = jest.fn().mockResolvedValue("shared-token");
+    const client = createRealtimeClient({ config });
+    const connection: { send: (input: unknown) => void; close: () => void } =
+      client.connect("123-myapp", {
+        connectionKey: `test-conn-${connectionId}`,
+        clientOnly: false,
+        throttleInterval: 0,
+        tokenProvider,
+        onResult: jest.fn(),
+        onClose: () => connection.send({ prompt: "reconnect" }),
+      });
+
+    connection.send({ prompt: "first" });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sockets).toHaveLength(1);
+    sockets[0].triggerOpen();
+    await Promise.resolve();
+
+    sockets[0].readyState = MockWebSocket.CLOSED;
+    sockets[0].onclose?.({ code: 1000, reason: "server done" });
+    // The reconnect re-authenticates (the closure expired the token) before opening a socket.
+    for (let flushes = 0; flushes < 10; flushes += 1) {
+      await Promise.resolve();
+    }
+
+    // The reconnect send moved the machine through idle into connecting: a second socket exists.
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+    connection.close();
+  });
+
+  it("delivers a falsy encoded message queued before the socket opened, without re-encoding", async () => {
+    // send() stores the ALREADY-ENCODED payload; a custom encoder can legitimately produce ""
+    // (an empty heartbeat frame). Truthiness gates would strand it, and the onopen flush must
+    // send the stored value verbatim rather than encoding it a second time.
+    const client = createRealtimeClient({ config });
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 0,
+      encodeMessage: () => "",
+      onResult: jest.fn(),
+      onError: jest.fn(),
+    });
+
+    connection.send({ ignored: true });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+    const socket = sockets[0];
+    socket.triggerOpen();
+    await Promise.resolve();
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(socket.send).toHaveBeenCalledWith("");
+    connection.close();
   });
 
   it("falls back to msgpack decode when receiving binary in json mode", async () => {
@@ -316,6 +604,113 @@ describe("createRealtimeClient", () => {
     expect(errorArg.status).toBe(400);
   });
 
+  it("drops a decoded result that finishes after the connection closes", async () => {
+    let finishDecode!: (value: unknown) => void;
+    const decoded = new Promise((resolve) => {
+      finishDecode = resolve;
+    });
+    const onResult = jest.fn();
+    const client = createRealtimeClient({ config });
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 0,
+      decodeMessage: () => decoded,
+      onResult,
+    });
+
+    connection.send({ prompt: "start" });
+    await Promise.resolve();
+    await Promise.resolve();
+    const socket = sockets[0];
+    socket.triggerOpen();
+    socket.onmessage?.({ data: "pending" });
+
+    connection.close();
+    finishDecode({ status: "ok", request_id: "late" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it("delivers a result decoded across a same-key reuse to the newest callbacks", async () => {
+    // A frame whose async decode spans a re-render belongs to the SAME logical stream — it must
+    // reach the newest render's onResult, not be silently discarded because the callbacks object
+    // identity changed mid-decode.
+    let finishDecode!: (value: unknown) => void;
+    const decoded = new Promise((resolve) => {
+      finishDecode = resolve;
+    });
+    const firstResult = jest.fn();
+    const secondResult = jest.fn();
+    const client = createRealtimeClient({ config });
+    const connectionKey = `test-conn-${connectionId}`;
+    const first = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      decodeMessage: () => decoded,
+      onResult: firstResult,
+    });
+
+    first.send({ prompt: "start" });
+    await Promise.resolve();
+    await Promise.resolve();
+    const socket = sockets[0];
+    socket.triggerOpen();
+    socket.onmessage?.({ data: "pending" });
+
+    const second = client.connect("123-myapp", {
+      connectionKey,
+      clientOnly: false,
+      throttleInterval: 0,
+      decodeMessage: () => decoded,
+      onResult: secondResult,
+    });
+    finishDecode({ status: "ok", request_id: "in-flight" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstResult).not.toHaveBeenCalled();
+    expect(secondResult).toHaveBeenCalledWith({
+      status: "ok",
+      request_id: "in-flight",
+    });
+    second.close();
+  });
+
+  it("drops a result decoded after the connection was closed", async () => {
+    // The stale case that must STAY dropped: a frame from a machine the caller already ended.
+    let finishDecode!: (value: unknown) => void;
+    const decoded = new Promise((resolve) => {
+      finishDecode = resolve;
+    });
+    const onResult = jest.fn();
+    const client = createRealtimeClient({ config });
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 0,
+      decodeMessage: () => decoded,
+      onResult,
+    });
+
+    connection.send({ prompt: "start" });
+    await Promise.resolve();
+    await Promise.resolve();
+    const socket = sockets[0];
+    socket.triggerOpen();
+    socket.onmessage?.({ data: "pending" });
+
+    connection.close();
+    finishDecode({ status: "ok", request_id: "stale" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
   it("uses custom tokenProvider when provided", async () => {
     const customTokenProvider = jest.fn().mockResolvedValue("custom-token");
     const client = createRealtimeClient({ config });
@@ -329,6 +724,7 @@ describe("createRealtimeClient", () => {
     });
 
     connection.send({ foo: "bar" });
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
@@ -378,11 +774,75 @@ describe("createRealtimeClient", () => {
     });
 
     connection.send({ foo: "bar" });
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let turn = 0; turn < 6; turn += 1) await Promise.resolve();
 
     expect(customTokenProvider).toHaveBeenCalledTimes(1);
     expect(WebSocketMock).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Token fetch failed",
+        status: 401,
+      }),
+    );
+  });
+
+  it("allows an onError callback to retry after token acquisition fails", async () => {
+    const tokenProvider = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("first token failed"))
+      .mockResolvedValueOnce("recovered-token");
+    const client = createRealtimeClient({ config });
+    const connectionRef: {
+      current?: ReturnType<typeof client.connect>;
+    } = {};
+    const onError = jest.fn(() =>
+      connectionRef.current?.send({ request_id: "attempt-2" }),
+    );
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+      onError,
+    });
+    connectionRef.current = connection;
+
+    connection.send({ request_id: "attempt-1" });
+    for (let turn = 0; turn < 6; turn += 1) await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(tokenProvider).toHaveBeenCalledTimes(2);
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits authInProgress even when the error callback throws", async () => {
+    const tokenProvider = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("first token failed"))
+      .mockResolvedValueOnce("recovered-token");
+    const client = createRealtimeClient({ config });
+    const connection = client.connect("123-myapp", {
+      connectionKey: `test-conn-${connectionId}`,
+      clientOnly: false,
+      throttleInterval: 0,
+      tokenProvider,
+      onResult: jest.fn(),
+      onError: () => {
+        throw new Error("render failed");
+      },
+    });
+
+    connection.send({ attempt: 1 });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    connection.send({ attempt: 2 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tokenProvider).toHaveBeenCalledTimes(2);
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses default getTemporaryAuthToken when tokenProvider is not provided", async () => {

--- a/libs/client/src/realtime.ts
+++ b/libs/client/src/realtime.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { decode, encode } from "@msgpack/msgpack";
+import { encode } from "@msgpack/msgpack";
 import {
   ContextFunction,
   InterpretOnChangeFunction,
@@ -14,18 +14,61 @@ import {
 } from "robot3";
 import {
   TOKEN_EXPIRATION_SECONDS,
-  type TokenProvider,
   getTemporaryAuthToken,
+  type TokenProvider,
 } from "./auth";
 import { RequiredConfig } from "./config";
+import type {
+  AnyRealtimeExtension,
+  ManagedRealtimeSession,
+  RealtimeDiagnostic,
+  RealtimeExtensionOptions,
+  RealtimeExtensionSession,
+  RealtimeOpenOptions,
+  RealtimeSession,
+  RealtimeState,
+} from "./realtime/extension";
+import { gatherIceCandidates } from "./realtime/ice";
+import {
+  DEFAULT_THROTTLE_INTERVAL,
+  WebSocketErrorCodes,
+  buildRealtimeUrl,
+  decodeRealtimeMessage,
+  encodeRealtimeMessage,
+  isFalErrorResult,
+  isSuccessfulResult,
+  isUnauthorizedError,
+  realtimeTokenScope,
+  type WithRequestId,
+} from "./realtime/protocol";
 import { ApiError } from "./response";
 import { isBrowser } from "./runtime";
-import {
-  ensureEndpointIdFormat,
-  isReact,
-  resolveEndpointPath,
-  throttle,
-} from "./utils";
+import type { EndpointType, InputType, OutputType } from "./types/client";
+import type { Result, RunOptions } from "./types/common";
+import { isReact, throttle } from "./utils";
+
+const FAL_SERVICE_HOSTS = new Set(["wma.fal.run"]);
+
+function assertFalInfrastructureUrl(rawUrl: string): void {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("Realtime infrastructure fetch requires an absolute URL.");
+  }
+
+  const host = url.host.toLowerCase();
+  const isFalInfrastructure =
+    url.protocol === "https:" &&
+    (host === "fal.ai" ||
+      host.endsWith(".fal.ai") ||
+      FAL_SERVICE_HOSTS.has(host));
+  if (!isFalInfrastructure) {
+    throw new Error(
+      "Realtime infrastructure fetch is restricted to fal-operated HTTPS hosts.",
+    );
+  }
+}
 
 // Define the context
 interface Context {
@@ -176,10 +219,6 @@ const connectionStateMachine = createMachine(
   initialState,
 );
 
-type WithRequestId = {
-  request_id: string;
-};
-
 /**
  * A connection object that allows you to `send` request payloads to a
  * realtime endpoint.
@@ -216,7 +255,7 @@ export interface RealtimeConnectionHandler<Output> {
   clientOnly?: boolean;
 
   /**
-   * The throtle duration in milliseconds. This is used to throtle the
+   * The throttle duration in milliseconds. This is used to throttle the
    * calls to the `send` function. Realtime apps usually react to user
    * input, which can be very frequent (e.g. fast typing or mouse/drag movements).
    *
@@ -265,6 +304,14 @@ export interface RealtimeConnectionHandler<Output> {
   onError?(error: ApiError<any>): void;
 
   /**
+   * Called when the connection closes NORMALLY (code 1000) from the remote side. Abnormal
+   * closures keep reporting through `onError`. Optional and additive: consumers that treat this
+   * connection as a live session (a signaling ride-along, say) need to hear a clean remote
+   * goodbye that is not an error, or they keep reporting live over a socket that is gone.
+   */
+  onClose?(event: { code: number; reason: string }): void;
+
+  /**
    * A custom token provider function. When provided, this function will be
    * used to fetch authentication tokens instead of the default internal
    * token fetching mechanism.
@@ -296,53 +343,32 @@ export interface RealtimeClient {
     app: string,
     handler: RealtimeConnectionHandler<Output>,
   ): RealtimeConnection<Input>;
+
+  /**
+   * Open a model-specific realtime session with an explicitly supplied
+   * extension. This form preserves the extension's options and session types.
+   *
+   * Returns the managed session SYNCHRONOUSLY, in state `"opening"`, while negotiation starts
+   * eagerly behind it — the caller holds a usable handle immediately, `send()` queues until the
+   * session is live, and failures arrive through `onError` and `onState("failed")`. Await
+   * `session.ready` for the promise-style call site; misconfiguration (no endpoint, an endpoint
+   * the extension rejects) still throws synchronously.
+   *
+   * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+   */
+  open<Extension extends AnyRealtimeExtension>(
+    extension: Extension,
+    options: RealtimeExtensionOptions<Extension> & RealtimeOpenOptions,
+  ): ManagedRealtimeSession<RealtimeExtensionSession<Extension>>;
 }
-
-type RealtimeUrlParams = {
-  token: string;
-  maxBuffering?: number;
-  path?: string;
-};
-
-function buildRealtimeUrl(
-  app: string,
-  { token, maxBuffering, path }: RealtimeUrlParams,
-): string {
-  if (maxBuffering !== undefined && (maxBuffering < 1 || maxBuffering > 60)) {
-    throw new Error("The `maxBuffering` must be between 1 and 60 (inclusive)");
-  }
-  const queryParams = new URLSearchParams({
-    fal_jwt_token: token,
-  });
-  if (maxBuffering !== undefined) {
-    queryParams.set("max_buffering", maxBuffering.toFixed(0));
-  }
-  const appId = ensureEndpointIdFormat(app);
-  const resolvedPath = resolveEndpointPath(app, path, "/realtime") ?? "";
-  return `wss://fal.run/${appId}${resolvedPath}?${queryParams.toString()}`;
-}
-
-const DEFAULT_THROTTLE_INTERVAL = 128;
-
-function isUnauthorizedError(message: any): boolean {
-  // TODO we need better protocol definition with error codes
-  return message["status"] === "error" && message["error"] === "Unauthorized";
-}
-
-/**
- * See https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
- */
-const WebSocketErrorCodes = {
-  NORMAL_CLOSURE: 1000,
-  GOING_AWAY: 1001,
-};
 
 type ConnectionStateMachine = {
   service: Service<typeof connectionStateMachine>;
-  throttledSend: (
-    event: Event,
-    payload?: any,
-  ) => void | Promise<void> | undefined;
+  throttledSend: (event: Event) => void | Promise<void> | undefined;
+  callbacks: RealtimeConnectionCallback;
+  dispose: () => void;
+  disposed: boolean;
+  handleId: symbol;
 };
 
 type ConnectionOnChange = InterpretOnChangeFunction<
@@ -351,27 +377,49 @@ type ConnectionOnChange = InterpretOnChangeFunction<
 
 type RealtimeConnectionCallback = Pick<
   RealtimeConnectionHandler<any>,
-  "onResult" | "onError" | "decodeMessage"
+  "onResult" | "onError" | "onClose" | "decodeMessage"
 >;
 
 const connectionCache = new Map<string, ConnectionStateMachine>();
-const connectionCallbacks = new Map<string, RealtimeConnectionCallback>();
 function reuseInterpreter(
   key: string,
   throttleInterval: number,
   onChange: ConnectionOnChange,
+  callbacks: RealtimeConnectionCallback,
+  dispose: () => void,
+  handleId: symbol,
 ) {
   if (!connectionCache.has(key)) {
     const service = interpret(connectionStateMachine, onChange);
-    connectionCache.set(key, {
+    // A trailing throttled send fires after it was scheduled, so it re-checks the CONNECTION at
+    // fire time: the cache entry must still be this one and not disposed. Deliberately NOT the
+    // scheduling handle's identity — a same-key reuse (a React re-render re-calling connect())
+    // is the same logical consumer, and its pending trailing sends must survive the re-render.
+    // Ownership against a genuinely stale handle is enforced at send() call time, and a fire
+    // after an explicit close() is blocked by the disposed/cache-identity checks here.
+    const guardedSend = (event: Event) => {
+      if (connectionCache.get(key) === cached && !cached.disposed) {
+        return service.send(event);
+      }
+    };
+    const cached: ConnectionStateMachine = {
       service,
       throttledSend:
         throttleInterval > 0
-          ? throttle(service.send, throttleInterval, true)
+          ? throttle(guardedSend, throttleInterval, true)
           : service.send,
-    });
+      callbacks,
+      dispose,
+      disposed: false,
+      handleId,
+    };
+    connectionCache.set(key, cached);
   }
-  return connectionCache.get(key) as ConnectionStateMachine;
+  const cached = connectionCache.get(key) as ConnectionStateMachine;
+  cached.handleId = handleId;
+  cached.callbacks = callbacks;
+  cached.disposed = false;
+  return cached;
 }
 
 const noop = () => {
@@ -389,64 +437,15 @@ const NoOpConnection: RealtimeConnection<any> = {
   close: noop,
 };
 
-function isSuccessfulResult(data: any): boolean {
-  return (
-    data.status !== "error" &&
-    data.type !== "x-fal-message" &&
-    !isFalErrorResult(data)
-  );
-}
-
-type FalErrorResult = {
-  type: "x-fal-error";
-  error: string;
-  reason: string;
-};
-
-function isFalErrorResult(data: any): data is FalErrorResult {
-  return data.type === "x-fal-error";
-}
-
 type RealtimeClientDependencies = {
   config: RequiredConfig;
-};
-
-async function decodeRealtimeMessage(data: any): Promise<any> {
-  if (typeof data === "string") {
-    return JSON.parse(data);
-  }
-
-  const toUint8Array = async (
-    value: ArrayBuffer | Uint8Array | Blob,
-  ): Promise<Uint8Array> => {
-    if (value instanceof Uint8Array) {
-      return value;
-    }
-    if (value instanceof Blob) {
-      return new Uint8Array(await value.arrayBuffer());
-    }
-    return new Uint8Array(value);
+  getClient?: () => {
+    run<Id extends EndpointType>(
+      endpointId: Id,
+      options: RunOptions<InputType<Id>>,
+    ): Promise<Result<OutputType<Id>>>;
   };
-
-  if (data instanceof ArrayBuffer || data instanceof Uint8Array) {
-    return decode(await toUint8Array(data));
-  }
-  if (data instanceof Blob) {
-    return decode(await toUint8Array(data));
-  }
-
-  return data;
-}
-
-function encodeRealtimeMessage(input: any): Uint8Array | string {
-  if (input instanceof Uint8Array) {
-    return input;
-  }
-  if (typeof input === "string") {
-    return encode(input);
-  }
-  return encode(input);
-}
+};
 
 type HandleRealtimeMessageParams = {
   data: any;
@@ -454,6 +453,7 @@ type HandleRealtimeMessageParams = {
   onResult: RealtimeConnectionCallback["onResult"];
   onError: NonNullable<RealtimeConnectionCallback["onError"]> | typeof noop;
   send: ConnectionStateMachine["service"]["send"];
+  isCurrent: () => boolean;
 };
 
 function handleRealtimeMessage({
@@ -462,6 +462,7 @@ function handleRealtimeMessage({
   onResult,
   onError,
   send,
+  isCurrent,
 }: HandleRealtimeMessageParams) {
   const handleDecoded = (decoded: any) => {
     // Drop messages that are not related to the actual result.
@@ -498,8 +499,11 @@ function handleRealtimeMessage({
   };
 
   Promise.resolve(decodeMessage ? decodeMessage(data) : data)
-    .then(handleDecoded)
+    .then((decoded) => {
+      if (isCurrent()) handleDecoded(decoded);
+    })
     .catch((error) => {
+      if (!isCurrent()) return;
       onError(
         new ApiError({
           message:
@@ -512,8 +516,9 @@ function handleRealtimeMessage({
 
 export function createRealtimeClient({
   config,
+  getClient,
 }: RealtimeClientDependencies): RealtimeClient {
-  return {
+  const realtimeClient: RealtimeClient = {
     connect<Input, Output>(
       app: string,
       handler: RealtimeConnectionHandler<Output>,
@@ -533,6 +538,11 @@ export function createRealtimeClient({
       if (clientOnly && !isBrowser()) {
         return NoOpConnection;
       }
+      // Validated HERE, where the caller can catch it: the realtime socket address is derived
+      // from an app id, so a URL or malformed string can never work — and a throw deferred into
+      // the state machine's auth step would fire from inside send() after the machine already
+      // transitioned, stranding it in authInProgress with no error routed anywhere.
+      const tokenScope = realtimeTokenScope(app, path);
 
       const encodeMessageFn =
         encodeMessageOverride ?? ((input: any) => encodeRealtimeMessage(input));
@@ -549,13 +559,19 @@ export function createRealtimeClient({
       // when the state machine is reused. This is needed because the callbacks
       // are passed as part of the handler object, which can be different across
       // different calls to `connect`.
-      connectionCallbacks.set(connectionKey, {
+      const callbacks: RealtimeConnectionCallback = {
         decodeMessage: decodeMessageFn,
         onError: handler.onError,
         onResult: handler.onResult,
-      });
-      const getCallbacks = () =>
-        connectionCallbacks.get(connectionKey) as RealtimeConnectionCallback;
+        onClose: handler.onClose,
+      };
+      const handleId = Symbol(connectionKey);
+      const dispose = () => {
+        tokenRefreshGeneration++;
+        clearTimeout(tokenRefreshTimer);
+        tokenRefreshTimer = undefined;
+      };
+      const getCallbacks = () => connectionCache.get(connectionKey)?.callbacks;
       const stateMachine = reuseInterpreter(
         connectionKey,
         throttleInterval,
@@ -564,7 +580,9 @@ export function createRealtimeClient({
           latestEnqueuedMessage = enqueuedMessage;
           if (
             machine.current === "active" &&
-            enqueuedMessage &&
+            // Explicit undefined check: the message is already encoded, and a custom encoder can
+            // legitimately produce "" (an empty heartbeat frame) — truthiness would strand it.
+            enqueuedMessage !== undefined &&
             websocket?.readyState === WebSocket.OPEN
           ) {
             send({ type: "send", message: enqueuedMessage });
@@ -578,11 +596,9 @@ export function createRealtimeClient({
             tokenRefreshGeneration++;
             const generation = tokenRefreshGeneration;
             // Use custom tokenProvider if provided, otherwise use default
-            const appId = ensureEndpointIdFormat(app);
-            const resolvedPath =
-              resolveEndpointPath(app, path, "/realtime") ?? "";
+            const scope = tokenScope;
             const fetchToken = tokenProvider
-              ? () => tokenProvider(`${appId}${resolvedPath}`)
+              ? () => tokenProvider(scope)
               : () => {
                   console.warn(
                     "[fal.realtime] Using the default token provider is deprecated. " +
@@ -599,26 +615,38 @@ export function createRealtimeClient({
             const scheduleTokenRefresh =
               effectiveExpiration !== undefined
                 ? () => {
+                    if (stateMachine.disposed) return;
                     clearTimeout(tokenRefreshTimer);
                     const refreshMs = Math.round(
                       effectiveExpiration * 0.9 * 1000,
                     );
                     tokenRefreshTimer = setTimeout(() => {
-                      if (generation !== tokenRefreshGeneration) {
+                      if (
+                        stateMachine.disposed ||
+                        generation !== tokenRefreshGeneration
+                      ) {
                         return;
                       }
                       fetchToken()
                         .then((newToken) => {
-                          if (generation !== tokenRefreshGeneration) {
+                          if (
+                            stateMachine.disposed ||
+                            generation !== tokenRefreshGeneration
+                          ) {
                             return;
                           }
                           queueMicrotask(() => {
-                            send({ type: "authenticated", token: newToken });
+                            if (!stateMachine.disposed) {
+                              send({ type: "authenticated", token: newToken });
+                            }
                           });
                           scheduleTokenRefresh();
                         })
                         .catch(() => {
-                          if (generation !== tokenRefreshGeneration) {
+                          if (
+                            stateMachine.disposed ||
+                            generation !== tokenRefreshGeneration
+                          ) {
                             return;
                           }
                           const retryMs = Math.round(
@@ -634,14 +662,39 @@ export function createRealtimeClient({
 
             fetchToken()
               .then((token) => {
+                if (stateMachine.disposed) return;
                 queueMicrotask(() => {
-                  send({ type: "authenticated", token });
+                  if (!stateMachine.disposed) {
+                    send({ type: "authenticated", token });
+                  }
                 });
                 scheduleTokenRefresh();
               })
               .catch((error) => {
+                if (stateMachine.disposed) return;
+                const { onError = noop } = getCallbacks() ?? {};
+                const authError =
+                  error instanceof ApiError
+                    ? error
+                    : new ApiError({
+                        message:
+                          error instanceof Error
+                            ? error.message
+                            : String(error),
+                        status: 401,
+                        body: error,
+                      });
                 queueMicrotask(() => {
+                  if (stateMachine.disposed) return;
+                  // Finish the transition before giving application code a chance to retry.
+                  // Otherwise a synchronous send() from onError is queued in authInProgress and
+                  // then stranded when unauthorized moves the machine back to idle.
                   send({ type: "unauthorized", error });
+                  try {
+                    onError(authError);
+                  } catch {
+                    // A caller's callback must not strand the state machine in authInProgress.
+                  }
                 });
               });
           }
@@ -654,12 +707,19 @@ export function createRealtimeClient({
               buildRealtimeUrl(app, { token, maxBuffering, path }),
             );
             ws.onopen = () => {
+              if (stateMachine.disposed) {
+                ws.close();
+                return;
+              }
               send({ type: "connected", websocket: ws });
               const queued =
                 stateMachine.service.context?.enqueuedMessage ??
                 latestEnqueuedMessage;
-              if (queued) {
-                ws.send(encodeMessageFn(queued));
+              // The queued value was encoded by send() already — re-encoding would double-encode
+              // custom string framings — and "" is a legitimate encoded frame, so the gate is an
+              // explicit undefined check rather than truthiness.
+              if (queued !== undefined) {
+                ws.send(queued);
                 stateMachine.service.context = {
                   ...stateMachine.service.context,
                   enqueuedMessage: undefined,
@@ -667,8 +727,9 @@ export function createRealtimeClient({
               }
             };
             ws.onclose = (event) => {
+              if (stateMachine.disposed) return;
               if (event.code !== WebSocketErrorCodes.NORMAL_CLOSURE) {
-                const { onError = noop } = getCallbacks();
+                const { onError = noop } = getCallbacks() ?? {};
                 onError(
                   new ApiError({
                     message: `Error closing the connection: ${event.reason}`,
@@ -676,38 +737,89 @@ export function createRealtimeClient({
                   }),
                 );
               }
-              send({ type: "connectionClosed", code: event.code });
+              send({
+                type: "connectionClosed",
+                code: event.code,
+                reason: event.reason,
+              });
+              if (event.code === WebSocketErrorCodes.NORMAL_CLOSURE) {
+                // A NORMAL closure is not an error, but a consumer that treats this connection as
+                // a live session (Lucy's signaling ride-along) still needs to hear it — silence
+                // here would leave that session reporting live over a socket that is gone.
+                // AFTER the idle transition, so a callback that synchronously send()s to
+                // reconnect enters "connecting" instead of enqueueing into a still-"active"
+                // machine that is about to move to idle without a connection.
+                getCallbacks()?.onClose?.({
+                  code: event.code,
+                  reason: event.reason,
+                });
+              }
             };
-            ws.onerror = (event) => {
+            ws.onerror = () => {
+              if (stateMachine.disposed) return;
               // TODO specify error protocol for identified errors
-              const { onError = noop } = getCallbacks();
+              const { onError = noop } = getCallbacks() ?? {};
               onError(new ApiError({ message: "Unknown error", status: 500 }));
             };
             ws.onmessage = (event) => {
-              const {
-                decodeMessage = decodeMessageFn,
-                onResult,
-                onError = noop,
-              } = getCallbacks();
+              const callbacks = getCallbacks();
+              if (!callbacks || stateMachine.disposed) return;
+              const { decodeMessage = decodeMessageFn } = callbacks;
 
               handleRealtimeMessage({
                 data: event.data,
                 decodeMessage,
-                onResult,
-                onError,
+                // Delivered to the callbacks that are current AT DELIVERY, not the ones captured
+                // when the frame arrived: a same-key reuse (a React re-render) during the async
+                // decode swaps in the newest render's closures, and the frame belongs to them —
+                // freezing the arrival-time identity turned every such re-render into silent
+                // frame loss.
+                onResult: (result) => {
+                  getCallbacks()?.onResult(result);
+                },
+                onError: (error) => {
+                  (getCallbacks()?.onError ?? noop)(error);
+                },
                 send,
+                isCurrent: () => {
+                  const current = connectionCache.get(connectionKey);
+                  const activeSocket = stateMachine.service.context.websocket;
+                  // `undefined` still delivers: a clean close clears the machine's socket while a
+                  // final frame is mid-decode, and that frame belongs to the caller. Only a
+                  // DIFFERENT socket — a reconnect superseding this one — marks frames stale.
+                  return (
+                    current === stateMachine &&
+                    !stateMachine.disposed &&
+                    (activeSocket === ws || activeSocket === undefined)
+                  );
+                },
               });
             };
           }
           if (previousState === "active" && machine.current !== "active") {
+            // The generation bump invalidates an in-flight fetchToken as well as the timer: its
+            // .then would otherwise pass the stale-generation check and re-arm the refresh loop
+            // on an idle connection, hitting the caller's tokenProvider forever.
+            tokenRefreshGeneration++;
             clearTimeout(tokenRefreshTimer);
             tokenRefreshTimer = undefined;
           }
           previousState = machine.current;
         },
+        callbacks,
+        dispose,
+        handleId,
       );
 
+      let handleClosed = false;
       const send = (input: Input & Partial<WithRequestId>) => {
+        if (
+          handleClosed ||
+          stateMachine.disposed ||
+          stateMachine.handleId !== handleId
+        ) {
+          return;
+        }
         // Use throttled send to avoid sending too many messages
         stateMachine.throttledSend({
           type: "send",
@@ -716,7 +828,16 @@ export function createRealtimeClient({
       };
 
       const close = () => {
+        if (handleClosed) return;
+        handleClosed = true;
+        // Reusing a connection key transfers ownership to the newest handle. A stale
+        // render must not close it, and a discarded stale handle must not keep it alive.
+        if (stateMachine.handleId !== handleId) return;
+        if (stateMachine.disposed) return;
+        stateMachine.disposed = true;
+        stateMachine.dispose();
         stateMachine.service.send({ type: "close" });
+        connectionCache.delete(connectionKey);
       };
 
       return {
@@ -724,5 +845,928 @@ export function createRealtimeClient({
         close,
       };
     },
+    open: undefined as unknown as RealtimeClient["open"],
   };
+
+  function open(
+    extension: AnyRealtimeExtension,
+    options: unknown,
+  ): RealtimeSession {
+    const rawOptionEndpointId =
+      typeof options === "object" && options !== null && "endpointId" in options
+        ? (options as { endpointId: unknown }).endpointId
+        : undefined;
+    const optionEndpointId =
+      rawOptionEndpointId == null ? undefined : String(rawOptionEndpointId);
+    const endpointId = optionEndpointId ?? extension.defaultEndpoint ?? "";
+
+    if (!endpointId) {
+      throw new Error(
+        `Realtime extension "${extension.id}" requires an endpointId option when opened explicitly.`,
+      );
+    }
+    // Extensions that own no closed set of endpoints omit this entirely; see RealtimeExtension.
+    if (extension.supports?.(endpointId) === false) {
+      throw new Error(
+        `Realtime extension "${extension.id}" does not support "${endpointId}".`,
+      );
+    }
+
+    const externalSignal = (options as { abortSignal?: AbortSignal })
+      ?.abortSignal;
+    const controller = new AbortController();
+    const cleanups: Array<() => void | Promise<void>> = [];
+    // THUNKS, executed only by the drain — not eagerly-started promises. A release registered
+    // while the main teardown loop is still running must wait its turn behind the remaining
+    // releases, or the documented once-in-reverse-order contract silently interleaves.
+    const lateCleanups: Array<() => void | Promise<void>> = [];
+    // A running late cleanup may register another one; the loop re-checks until empty, so an
+    // awaited close() really means every registration finished.
+    let lateCleanupDrainPromise: Promise<void> | undefined;
+    const drainLateCleanups = (): Promise<void> => {
+      if (lateCleanupDrainPromise) return lateCleanupDrainPromise;
+      const drain = async () => {
+        while (lateCleanups.length > 0) {
+          const release = lateCleanups.shift() as () => void | Promise<void>;
+          try {
+            await release();
+          } catch {
+            // Late registration follows the same best-effort rule as normal teardown.
+          }
+        }
+      };
+      lateCleanupDrainPromise = drain().finally(() => {
+        lateCleanupDrainPromise = undefined;
+        // A detached microtask can enqueue after the loop's final empty check but before this
+        // promise settles. Chain the follow-up worker so an in-progress teardown still awaits it.
+        if (lateCleanups.length > 0) return drainLateCleanups();
+      });
+      return lateCleanupDrainPromise;
+    };
+    // True for the whole teardown body: late registrations made during it are picked up by the
+    // body's own drain; registrations after teardown COMPLETED start their own drain. Between
+    // closed=true and the body running (an abort listener's registration), the pending body
+    // covers them — starting a drain there would run releases before the session close hook.
+    let teardownRunning = false;
+    let teardownCompleted = false;
+    let closed = false;
+    let cleanupPromise: Promise<void> | undefined;
+    let session: RealtimeSession | undefined;
+    let extensionClose: (() => void | Promise<void>) | undefined;
+    let sessionClosePromise: Promise<void> | undefined;
+    let sessionCloseInProgress = false;
+    // Owned by the kernel, not the extension. The kernel is the only thing that knows about abort,
+    // failed opens and idempotent close, so it is the only thing that can report those honestly —
+    // and an extension's own state field cannot then contradict it.
+    let state: RealtimeState = "opening";
+    const onState = (options as { onState?: (next: RealtimeState) => void })
+      ?.onState;
+    // "failed" and "closed" are both TERMINAL, and failure latches over the teardown that follows it.
+    // Without that, `fail()` was self-defeating: it set "failed" and then immediately called
+    // cleanup(), which set "closed" — so the distinction it exists to draw survived only in the
+    // instant between two synchronous calls, and anything rendering from the latest value (a status
+    // pill, `session.state`) showed a died session as a clean disconnect.
+    const setState = (next: RealtimeState) => {
+      if (state === next || state === "closed" || state === "failed") return;
+      state = next;
+      try {
+        onState?.(next);
+      } catch {
+        // A caller's callback must never be able to fail a session.
+      }
+    };
+
+    const closeSession = (): Promise<void> => {
+      if (!extensionClose) return Promise.resolve();
+      if (!sessionClosePromise) {
+        const closeExtension = extensionClose;
+        sessionClosePromise = Promise.resolve().then(async () => {
+          sessionCloseInProgress = true;
+          try {
+            await closeExtension();
+          } finally {
+            sessionCloseInProgress = false;
+          }
+        });
+      }
+      return sessionClosePromise;
+    };
+
+    const cleanup = (): Promise<void> => {
+      if (cleanupPromise) return cleanupPromise;
+      closed = true;
+      // A terminal handle can remain in application state indefinitely. Release inputs queued
+      // during negotiation now rather than retaining up to 64 potentially large payloads on a
+      // session that can never flush them.
+      queuedSends.length = 0;
+      cleanupPromise = Promise.resolve().then(async () => {
+        teardownRunning = true;
+        try {
+          await closeSession();
+        } catch {
+          // Teardown is best-effort; a broken extension close hook must not leak rejection.
+        } finally {
+          // splice() consumes the list, so any reentrant call that slips past the memo can never
+          // run a release twice, and reverse() no longer mutates a shared array.
+          for (const release of cleanups.splice(0).reverse()) {
+            try {
+              await release();
+            } catch {
+              // Teardown is best-effort; one failed release must not prevent the
+              // remaining resources from being closed.
+            }
+          }
+          // Publish completion before the final drain. A cleanup can schedule addCleanup() through
+          // detached microtasks that land after this drain has observed an empty queue; those
+          // registrations must see the completed state and start a fresh drain instead of being
+          // stranded forever between the drain and this flag.
+          teardownCompleted = true;
+          await drainLateCleanups();
+          teardownRunning = false;
+        }
+      });
+      // EVERY synchronous callback fired below can re-enter cleanup() — onState("closed") through
+      // a caller that closes on seeing "closed", abort listeners through context.close() or
+      // context.fail() — so the shared teardown promise is published before any of them run.
+      setState("closed");
+      controller.abort();
+      externalSignal?.removeEventListener("abort", abort);
+      // A promise-shaped terminal signal even against an extension whose open() ignores the
+      // abort signal and never settles: openTask's catch would be the normal rejection site,
+      // but it is unreachable while extension.open() is parked. No-op once ready settled.
+      // Skipped on the failed path — there the real error reaches rejectReady through fail()
+      // or openTask's catch, and this generic reason must not beat it to the promise.
+      if (state !== "failed") {
+        rejectReady(
+          controller.signal.reason ?? new Error("Realtime session closed"),
+        );
+      }
+      return cleanupPromise;
+    };
+    const abort = () => {
+      // The closed latch rises BEFORE the managed abort broadcasts: controller.abort() invokes
+      // extension listeners synchronously, and one reacting with context.fail() must see the
+      // session as already ending — or an intentional caller cancellation gets relabeled as a
+      // transport failure ("failed" + onError).
+      closed = true;
+      controller.abort(externalSignal?.reason);
+      void cleanup();
+    };
+    // What the CALLER's close() returns. A close during negotiation must not report done while the
+    // extension can still hand back a resource-bearing session — the opening task observes the
+    // abort and tears any late session down, so completion includes the task. The task itself only
+    // ever awaits cleanup(), never this wrapper, so an extension that closes or fails from inside
+    // its own open() cannot deadlock against it.
+    // Assigned once, after the handle exists — publicClose only reads it through a closure, which
+    // prefer-const cannot see past.
+    // eslint-disable-next-line prefer-const
+    let openTaskPromise: Promise<void> | undefined;
+    let publicClosePromise: Promise<void> | undefined;
+    const publicClose = (): Promise<void> => {
+      // Memoized so every concurrent close awaits the same teardown, the same identity guarantee
+      // cleanup() itself makes.
+      if (!publicClosePromise) {
+        const teardown = cleanup();
+        // Unconditionally through the open task: close() documents that it covers a session the
+        // extension hands back LATE, which requires waiting for extension.open() to settle. The
+        // price is that close() shares the fate of an extension that ignores its abort signal
+        // and never settles — ready rejects promptly either way, so callers always have a
+        // terminal signal even against such an extension.
+        publicClosePromise = openTaskPromise
+          ? teardown.then(() => openTaskPromise)
+          : teardown;
+      }
+      return publicClosePromise;
+    };
+    // Dropped when the caller did not ask, so an extension can report unconditionally rather than
+    // guarding every call site.
+    const onDiagnostic = (
+      options as { onDiagnostic?: (event: RealtimeDiagnostic) => void }
+    )?.onDiagnostic;
+    const diagnostic = (event: RealtimeDiagnostic) => {
+      try {
+        onDiagnostic?.(event);
+      } catch {
+        // A caller's reporting callback must never be able to fail a session.
+      }
+    };
+    // Same swallow-and-continue rule as diagnostics, and for a sharper reason: these fire from inside
+    // `pc.ontrack` and `channel.onmessage`, where a throw lands in a browser event handler that no
+    // caller can catch. An application whose render throws must not take the session with it.
+    const onMedia = (options as { onMedia?: (stream: MediaStream) => void })
+      ?.onMedia;
+    const media = (stream: MediaStream) => {
+      if (closed) return;
+      try {
+        onMedia?.(stream);
+      } catch {
+        // A caller's media handler must never be able to fail a session.
+      }
+    };
+    const onData = (options as { onData?: (raw: string) => void })?.onData;
+    const data = (raw: string) => {
+      if (closed) return;
+      try {
+        onData?.(raw);
+      } catch {
+        // Nor a caller's message handler — one unparseable payload is not a dead session.
+      }
+    };
+    if (externalSignal?.aborted) {
+      // Not a synchronous throw: an already-aborted signal is a legitimate race (a component
+      // unmounting mid-render), not a programmer error. The opening task observes the aborted
+      // controller before calling the extension and fails the handle through the normal channels.
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal?.addEventListener("abort", abort, { once: true });
+    }
+
+    // The failure channel for the synchronous handle: there is no returned promise whose
+    // rejection could carry a terminal error, so it is delivered once through onError — and
+    // through `ready` for callers who chose the awaited style.
+    const onError = (options as { onError?: (error: unknown) => void })
+      ?.onError;
+    let errorReported = false;
+    const reportError = (error: unknown) => {
+      if (errorReported) return;
+      errorReported = true;
+      try {
+        onError?.(error);
+      } catch {
+        // A caller's error handler must never be able to fail teardown.
+      }
+    };
+    let resolveReady!: (value: RealtimeSession) => void;
+    let rejectReady!: (error: unknown) => void;
+    const ready = new Promise<RealtimeSession>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    // A caller may consume the session entirely through callbacks; an ignored `ready` must not
+    // surface a failed open as an unhandled rejection.
+    ready.catch(() => undefined);
+
+    // The handle is usable the moment open() returns: sends while "opening" are queued, bounded,
+    // and flushed in order the instant the session is live. Oldest-first eviction, because for a
+    // realtime input stream the newest message is the one that still matters. After a terminal
+    // state sends are dropped, mirroring what the extensions do with a dead transport.
+    const MAX_QUEUED_SENDS = 64;
+    const queuedSends: unknown[][] = [];
+    let warnedQueueOverflow = false;
+    const queuedSend = (...args: unknown[]) => {
+      if (state !== "opening") return;
+      if (queuedSends.length >= MAX_QUEUED_SENDS) {
+        queuedSends.shift();
+        if (!warnedQueueOverflow) {
+          warnedQueueOverflow = true;
+          diagnostic({
+            kind: "warning",
+            message: `More than ${MAX_QUEUED_SENDS} messages were queued before the session became live; the oldest are being dropped.`,
+          });
+        }
+      }
+      queuedSends.push(args);
+    };
+    const flushQueuedSends = () => {
+      if (queuedSends.length === 0 || !session) return;
+      const pending = queuedSends.splice(0);
+      let send: unknown;
+      try {
+        send = Reflect.get(session, "send", session);
+      } catch {
+        // A throwing `send` getter is the extension's business; one queued frame must not
+        // escalate it into a failed session. Same warn-and-drop as a missing send below.
+        send = undefined;
+      }
+      if (typeof send !== "function") {
+        diagnostic({
+          kind: "warning",
+          message: `The extension session has no send(); ${pending.length} queued message(s) were dropped.`,
+        });
+        return;
+      }
+      for (const args of pending) {
+        if (closed || state === "failed" || state === "closed") break;
+        try {
+          const result = (send as (...sendArgs: unknown[]) => unknown).apply(
+            session,
+            args,
+          );
+          // A value-returning send has no call site left to observe it — the caller's send was
+          // fire-and-forget by contract — so an async delivery failure becomes a diagnostic
+          // rather than an unhandled rejection.
+          void Promise.resolve(result).catch(() =>
+            diagnostic({
+              kind: "warning",
+              message:
+                "A queued message could not be delivered to the session.",
+            }),
+          );
+        } catch {
+          diagnostic({
+            kind: "warning",
+            message: "A queued message could not be delivered to the session.",
+          });
+        }
+      }
+    };
+
+    // A request-local signal an extension hands to context.fetch() or context.gatherIce() must not
+    // displace the managed session signal: either one aborts the work. Hand-rolled rather than
+    // AbortSignal.any() to keep the runtime floor unchanged.
+    //
+    // The session signal carries ONE listener for all requests, driving a set of active
+    // combinations — never one listener per request, because a session sending heartbeats every few
+    // seconds would otherwise accumulate listeners for its whole lifetime. Each combination leaves
+    // the set when it aborts or its request completes; the set itself is released with the session.
+    const activeRequestCombos = new Set<{
+      combined: AbortController;
+      detach: () => void;
+    }>();
+    let sessionComboHookInstalled = false;
+    // Shared sentinel: a dispose that releases nothing. context.fetch skips the response
+    // body-monitoring apparatus entirely when it gets this back — patching clone/body methods
+    // to eventually call a no-op is pure metaprogramming overhead.
+    const noopDispose = () => undefined;
+    const withSessionSignal = (
+      requestSignal: AbortSignal | null | undefined,
+    ): { signal: AbortSignal; dispose: () => void } => {
+      if (!requestSignal || requestSignal === controller.signal) {
+        return { signal: controller.signal, dispose: noopDispose };
+      }
+      const combined = new AbortController();
+      if (controller.signal.aborted) {
+        combined.abort(controller.signal.reason);
+        return { signal: combined.signal, dispose: noopDispose };
+      }
+      if (requestSignal.aborted) {
+        combined.abort(requestSignal.reason);
+        return { signal: combined.signal, dispose: noopDispose };
+      }
+      const abortFromRequest = () => {
+        activeRequestCombos.delete(entry);
+        combined.abort(requestSignal.reason);
+      };
+      // The entry carries its own detach so the session-abort sweep can remove the listener from
+      // the REQUEST signal too — a long-lived request signal outliving the session must not keep
+      // retaining the combined controller through a listener nobody will ever fire.
+      const entry = {
+        combined,
+        detach: () =>
+          requestSignal.removeEventListener("abort", abortFromRequest),
+      };
+      if (!sessionComboHookInstalled) {
+        sessionComboHookInstalled = true;
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            for (const combo of activeRequestCombos) {
+              combo.detach();
+              combo.combined.abort(controller.signal.reason);
+            }
+            activeRequestCombos.clear();
+          },
+          { once: true },
+        );
+      }
+      activeRequestCombos.add(entry);
+      requestSignal.addEventListener("abort", abortFromRequest, {
+        once: true,
+      });
+      return {
+        signal: combined.signal,
+        dispose: () => {
+          activeRequestCombos.delete(entry);
+          entry.detach();
+        },
+      };
+    };
+
+    // Dispose a request's signal combination once its response body has actually been consumed —
+    // fetch() resolves at headers, and the signal must keep covering body reads until then. The
+    // body-reading methods are patched per instance, and `body` itself is served through a
+    // monitored stream so direct consumers (getReader, pipeTo, async iteration) also release the
+    // combination at end-of-stream or cancellation.
+    const disposeWhenBodyConsumed = (
+      response: Response,
+      dispose: () => void,
+    ) => {
+      const originalBody = response.body;
+      if (!originalBody) {
+        dispose();
+        return;
+      }
+      // clone() tees the response internally and RE-POINTS the original's body at a fresh branch,
+      // so a stream captured before the clone is stale and locked afterwards. The prototype getter
+      // — reachable even after the instance property below shadows it — always reads the current
+      // branch, keeping the original consumable after cloning, exactly like a native response.
+      const nativeBodyGetter = (() => {
+        let proto = Object.getPrototypeOf(response) as object | null;
+        while (proto) {
+          const descriptor = Object.getOwnPropertyDescriptor(proto, "body");
+          if (descriptor?.get) return descriptor.get;
+          proto = Object.getPrototypeOf(proto);
+        }
+        return undefined;
+      })();
+      const currentNativeBody = (): ReadableStream<Uint8Array> =>
+        (nativeBodyGetter?.call(response) as ReadableStream<Uint8Array>) ??
+        originalBody;
+      let disposed = false;
+      const settle = () => {
+        if (!disposed) {
+          disposed = true;
+          dispose();
+        }
+      };
+      // Clones share the combination: clone() tees the underlying source, so fully consuming
+      // EITHER branch means the network stream finished, and the other branch replays from the
+      // buffer where the signal no longer matters. Recursive, so clones of clones participate.
+      const originalClone = response.clone.bind(response);
+      Object.defineProperty(response, "clone", {
+        configurable: true,
+        writable: true,
+        value: () => {
+          // Native fetch rejects cloning once a reader holds the body. The monitored wrapper
+          // defers locking the NATIVE body until the first read, so without this check a caller
+          // holding a reader on the wrapper could still clone — teeing the source beneath an
+          // already-held reader, which a raw Response would never allow.
+          if (reader || monitored?.locked) {
+            throw new TypeError(
+              "Failed to execute 'clone' on 'Response': body is disturbed or locked",
+            );
+          }
+          const cloned = originalClone();
+          disposeWhenBodyConsumed(cloned, settle);
+          return cloned;
+        },
+      });
+      // The native reader is acquired only when the monitored stream is actually READ — merely
+      // accessing `response.body` must not lock the response, or the common "inspect body, then
+      // call json()" pattern would throw. highWaterMark 0 stops the wrapper from prefetching,
+      // which would otherwise acquire the reader at construction.
+      let monitored: ReadableStream<Uint8Array> | undefined;
+      let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+      // Set while a consumer-initiated cancellation is in flight: reader.closed resolves the moment
+      // the READER is cancelled, but on a teed body (a clone) the underlying cancellation promise
+      // stays pending while the sibling branch is still streaming — and the shared combination
+      // must keep covering that sibling until it truly finishes.
+      let cancelling = false;
+      const settleUnlessCancelling = () => {
+        if (!cancelling) settle();
+      };
+      const acquireReader = () => {
+        if (!reader) {
+          reader = currentNativeBody().getReader();
+          // Covers end-of-stream and stream error; cancellation settles through the cancel hook
+          // below, after the underlying (possibly composite tee) cancellation completes.
+          void reader.closed.then(
+            settleUnlessCancelling,
+            settleUnlessCancelling,
+          );
+        }
+        return reader;
+      };
+      Object.defineProperty(response, "body", {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          if (!monitored) {
+            // type "bytes", because native fetch bodies are byte streams and a BYOB reader that
+            // works on a raw Response must keep working here — context.fetch() promises a raw
+            // Response. Cast through unknown: TS libs without the byte-source overload need the
+            // assertion, and strict mode rejects the direct cast as insufficiently overlapping.
+            monitored = new ReadableStream(
+              {
+                type: "bytes",
+                pull: async (
+                  streamController: ReadableByteStreamController,
+                ) => {
+                  const { done, value } = await acquireReader().read();
+                  if (done) {
+                    streamController.close();
+                    // A pending BYOB request must be answered after close or the reader hangs.
+                    streamController.byobRequest?.respond(0);
+                    settle();
+                    return;
+                  }
+                  // A byte controller rejects empty chunks; skipping resolves this pull and the
+                  // stream simply pulls again.
+                  if (value && value.byteLength > 0) {
+                    streamController.enqueue(value);
+                  }
+                },
+                cancel: async (reason: unknown) => {
+                  cancelling = true;
+                  try {
+                    await (reader
+                      ? reader.cancel(reason)
+                      : currentNativeBody().cancel(reason));
+                  } finally {
+                    // On a teed body this promise settles only once the composite cancellation
+                    // does; a sibling branch that instead completes normally settles the shared
+                    // state through its own hooks, and this late settle is then a no-op.
+                    settle();
+                  }
+                },
+              } as unknown as UnderlyingDefaultSource<Uint8Array>,
+              { highWaterMark: 0 },
+            ) as ReadableStream<Uint8Array>;
+          }
+          return monitored;
+        },
+      });
+      for (const method of [
+        "arrayBuffer",
+        "blob",
+        "bytes",
+        "formData",
+        "json",
+        "text",
+      ] as const) {
+        const original = (response as Response & Record<string, unknown>)[
+          method
+        ];
+        if (typeof original !== "function") continue;
+        Object.defineProperty(response, method, {
+          configurable: true,
+          writable: true,
+          value: function patched(this: Response, ...args: unknown[]) {
+            // Native semantics: consuming the body while a reader holds it rejects. The wrapper
+            // defers locking the NATIVE stream, so without this check a held monitored reader
+            // could be bypassed by json()/text() reading the still-unlocked native body.
+            if (reader || monitored?.locked) {
+              return Promise.reject(
+                new TypeError(
+                  `Failed to execute '${method}' on 'Response': body is disturbed or locked`,
+                ),
+              );
+            }
+            return (original as (...a: unknown[]) => Promise<unknown>)
+              .apply(this, args)
+              .finally(settle);
+          },
+        });
+      }
+    };
+
+    // The handle is a PLAIN OBJECT, deliberately not a facade over the extension's session: it
+    // owns exactly the kernel members — state, ready, send, close — plus a `session` accessor
+    // through which extension-specific surface is reached once the session exists. A transparent
+    // Proxy could impersonate the session from the first tick, but the language invariants it
+    // drags in (freeze/seal mirroring, pinned descriptors, prototype cycles) cost far more
+    // machinery than the convenience is worth.
+    const send = (...args: unknown[]): void => {
+      // The documented contract: after a terminal state sends are DROPPED, mirroring a dead
+      // transport — not delivered to a session that is mid-teardown, where a still-open data
+      // channel would transmit a frame the user already disconnected from.
+      if (state === "failed" || state === "closed") return;
+      if (!session) {
+        queuedSend(...args);
+        return;
+      }
+      const sessionSend = Reflect.get(session, "send", session) as unknown;
+      if (typeof sessionSend !== "function") {
+        diagnostic({
+          kind: "warning",
+          message:
+            "The extension session has no send(); the message was dropped.",
+        });
+        return;
+      }
+      // Fire-and-forget by contract (the handle types send as void): a synchronous throw still
+      // propagates to the caller, while an async delivery failure has no call site left to
+      // observe it and becomes a diagnostic rather than an unhandled rejection — exactly as the
+      // pre-live queue flush does.
+      const result = (sessionSend as (...sendArgs: unknown[]) => unknown).apply(
+        session,
+        args,
+      );
+      if (result && typeof (result as { then?: unknown }).then === "function") {
+        void Promise.resolve(result).catch(() =>
+          diagnostic({
+            kind: "warning",
+            message: "A message could not be delivered to the session.",
+          }),
+        );
+      }
+    };
+    const handle = {
+      get state() {
+        return state;
+      },
+      // The extension's own session: undefined while opening, set once negotiation completes,
+      // and left readable after close so late observers see what they held rather than a hole.
+      get session() {
+        return session;
+      },
+      ready,
+      send,
+      close: publicClose,
+    } as unknown as RealtimeSession;
+
+    const openTask = async (): Promise<void> => {
+      try {
+        // One microtask of deferral before anything can fail: open() must RETURN before any
+        // caller callback fires, or an onState("closed")/onError closure referencing the handle
+        // variable (`const s = open(...)`) hits a TDZ hole when the signal was already aborted
+        // or the extension throws in the synchronous prefix of its open().
+        await Promise.resolve();
+        if (controller.signal.aborted) {
+          throw (
+            controller.signal.reason ??
+            new DOMException("Realtime open aborted", "AbortError")
+          );
+        }
+        session = await extension.open(
+          {
+            endpointId,
+            signal: controller.signal,
+            run: <Input, Output>(
+              id: string,
+              runOptions: RunOptions<Input>,
+            ): Promise<Result<Output>> => {
+              // The same lifecycle boundary fetch and gatherIce enforce through the combined
+              // signal: a credentialed request must not leave after the caller closed.
+              if (closed || controller.signal.aborted) {
+                throw new Error(
+                  "Realtime extension run() was called after the session ended.",
+                );
+              }
+              const normalizedId = id.trim();
+              if (
+                /^[a-z][a-z\d+.-]*:/i.test(normalizedId) ||
+                normalizedId.startsWith("//")
+              ) {
+                throw new Error(
+                  "Realtime extension run() requires an app endpoint id, not an absolute URL.",
+                );
+              }
+              if (!getClient) {
+                throw new Error(
+                  "This realtime client was created without fal request access.",
+                );
+              }
+              return getClient().run(
+                normalizedId,
+                runOptions as RunOptions<Record<string, any>>,
+              ) as Promise<Result<Output>>;
+            },
+            connect: realtimeClient.connect,
+            // Credentials, request middleware and proxy come from the parent client, so a proxied
+            // application stays proxied and the extension never sees a key. Raw `Response` rather than
+            // a parsed result: this reaches infrastructure that does not speak fal's result envelope.
+            fetch: async (
+              url: string,
+              init: Omit<RequestInit, "body"> & { body?: string } = {},
+            ) => {
+              // Validate the extension-controlled destination before middleware may rewrite it to an
+              // application-controlled proxy. Otherwise an extension could send the parent API key to
+              // an arbitrary host merely by naming it here.
+              assertFalInfrastructureUrl(url);
+              if (init.body !== undefined && typeof init.body !== "string") {
+                throw new Error(
+                  "Realtime extension fetch() supports JSON string bodies only.",
+                );
+              }
+              // Destructure before invocation: native fetch validates its receiver, so calling it as a
+              // method of the config object can throw "Illegal invocation".
+              const { fetch: doFetch, credentials: credentialsValue } = config;
+              const credentials =
+                typeof credentialsValue === "function"
+                  ? credentialsValue()
+                  : credentialsValue;
+              let requestHeaders: Record<string, string> | undefined;
+              if (init.headers !== undefined) {
+                const normalized: Record<string, string> = {};
+                new Headers(init.headers).forEach((value, key) => {
+                  normalized[key] = value;
+                });
+                requestHeaders = normalized;
+              }
+              // Native fetch defaults to GET; context.fetch takes RequestInit and must not
+              // surprise an extension hitting a read-only endpoint without naming a method.
+              const requestedMethod = (init.method ?? "GET").toUpperCase();
+              // GET and POST only — the smallest surface the shipped extensions need, and the
+              // one every fal proxy adapter is guaranteed to route. Widening this means widening
+              // three frameworks' adapter exports; an extension that needs more should say so.
+              if (requestedMethod !== "GET" && requestedMethod !== "POST") {
+                throw new Error(
+                  `Realtime extension fetch() supports GET and POST only (got ${requestedMethod}).`,
+                );
+              }
+              const {
+                method,
+                url: targetUrl,
+                headers,
+              } = await config.requestMiddleware({
+                method: requestedMethod,
+                url,
+                headers: requestHeaders,
+              });
+              const finalHeaders = new Headers();
+              if (credentials) {
+                finalHeaders.set("Authorization", `Key ${credentials}`);
+              }
+              for (const [name, value] of Object.entries(headers ?? {})) {
+                finalHeaders.set(
+                  name,
+                  Array.isArray(value) ? value.join(", ") : value,
+                );
+              }
+              const { signal, dispose } = withSessionSignal(init.signal);
+              try {
+                const response = await doFetch(targetUrl, {
+                  ...init,
+                  method,
+                  signal,
+                  headers: finalHeaders,
+                });
+                // The Response outlives this call: callers read the body afterwards, and a fetch
+                // signal also cancels those reads. Disposing here would sever the combination just
+                // when a stalled body needs it — keep it until the body is consumed or a side aborts.
+                if (dispose !== noopDispose) {
+                  disposeWhenBodyConsumed(response, dispose);
+                }
+                return response;
+              } catch (error) {
+                dispose();
+                throw error;
+              }
+            },
+            gatherIce: async (pc, iceOptions) => {
+              const { signal, dispose } = withSessionSignal(iceOptions?.signal);
+              try {
+                return await gatherIceCandidates(pc, {
+                  ...iceOptions,
+                  signal,
+                  onProgress: (result) =>
+                    diagnostic({
+                      kind: "progress",
+                      phase: "ice-gathering",
+                      detail: { ...result },
+                    }),
+                });
+              } finally {
+                dispose();
+              }
+            },
+            diagnostic,
+            media,
+            data,
+            fail: async (
+              message: string,
+              observed?: Record<string, number | string>,
+            ) => {
+              // A failure reported after managed teardown began is stale: the caller already
+              // closed, the lifecycle correctly reads "closed", and surfacing the report would
+              // render a failure for a session the user ended — the same suppression rule the
+              // media and data channels apply. An extension's in-flight work observing its own
+              // teardown lands here.
+              if (closed) return;
+              // Latch failure before invoking either lifecycle or diagnostic callbacks. Both are
+              // application-controlled and may re-enter close(); failure must still win.
+              setState("failed");
+              diagnostic({ kind: "failure", message, observed });
+              const failure = new Error(message);
+              reportError(failure);
+              // No-ops once the session went live; before that, a caller awaiting `ready` must not
+              // wait out a negotiation the extension has already declared dead.
+              rejectReady(failure);
+              await cleanup();
+            },
+            addCleanup: (release) => {
+              if (closed) {
+                lateCleanups.push(release);
+                // Until teardown completes, its own drain picks this up IN ORDER, behind the
+                // close hook and the releases still pending; afterwards a fresh drain is the
+                // only runner left.
+                if (teardownCompleted) void drainLateCleanups();
+              } else {
+                cleanups.push(release);
+              }
+            },
+            // `teardownRunning` in the guard, not `closed`: a cleanup release that awaits
+            // context.close() (or the patched session.close) would otherwise receive the
+            // memoized teardown promise FROM INSIDE that promise's own body — a circular await
+            // that hangs every close() forever. Callers OUTSIDE the body (an abort listener,
+            // late app code) still share the real teardown through cleanup()'s memo.
+            close: () =>
+              sessionCloseInProgress || teardownRunning
+                ? Promise.resolve()
+                : cleanup(),
+          },
+          options,
+        );
+        extensionClose = session.close.bind(session);
+        // Raw class methods are bound to the original instance for private fields.
+        // Route an internal this.close() through managed teardown when possible — with the SAME
+        // re-entrancy guard context.close carries: managed teardown awaits the ORIGINAL close
+        // hook, and a hook that (directly or through a shared shutdown helper) awaits its own
+        // patched this.close() would otherwise receive the memoized cleanup promise that is
+        // awaiting the hook — a permanent deadlock.
+        const patchedClose = () =>
+          sessionCloseInProgress || teardownRunning
+            ? Promise.resolve()
+            : cleanup();
+        const closePatched = Reflect.set(
+          session,
+          "close",
+          patchedClose,
+          session,
+        );
+        // Best-effort for `state` too: the handle's state is the authoritative lifecycle, and a
+        // session field freely contradicting it (an extension writing "closed" while the kernel
+        // latched "failed") would lie through the documented handle.session surface. A no-op
+        // setter absorbs extension writes rather than throwing in strict-mode class code.
+        const statePatched = Reflect.defineProperty(session, "state", {
+          get: () => state,
+          set: () => undefined,
+          enumerable: false,
+          configurable: true,
+        });
+        const patchWarningPending = !closePatched || !statePatched;
+        if (controller.signal.aborted) {
+          try {
+            await closeSession();
+          } catch {
+            // Preserve the caller's abort reason when a late session close hook is broken.
+          }
+          await cleanup();
+          await drainLateCleanups();
+          throw controller.signal.reason ?? new Error("Realtime open aborted");
+        }
+        // Queued sends flush in order the moment the session exists, and only then does state
+        // report "live" — so an onState("live") callback that sends immediately cannot jump the
+        // queue.
+        flushQueuedSends();
+        if (patchWarningPending) {
+          // Emitted AFTER the flush: the session is set by now, so a handle.send() from the
+          // caller's onDiagnostic would deliver directly — ahead of the queued messages — if
+          // this fired any earlier.
+          diagnostic({
+            kind: "warning",
+            message:
+              "The extension session could not be patched (frozen or sealed); " +
+              "handle.session.close() will bypass managed teardown — use handle.close().",
+          });
+        }
+        // A queued send can synchronously end the session — an extension send that calls
+        // context.close(), or app code aborting the caller's signal. The state latch already
+        // refuses "live" after a terminal state; ready must reject through the normal
+        // cancellation/failure path rather than resolve a session that never went live.
+        if (
+          controller.signal.aborted ||
+          state === "failed" ||
+          state === "closed"
+        ) {
+          throw (
+            controller.signal.reason ??
+            new Error("Realtime session ended while delivering queued sends")
+          );
+        }
+        // ready resolves BEFORE onState("live") fires: a caller callback that synchronously
+        // closes on "live" (a connect-probe, an unmounted effect) re-enters cleanup, whose
+        // generic rejection would otherwise beat this resolution — rejecting ready for a
+        // session that demonstrably went live.
+        resolveReady(handle);
+        setState("live");
+      } catch (error) {
+        const wasTerminal = state === "failed" || state === "closed";
+        // A cancellation the caller initiated — close(), an aborted abortSignal, or a signal
+        // aborted before open() — is an orderly ending, not a failure: cleanup reports it as
+        // "closed" and it must not reach onError, or a callback-driven UI would render a failure
+        // for its own disconnect button. Everything else moves to "failed" BEFORE cleanup, so a
+        // caller watching state sees that this session died rather than ended.
+        const cancelled = controller.signal.aborted && state !== "failed";
+        if (!cancelled) {
+          setState("failed");
+        }
+        if (state === "failed") {
+          if (!wasTerminal) {
+            // The synchronous shape has no returned promise whose rejection could carry this, so
+            // the failure that was previously a rejection is also a reportable diagnostic —
+            // unless the extension already reported it through context.fail().
+            diagnostic({
+              kind: "failure",
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+          reportError(error);
+        }
+        // Rejects either way: a caller awaiting `ready` must not wait forever on a session that
+        // will never become live, whether it failed or was cancelled.
+        rejectReady(error);
+        // Caller-facing failure channels settle before teardown. Resource release may be slow or
+        // even externally blocked; ready and onError are liveness signals, not cleanup waiters.
+        await cleanup();
+        await drainLateCleanups();
+      }
+    };
+    openTaskPromise = openTask();
+    return handle;
+  }
+
+  realtimeClient.open = open as RealtimeClient["open"];
+  return realtimeClient;
 }

--- a/libs/client/src/realtime/abort.ts
+++ b/libs/client/src/realtime/abort.ts
@@ -1,0 +1,7 @@
+export function throwIfRealtimeAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  throw (
+    signal.reason ??
+    new DOMException("Realtime operation aborted", "AbortError")
+  );
+}

--- a/libs/client/src/realtime/extension.ts
+++ b/libs/client/src/realtime/extension.ts
@@ -1,0 +1,413 @@
+import type {
+  RealtimeConnection,
+  RealtimeConnectionHandler,
+} from "../realtime";
+import type { Result, RunOptions } from "../types/common";
+
+/**
+ * The minimum contract for a long-lived realtime session.
+ *
+ * Extensions may add any model-specific fields and methods they need. The
+ * client only standardizes teardown so callers always have one reliable way
+ * to release the resources owned by a session.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export interface RealtimeSession {
+  close(): void | Promise<void>;
+  /**
+   * Coarse lifecycle, uniform across every extension.
+   *
+   * An extension's own OPERATIONS stay its own: they carry meaning only inside their protocol, and
+   * nothing is gained by forcing them into a shared shape. "Is this opening, live, or dead" is the
+   * opposite — every protocol has it, each names it in its own vocabulary, and leaving it to the
+   * extensions makes an application that renders a single status indicator branch per protocol.
+   *
+   * Deliberately four values. Anything finer is protocol detail: a state that is meaningful while one
+   * protocol negotiates may not exist in another that spends thirty seconds building before it can
+   * stream at all. Detail belongs in {@link RealtimeDiagnostic}.
+   *
+   * OPTIONAL here because no extension has to implement it — the kernel supplies it on the session
+   * it hands back, so what `open()` returns always has one. See {@link ManagedRealtimeSession}.
+   */
+  readonly state?: RealtimeState;
+}
+
+/**
+ * `opening` → `live` → (`failed` | `closed`).
+ *
+ * Both endings are TERMINAL and neither is reachable from the other: a session that failed reports
+ * `"failed"` forever, and does not decay into `"closed"` as its resources are released. Teardown
+ * happens either way, so reporting it would overwrite the only thing that separates "the transport
+ * died" from "the user pressed disconnect".
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export type RealtimeState = "opening" | "live" | "failed" | "closed";
+
+/**
+ * What `fal.realtime.open()` returns: a small, plain handle owned by the kernel.
+ *
+ * Returned SYNCHRONOUSLY, in state `"opening"`, while negotiation runs eagerly behind it. The
+ * caller can hold the handle, render from `state`, and call `send()` immediately — queued sends
+ * are flushed in order the moment the session is live. Extension-specific members live on
+ * {@link ManagedRealtimeSession.session}, which is set once negotiation completes; `ready` is
+ * for the caller that wants the awaited style.
+ *
+ * Deliberately a plain object rather than a facade impersonating the extension's session: the
+ * handle's members never change shape, and the raw session — with whatever fields and methods
+ * its extension declared — is reached explicitly through `session`.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export type ManagedRealtimeSession<Session extends RealtimeSession> =
+  (Session extends { send: (...args: infer Args) => unknown }
+    ? {
+        /**
+         * Fire-and-forget, whatever the extension's own `send` returns. A send issued while the
+         * session is still opening is queued and delivered later, so there is no extension return
+         * value to hand back at the call site — the type says so rather than pretending. Delivery
+         * failures surface as diagnostics.
+         */
+        send: (...args: Args) => void;
+      }
+    : Record<never, never>) & {
+    readonly state: RealtimeState;
+    /**
+     * The extension's own session: `undefined` while opening, set once negotiation completes,
+     * and left readable after close. This is where extension-specific fields and methods live —
+     * the handle itself never grows them.
+     */
+    readonly session: Session | undefined;
+    /**
+     * Always a promise, whatever the extension declared. The kernel substitutes its own idempotent
+     * teardown for the extension's `close`, and that teardown awaits every registered cleanup — so a
+     * caller that awaits this knows the resources are actually released, which is not something an
+     * extension returning `void` could promise. Calling it while the session is still opening
+     * cancels the negotiation.
+     */
+    close(): Promise<void>;
+    /**
+     * Resolves with this same handle once the session is live; rejects with the failure when
+     * opening fails or is aborted. Optional — every failure it can carry also reaches `onError`
+     * and `onState("failed")`, so a caller living entirely on callbacks never needs to touch it,
+     * and an ignored `ready` never becomes an unhandled rejection.
+     *
+     * The resolved type narrows `session` to PRESENT: the kernel always sets it before
+     * resolving, so a caller who awaited `ready` never pays an optional-chain for an invariant
+     * the runtime already guarantees.
+     */
+    readonly ready: Promise<
+      ManagedRealtimeSession<Session> & { readonly session: Session }
+    >;
+  };
+
+/**
+ * Options the KERNEL reads, accepted alongside whatever an extension declares.
+ *
+ * Separate from an extension's own `Options` because they belong to different owners: the extension
+ * defines its product inputs, the kernel defines cancellation and reporting. Declaring them here is
+ * what makes them reachable through the typed `open(extension, options)` overload, which otherwise
+ * types the options bag as the extension's alone and rejects every kernel option at the call site.
+ *
+ * An extension with NO options of its own must declare `Record<never, never>`, not
+ * `Record<string, never>`. The latter asserts that every string key maps to `never`, which makes
+ * `Options & RealtimeOpenOptions` contradictory and rejects `onMedia`, `onState` and `onDiagnostic`
+ * at the call site — leaving an extension that takes no product inputs unable to receive any kernel
+ * option at all.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export interface RealtimeOpenOptions {
+  /**
+   * The endpoint to open, when the extension's default is not the one wanted. Declared HERE
+   * because the KERNEL reads it — an extension never has to redeclare it, and a third-party
+   * extension that forgets to would otherwise strand its callers unable to select an endpoint.
+   */
+  endpointId?: string;
+  /** Cancels opening, and closes the session if it is already open. */
+  abortSignal?: AbortSignal;
+  /** Coarse lifecycle transitions, uniform across every extension. */
+  onState?: (state: RealtimeState) => void;
+  /**
+   * The terminal FAILURE, delivered once: the error that failed opening, or the transport failure
+   * an extension reported through `context.fail()`. A caller's own cancellation — close() or an
+   * aborted abortSignal — is an orderly ending, not a failure: it reaches onState("closed") and
+   * rejects `ready`, and deliberately never fires this.
+   *
+   * This is the failure channel for the synchronous `open()` shape — there is no returned promise
+   * whose rejection could carry it, and requiring every caller to attach to `ready` would turn an
+   * optional convenience into an obligation.
+   */
+  onError?: (error: unknown) => void;
+  /** Progress and failure reports. See {@link RealtimeDiagnostic}. */
+  onDiagnostic?: (event: RealtimeDiagnostic) => void;
+  /**
+   * Inbound media, once per stream, for any extension that returns some.
+   *
+   * Named HERE rather than per extension because "a remote stream arrived" is one concept, and left
+   * to the extensions it acquires one name per protocol — every one of them defensible, none of them
+   * shared. An application offering two extensions then needs a branch to do the single thing it
+   * actually wants, which is attach a video element. Same tax `onState` removes for lifecycle.
+   *
+   * Not every extension calls it. An app can send a camera up and get its answer back as data with no
+   * inbound media at all, which is why this is optional on both sides rather than part of opening.
+   */
+  onMedia?: (stream: MediaStream) => void;
+  /**
+   * Inbound application data, once per message.
+   *
+   * Deliberately a string rather than a parsed object: the kernel cannot know a model's schema, and
+   * pretending otherwise would put one protocol's vocabulary in the transport. The extension delivers;
+   * the application parses and validates.
+   *
+   * Declared for every extension rather than only the ones that obviously need it, because "media up,
+   * data down" is a shape any of them can take, and an extension whose surface omits this cannot
+   * express it even when its protocol allows it.
+   */
+  onData?: (raw: string) => void;
+}
+
+/**
+ * A structured progress or failure report from an extension.
+ *
+ * NOT protocol-shaped, on purpose. Useful progress for one model is "world building, 40%" and for
+ * another "3 of 4 TURN servers answered"; a `phase` plus a free-form `detail` bag carries both,
+ * where an ICE-shaped schema would carry only one.
+ *
+ * The rule that matters here is cultural rather than typed: **a `failure` reports what was OBSERVED,
+ * never what was inferred.** A speculative diagnostic is worse than none, because it gets believed: a
+ * message naming symmetric NAT or blocked UDP sends whoever reads it into the network, and the cause
+ * of a connection that gathered no relay candidate is at least as often a credential or a
+ * misconfigured server. Report the counts and the errors; let the reader conclude.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export type RealtimeDiagnostic =
+  | {
+      kind: "progress";
+      phase: string;
+      detail?: Record<string, number | string>;
+    }
+  | {
+      kind: "warning";
+      message: string;
+      detail?: Record<string, number | string>;
+    }
+  | {
+      kind: "failure";
+      message: string;
+      /** What was measured. Counts, codes, per-server errors — not conclusions. */
+      observed?: Record<string, number | string>;
+    };
+
+/**
+ * Counts of gathered ICE candidates by type, and why gathering stopped.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export interface IceGatheringResult {
+  host: number;
+  srflx: number;
+  relay: number;
+  state: "complete" | "sufficient" | "timeout";
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface IceGatheringOptions {
+  /**
+   * The servers handed to the peer connection. Used to decide what "sufficient" means: when TURN is
+   * configured, a relay candidate is required before the set counts as usable, because that is the
+   * entire reason TURN was configured.
+   */
+  iceServers?: RTCIceServer[];
+  /**
+   * The candidate policy used by the peer connection. Relay-only gathering is sufficient as soon
+   * as a relay candidate settles; it intentionally cannot produce a server-reflexive candidate.
+   */
+  iceTransportPolicy?: RTCIceTransportPolicy;
+  /** Hard bound. Reached only when gathering neither completes nor becomes sufficient. */
+  timeoutMs?: number;
+  /** How long the candidate set must stop changing before it is considered settled. */
+  quietPeriodMs?: number;
+  /** Cancel gathering immediately and remove its listeners and timers. */
+  signal?: AbortSignal;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface RealtimeExtensionContext {
+  /** The endpoint selected by `fal.realtime.open()`. */
+  readonly endpointId: string;
+
+  /**
+   * Aborted when the caller cancels opening or closes the resulting session.
+   * Extensions should pass it to fetch-like work and check it between
+   * negotiation steps.
+   */
+  readonly signal: AbortSignal;
+
+  /**
+   * Call any fal endpoint with the same credentials, middleware, storage
+   * handling, and retry policy as the parent client. This is just for getting ICE servers
+   * from the app's own /ice endpoint in case the bridge is not available.
+   */
+  run<Input = unknown, Output = unknown>(
+    endpointId: string,
+    options: RunOptions<Input>,
+  ): Promise<Result<Output>>;
+
+  /**
+   * Open the existing low-level fal WebSocket connection. This is useful for
+   * extensions whose negotiation protocol rides over fal realtime.
+   */
+  connect<Input = unknown, Output = unknown>(
+    endpointId: string,
+    handler: RealtimeConnectionHandler<Output>,
+  ): RealtimeConnection<Input>;
+
+  /**
+   * Register a resource release callback. Callbacks run once, in reverse
+   * order, when opening fails, the signal aborts, or the session closes.
+   */
+  addCleanup(cleanup: () => void | Promise<void>): void;
+
+  /**
+   * End the managed session from inside the extension, for example when a
+   * provider reports that the remote session finished on its own.
+   */
+  close(): Promise<void>;
+
+  /**
+   * A credentialed request to fal infrastructure that is NOT an endpoint.
+   *
+   * `run()` covers fal endpoints and `connect()` covers the fal WebSocket, which leaves a real gap:
+   * a shared signalling bridge, a regional relay or a control plane addressed by body rather than
+   * path — say `POST https://<service>.fal.run/session` carrying the app id as a body parameter — is
+   * reachable through neither. Without this, the only way to reach one is for the APPLICATION to
+   * inject a credentialed fetch, which hands auth for one leg of the connection back to the caller
+   * and is exactly what this API exists to prevent.
+   *
+   * Applies the parent client's credentials, request middleware and proxy, so a proxied application
+   * stays proxied. Request bodies are JSON strings because that is the common body contract every
+   * supported proxy adapter preserves. Returns the raw `Response`: unlike `run()`, this makes no
+   * assumption that the other end speaks fal's result envelope.
+   */
+  fetch(
+    url: string,
+    init?: Omit<RequestInit, "body"> & { body?: string },
+  ): Promise<Response>;
+
+  /**
+   * Wait for ICE gathering to produce a usable candidate set.
+   *
+   * In the kernel because every extension doing browser WebRTC against a non-trickle signalling
+   * channel needs it, and both obvious strategies are wrong: waiting for `complete` pays a dead STUN
+   * server's full timeout, while a fixed short cap silently ships a host+srflx-only offer that can
+   * never form a relayed path and fails with no error at all.
+   *
+   * What works is sufficient-set, then a quiet period, under a hard bound. An extension that trickles
+   * its candidates has no use for it, which is precisely why it belongs here rather than inside
+   * whichever extension meets the problem first — otherwise the next one writes it again, slightly
+   * differently.
+   */
+  gatherIce(
+    pc: RTCPeerConnection,
+    options?: IceGatheringOptions,
+  ): Promise<IceGatheringResult>;
+
+  /**
+   * End the session because it FAILED, as opposed to being closed.
+   *
+   * `close()` alone cannot express this. A dead peer connection or an expired lease is not a clean
+   * teardown, but the kernel only sees a close request and reports "closed" — so a caller cannot
+   * distinguish "the user pressed disconnect" from "the transport died", which are the two cases a
+   * status UI most needs to tell apart.
+   *
+   * Emits a failure diagnostic, moves the state to "failed", then tears down.
+   */
+  fail(
+    message: string,
+    observed?: Record<string, number | string>,
+  ): Promise<void>;
+
+  /**
+   * Report progress or failure to the caller, if it asked to hear about it.
+   *
+   * Safe to call unconditionally — the kernel drops the event when no `onDiagnostic` was supplied, so
+   * an extension never needs to check.
+   */
+  diagnostic(event: RealtimeDiagnostic): void;
+  /**
+   * Publish an inbound stream to `onMedia`.
+   *
+   * A kernel channel like {@link RealtimeExtensionContext.diagnostic}, not an option the extension
+   * reads, so the name is fixed in one place and a fourth extension cannot invent a fifth spelling.
+   */
+  media(stream: MediaStream): void;
+  /** Publish one inbound message to `onData`. Raw; parsing belongs to the application. */
+  data(raw: string): void;
+}
+
+/**
+ * A customer-installable realtime protocol implementation.
+ *
+ * Which extension opens a session is the caller's decision, made at the call site by naming one. The
+ * kernel owns lifecycle; the extension owns negotiation and the model-specific session API.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export interface RealtimeExtension<
+  Options = unknown,
+  Session extends RealtimeSession = RealtimeSession,
+> {
+  /** Stable diagnostic name, for example `fal/webrtc` or `acme/dragon-world`. */
+  readonly id: string;
+
+  /**
+   * Endpoint opened when the options do not name one.
+   */
+  readonly defaultEndpoint?: string;
+
+  /**
+   * Reject an endpoint this extension knows it cannot open.
+   *
+   * A guard, not a router. It exists for the extension that owns a closed set of endpoints — Lucy
+   * ships two — so a mistyped or stale id fails at the call site instead of partway through a
+   * negotiation that was never going to succeed.
+   *
+   * Optional because most protocols have no such set. Any customer can build an app on the WMA
+   * transport, so no list of ids describes it, and an extension in that position should say nothing
+   * rather than assert something it cannot know.
+   */
+  supports?(endpointId: string): boolean;
+
+  /** Negotiate the model session and return its model-specific facade. */
+  open(context: RealtimeExtensionContext, options: Options): Promise<Session>;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export type AnyRealtimeExtension = RealtimeExtension<unknown, RealtimeSession>;
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export type RealtimeExtensionOptions<Extension> =
+  Extension extends RealtimeExtension<infer Options, RealtimeSession>
+    ? Options
+    : never;
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export type RealtimeExtensionSession<Extension> =
+  Extension extends RealtimeExtension<unknown, infer Session> ? Session : never;
+
+/**
+ * Identity helper that preserves an extension's options and session types.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function defineRealtimeExtension<
+  Options,
+  Session extends RealtimeSession,
+>(
+  extension: RealtimeExtension<Options, Session>,
+): RealtimeExtension<Options, Session> {
+  return extension;
+}

--- a/libs/client/src/realtime/ice.spec.ts
+++ b/libs/client/src/realtime/ice.spec.ts
@@ -1,0 +1,241 @@
+import {
+  countTurnServers,
+  gatherIceCandidates,
+  hasTurnServer,
+  parseIceCandidateType,
+} from "./ice";
+
+/** A peer connection just real enough to drive the gathering strategy. */
+function fakePc() {
+  const listeners: Record<string, Array<(event: any) => void>> = {};
+  return {
+    iceGatheringState: "gathering" as RTCIceGatheringState,
+    addEventListener: (type: string, fn: any) => {
+      (listeners[type] ??= []).push(fn);
+    },
+    removeEventListener: (type: string, fn: any) => {
+      listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+    },
+    emitCandidate(candidate: string | null) {
+      for (const fn of listeners["icecandidate"] ?? []) {
+        fn({ candidate: candidate ? { candidate } : null });
+      }
+    },
+    complete() {
+      this.iceGatheringState = "complete";
+      for (const fn of listeners["icegatheringstatechange"] ?? []) fn({});
+    },
+  };
+}
+
+const line = (type: string) => `candidate:1 1 udp 1 1.2.3.4 1 typ ${type}`;
+
+describe("parseIceCandidateType", () => {
+  it("reads the candidate type", () => {
+    expect(parseIceCandidateType(line("host"))).toBe("host");
+    expect(parseIceCandidateType(line("srflx"))).toBe("srflx");
+    expect(parseIceCandidateType(line("relay"))).toBe("relay");
+  });
+
+  it("returns null rather than guessing", () => {
+    expect(parseIceCandidateType("candidate:1 1 udp 1 1.2.3.4 1")).toBeNull();
+  });
+});
+
+describe("hasTurnServer", () => {
+  it("finds turn and turns among string or array urls", () => {
+    expect(hasTurnServer([{ urls: "turn:example:3478" }])).toBe(true);
+    expect(hasTurnServer([{ urls: ["stun:a", "turns:b"] }])).toBe(true);
+    expect(hasTurnServer([{ urls: "stun:example:19302" }])).toBe(false);
+  });
+});
+
+describe("countTurnServers", () => {
+  it("counts configured TURN server objects rather than URLs", () => {
+    expect(
+      countTurnServers([
+        { urls: ["turn:a:3478", "turns:a:443", "stun:a:19302"] },
+        { urls: "stun:b:19302" },
+        { urls: "turn:b:3478" },
+      ]),
+    ).toBe(2);
+  });
+});
+
+describe("gatherIceCandidates", () => {
+  it("settles on a sufficient set after the quiet period", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, { quietPeriodMs: 20 });
+    pc.emitCandidate(line("host"));
+    pc.emitCandidate(line("srflx"));
+    const result = await done;
+    expect(result).toEqual({
+      host: 1,
+      srflx: 1,
+      relay: 0,
+      state: "sufficient",
+    });
+  });
+
+  it("settles even when the progress callback throws at completion", async () => {
+    // finish() runs from an event or timer with every waiter removed; a throwing onProgress could
+    // never surface as a rejection — only leave the returned promise pending forever.
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, {
+      quietPeriodMs: 20,
+      onProgress: () => {
+        throw new Error("reporting UI exploded");
+      },
+    });
+    pc.emitCandidate(line("host"));
+    pc.emitCandidate(line("srflx"));
+    const result = await done;
+    expect(result.state).toBe("sufficient");
+  });
+
+  it("seeds counts from candidates already in the local description", async () => {
+    // A caller invoking the helper after setLocalDescription() (or after gathering completed)
+    // must not see zero counts — pre-registration candidates live in the SDP, not in future
+    // icecandidate events.
+    const donePc = {
+      ...fakePc(),
+      iceGatheringState: "complete" as RTCIceGatheringState,
+      localDescription: {
+        sdp: `v=0\r\na=${line("host")}\r\na=${line("relay")}\r\n`,
+      } as RTCSessionDescription,
+    };
+    const done = await gatherIceCandidates(donePc as any, {});
+    expect(done).toEqual({ host: 1, srflx: 0, relay: 1, state: "complete" });
+
+    // Mid-gathering: a seeded, already-sufficient set settles after the quiet period without
+    // requiring any further event.
+    const midPc = {
+      ...fakePc(),
+      localDescription: {
+        sdp: `v=0\r\na=${line("host")}\r\na=${line("srflx")}\r\n`,
+      } as RTCSessionDescription,
+    };
+    const result = await gatherIceCandidates(midPc as any, {
+      quietPeriodMs: 20,
+    });
+    expect(result).toEqual({
+      host: 1,
+      srflx: 1,
+      relay: 0,
+      state: "sufficient",
+    });
+  });
+
+  it("is NOT sufficient without a relay when TURN is configured", async () => {
+    // The case that matters: shipping an offer with no relay candidate while TURN is configured
+    // produces a connection that cannot work, and reports nothing about why.
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, {
+      iceServers: [{ urls: "turn:example:3478" }],
+      quietPeriodMs: 15,
+      timeoutMs: 90,
+    });
+    pc.emitCandidate(line("host"));
+    pc.emitCandidate(line("srflx"));
+    const result = await done;
+    expect(result.state).toBe("timeout");
+    expect(result.relay).toBe(0);
+  });
+
+  it("settles once the relay arrives when TURN is configured", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, {
+      iceServers: [{ urls: "turn:example:3478" }],
+      quietPeriodMs: 15,
+    });
+    pc.emitCandidate(line("srflx"));
+    pc.emitCandidate(line("relay"));
+    const result = await done;
+    expect(result).toEqual({
+      host: 0,
+      srflx: 1,
+      relay: 1,
+      state: "sufficient",
+    });
+  });
+
+  it("settles on a relay without waiting for srflx when TURN is configured", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as unknown as RTCPeerConnection, {
+      iceServers: [{ urls: "turn:example:3478" }],
+      quietPeriodMs: 15,
+    });
+    pc.emitCandidate(line("relay"));
+    const result = await done;
+    expect(result).toEqual({
+      host: 0,
+      srflx: 0,
+      relay: 1,
+      state: "sufficient",
+    });
+  });
+
+  it("settles on a relay without waiting for srflx in relay-only mode", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, {
+      iceServers: [{ urls: "turn:example:3478" }],
+      iceTransportPolicy: "relay",
+      quietPeriodMs: 15,
+    });
+    pc.emitCandidate(line("relay"));
+    const result = await done;
+    expect(result).toEqual({
+      host: 0,
+      srflx: 0,
+      relay: 1,
+      state: "sufficient",
+    });
+  });
+
+  it("a later candidate restarts the quiet period", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, { quietPeriodMs: 40 });
+    pc.emitCandidate(line("srflx"));
+    await new Promise((r) => setTimeout(r, 25));
+    pc.emitCandidate(line("srflx"));
+    const result = await done;
+    // Both counted: settling on the first would have put a half-gathered set in the SDP.
+    expect(result.srflx).toBe(2);
+  });
+
+  it("resolves immediately when gathering already completed", async () => {
+    const pc = fakePc();
+    pc.iceGatheringState = "complete";
+    await expect(gatherIceCandidates(pc as any)).resolves.toEqual({
+      host: 0,
+      srflx: 0,
+      relay: 0,
+      state: "complete",
+    });
+  });
+
+  it("prefers completion over the hard bound", async () => {
+    const pc = fakePc();
+    const done = gatherIceCandidates(pc as any, { timeoutMs: 500 });
+    pc.emitCandidate(line("host"));
+    pc.complete();
+    expect((await done).state).toBe("complete");
+  });
+
+  it("rejects immediately and removes listeners when gathering is aborted", async () => {
+    const pc = fakePc();
+    const controller = new AbortController();
+    const reason = new Error("session closed");
+    const done = gatherIceCandidates(pc as any, {
+      signal: controller.signal,
+      timeoutMs: 10_000,
+    });
+
+    controller.abort(reason);
+
+    await expect(done).rejects.toBe(reason);
+    // Removed listeners make late browser events inert instead of reviving progress after abort.
+    pc.emitCandidate(line("relay"));
+    pc.complete();
+  });
+});

--- a/libs/client/src/realtime/ice.ts
+++ b/libs/client/src/realtime/ice.ts
@@ -1,0 +1,173 @@
+import type { IceGatheringOptions, IceGatheringResult } from "./extension";
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export const DEFAULT_ICE_TIMEOUT_MS = 12_000;
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export const DEFAULT_ICE_QUIET_PERIOD_MS = 1_250;
+
+/**
+ * Number of configured TURN servers, counting each server object at most once.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function countTurnServers(iceServers: RTCIceServer[]): number {
+  return iceServers.filter((server) => {
+    const urls = Array.isArray(server.urls) ? server.urls : [server.urls];
+    return urls.some((url) => /^turns?:/i.test(url));
+  }).length;
+}
+
+/**
+ * Does this configuration include a TURN server? Then a relay candidate is required.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function hasTurnServer(iceServers: RTCIceServer[]): boolean {
+  return countTurnServers(iceServers) > 0;
+}
+
+/**
+ * `typ host`, `typ srflx` or `typ relay` out of a candidate line.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function parseIceCandidateType(
+  candidate: string,
+): "host" | "srflx" | "relay" | null {
+  const match = candidate.match(/(?:^|\s)typ\s+(host|srflx|relay)(?:\s|$)/);
+  return (match?.[1] as "host" | "srflx" | "relay" | undefined) ?? null;
+}
+
+/**
+ * Resolve when the candidate set is good enough AND has settled, when gathering completes, or when
+ * the hard bound elapses — whichever comes first.
+ *
+ * Every candidate restarts the quiet-period debounce, because the goal is a stable set in the SDP
+ * rather than the first usable address the browser happens to find. A TURN configuration is not
+ * "sufficient" until a relay candidate exists: shipping an offer without one when TURN was configured
+ * produces a connection that cannot work and reports nothing about why.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export async function gatherIceCandidates(
+  pc: Pick<
+    RTCPeerConnection,
+    "iceGatheringState" | "addEventListener" | "removeEventListener"
+  > &
+    Partial<Pick<RTCPeerConnection, "localDescription">>,
+  options: IceGatheringOptions & {
+    onProgress?: (result: IceGatheringResult) => void;
+  } = {},
+): Promise<IceGatheringResult> {
+  const {
+    iceServers = [],
+    iceTransportPolicy = "all",
+    timeoutMs = DEFAULT_ICE_TIMEOUT_MS,
+    quietPeriodMs = DEFAULT_ICE_QUIET_PERIOD_MS,
+    signal,
+    onProgress,
+  } = options;
+
+  const abortReason = () =>
+    signal?.reason ?? new DOMException("ICE gathering aborted", "AbortError");
+  if (signal?.aborted) throw abortReason();
+
+  const counts = { host: 0, srflx: 0, relay: 0 };
+  const snapshot = (
+    state: IceGatheringResult["state"],
+  ): IceGatheringResult => ({
+    ...counts,
+    state,
+  });
+
+  // Candidates gathered BEFORE this call live in the local description, not in future
+  // icecandidate events — a caller invoking the helper after setLocalDescription() (or after
+  // gathering completed entirely) would otherwise see zero counts, producing false no-relay
+  // diagnostics or waiting out the full timeout on an already sufficient set.
+  const sdp = pc.localDescription?.sdp;
+  if (sdp) {
+    for (const line of sdp.split(/\r?\n/)) {
+      if (line.startsWith("a=candidate:")) {
+        const type = parseIceCandidateType(line.slice(2));
+        if (type) counts[type] += 1;
+      }
+    }
+  }
+
+  if (pc.iceGatheringState === "complete") {
+    const done = snapshot("complete");
+    try {
+      onProgress?.(done);
+    } catch {
+      // A progress callback must never be able to fail gathering.
+    }
+    return done;
+  }
+
+  return new Promise<IceGatheringResult>((resolve, reject) => {
+    let settled = false;
+    let quiet: ReturnType<typeof setTimeout> | null = null;
+    const requireRelay = hasTurnServer(iceServers);
+    const sufficient = () =>
+      iceTransportPolicy === "relay"
+        ? counts.relay > 0
+        : requireRelay
+          ? counts.relay > 0
+          : counts.srflx > 0;
+
+    const removeWaiters = () => {
+      clearTimeout(hardBound);
+      if (quiet !== null) clearTimeout(quiet);
+      pc.removeEventListener(
+        "icegatheringstatechange",
+        onState as EventListener,
+      );
+      pc.removeEventListener("icecandidate", onCandidate as EventListener);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const finish = (state: IceGatheringResult["state"]) => {
+      if (settled) return;
+      settled = true;
+      removeWaiters();
+      const done = snapshot(state);
+      // The promise settles regardless of the caller's reporting callback: a throw here fires
+      // from an event or timer with every waiter already removed, so it could never surface as a
+      // rejection — only leave the returned promise pending forever.
+      try {
+        onProgress?.(done);
+      } catch {
+        // A progress callback must never be able to fail gathering.
+      }
+      resolve(done);
+    };
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      removeWaiters();
+      reject(abortReason());
+    };
+    const onState = () => {
+      if (pc.iceGatheringState === "complete") finish("complete");
+    };
+    const onCandidate = (event: RTCPeerConnectionIceEvent) => {
+      const type = event.candidate
+        ? parseIceCandidateType(event.candidate.candidate)
+        : null;
+      if (type) counts[type] += 1;
+      if (quiet !== null) clearTimeout(quiet);
+      if (sufficient())
+        quiet = setTimeout(() => finish("sufficient"), quietPeriodMs);
+    };
+    const hardBound = setTimeout(() => finish("timeout"), timeoutMs);
+    pc.addEventListener("icegatheringstatechange", onState as EventListener);
+    pc.addEventListener("icecandidate", onCandidate as EventListener);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    // A set seeded from the local description can already be sufficient — start the quiet period
+    // now rather than waiting for a further event that may never come.
+    if (sufficient()) {
+      quiet = setTimeout(() => finish("sufficient"), quietPeriodMs);
+    }
+    // Close the race where the signal aborts between the initial check and listener registration.
+    if (signal?.aborted) onAbort();
+  });
+}

--- a/libs/client/src/realtime/index.ts
+++ b/libs/client/src/realtime/index.ts
@@ -1,0 +1,29 @@
+export {
+  defineRealtimeExtension,
+  type AnyRealtimeExtension,
+  type IceGatheringOptions,
+  type IceGatheringResult,
+  type ManagedRealtimeSession,
+  type RealtimeDiagnostic,
+  type RealtimeExtension,
+  type RealtimeExtensionContext,
+  type RealtimeExtensionOptions,
+  type RealtimeExtensionSession,
+  type RealtimeOpenOptions,
+  type RealtimeSession,
+  type RealtimeState,
+} from "./extension";
+
+// Public building blocks for extensions, including ones maintained outside this package.
+export {
+  DEFAULT_ICE_QUIET_PERIOD_MS,
+  DEFAULT_ICE_TIMEOUT_MS,
+  countTurnServers,
+  gatherIceCandidates,
+  hasTurnServer,
+  parseIceCandidateType,
+} from "./ice";
+
+export * from "./lucy";
+export * from "./websocket";
+export * from "./wma";

--- a/libs/client/src/realtime/lucy.spec.ts
+++ b/libs/client/src/realtime/lucy.spec.ts
@@ -1,0 +1,644 @@
+import type { RealtimeConnectionHandler } from "../realtime";
+import type { RealtimeExtensionContext } from "./extension";
+import { lucyRealtime } from "./lucy";
+import { fakeExtensionContext } from "./testing";
+
+describe("lucyRealtime", () => {
+  beforeEach(() => {
+    (global as any).crypto = { randomUUID: () => "lucy-test" };
+  });
+
+  it("negotiates WebRTC after the endpoint supplies ICE servers", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const send = jest.fn();
+    const close = jest.fn();
+    const fail = jest.fn();
+    const controller = new AbortController();
+    const cleanups: Array<() => void | Promise<void>> = [];
+    const diagnostics: unknown[] = [];
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      signal: controller.signal,
+      run: jest.fn(),
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send, close };
+        // Cast narrowed to this member: the mock cannot express connect's generics. The surrounding
+        // compiler-checked context ensures required members cannot disappear from the fake.
+      }) as RealtimeExtensionContext["connect"],
+      addCleanup: (cleanup: () => void | Promise<void>) =>
+        cleanups.push(cleanup),
+      close: jest.fn(),
+      diagnostic: (event: unknown) => diagnostics.push(event),
+      fail,
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "make it cinematic" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    const session = await opening;
+
+    expect(send).toHaveBeenNthCalledWith(1, {
+      prompt: "make it cinematic",
+    });
+    expect(send).toHaveBeenNthCalledWith(2, {
+      type: "offer",
+      sdp: "local-offer",
+    });
+    expect(peer.addTransceiver).toHaveBeenCalledWith("video", {
+      direction: "recvonly",
+    });
+
+    controller.abort();
+    await Promise.all(cleanups.map((cleanup) => cleanup()));
+    session.send({ prompt: "must stay closed" });
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(fail).not.toHaveBeenCalled();
+    expect(peer.close).toHaveBeenCalledTimes(1);
+    // Lucy's own vocabulary is progress detail; the uniform lifecycle belongs to the kernel, and
+    // this spec drives open() directly so there is no kernel here to ask.
+    expect(diagnostics).toContainEqual({
+      kind: "progress",
+      phase: "connection-state",
+      detail: { state: "closed" },
+    });
+  });
+
+  it("applies an at-least-once SDP answer only once while the first is pending", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    let releaseRemoteDescription!: () => void;
+    const remoteDescriptionGate = new Promise<void>((resolve) => {
+      releaseRemoteDescription = resolve;
+    });
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn(() => remoteDescriptionGate),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const answer = {
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    };
+    handler?.onResult(answer);
+    handler?.onResult(answer);
+
+    expect(peer.setRemoteDescription).toHaveBeenCalledTimes(1);
+    releaseRemoteDescription();
+    await opening;
+  });
+
+  it("latches a failed peer before its progress diagnostic can close", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    let closed = false;
+    const order: string[] = [];
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting" as RTCPeerConnectionState,
+      iceConnectionState: "failed" as RTCIceConnectionState,
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const fail = jest.fn(async () => {
+      if (!closed) order.push("fail");
+    });
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      fail,
+      diagnostic: (event) => {
+        if (
+          event.kind === "progress" &&
+          event.phase === "connection-state" &&
+          event.detail?.state === "failed"
+        ) {
+          order.push("diagnostic");
+          closed = true;
+        }
+      },
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+
+    (
+      peer as unknown as { connectionState: RTCPeerConnectionState }
+    ).connectionState = "failed";
+    peer.onconnectionstatechange?.(new Event("connectionstatechange"));
+
+    expect(order).toEqual(["fail", "diagnostic"]);
+    expect(fail).toHaveBeenCalledWith(
+      "Lucy peer connection failed — no candidate pair survived",
+      { iceConnectionState: "failed" },
+    );
+  });
+
+  it("reports an error frame that lands right after the answer resolves", async () => {
+    // The failure window: the answer resolves the negotiation promise, but open()'s awaiting
+    // continuation has not run yet. An error frame handled in that microtask gap must reach
+    // context.fail — rejecting the already-resolved negotiation promise is a silent no-op.
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const fail = jest.fn(async () => undefined);
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      fail,
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+    // An error frame after the negotiation settled must reach context.fail — `settled` flips at
+    // promise-settle time, so no microtask window exists where rejecting the already-resolved
+    // negotiation promise would swallow the failure silently.
+    handler?.onResult({ type: "error", request_id: "boom" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fail).toHaveBeenCalledWith(
+      "Lucy signaling endpoint reported an error",
+    );
+  });
+
+  it("falls back to a receive-only transceiver for an empty local stream", async () => {
+    // A valid-but-empty MediaStream must not produce an offer with no media section: track count
+    // decides the path, not stream truthiness.
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const peer = {
+      addTrack: jest.fn(),
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+      localStream: { getTracks: () => [] } as unknown as MediaStream,
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+
+    expect(peer.addTrack).not.toHaveBeenCalled();
+    expect(peer.addTransceiver).toHaveBeenCalledWith("video", {
+      direction: "recvonly",
+    });
+  });
+
+  it("closes the session when signaling closes normally after negotiation", async () => {
+    // A normal remote closure (code 1000) is not an error, but Lucy's controls ride the
+    // signaling socket — a session that cannot be steered must not keep reporting live.
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const close = jest.fn(async () => undefined);
+    const fail = jest.fn(async () => undefined);
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      close,
+      fail,
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+
+    handler?.onClose?.({ code: 1000, reason: "server done" });
+    await Promise.resolve();
+
+    expect(close).toHaveBeenCalled();
+    expect(fail).not.toHaveBeenCalled();
+  });
+
+  it("fails negotiation when signaling closes normally before the answer", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const fail = jest.fn(async () => undefined);
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      fail,
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "x" },
+    });
+    const settled = opening.catch((error) => error);
+    handler?.onClose?.({ code: 1000, reason: "gone early" });
+
+    const error = await settled;
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toMatch(/closed before negotiation/);
+  });
+
+  it("publishes its remote stream through context.media", async () => {
+    // Inbound media goes through the kernel's channel, never an option of this extension's own, so
+    // that an app offering more than one protocol has one name for it rather than one per protocol.
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const seen: MediaStream[] = [];
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      run: jest.fn(),
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      media: (stream: MediaStream) => void seen.push(stream),
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "anything" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+
+    const stream = { id: "lucy-remote" } as unknown as MediaStream;
+    const secondStream = {
+      id: "lucy-remote-secondary",
+    } as unknown as MediaStream;
+    (peer.ontrack as unknown as (event: unknown) => void)({
+      streams: [stream, secondStream],
+    });
+    (peer.ontrack as unknown as (event: unknown) => void)({
+      streams: [stream, secondStream],
+    });
+    expect(seen).toEqual([stream, secondStream]);
+  });
+
+  it("synthesizes a stream for a streamless remote track", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const seen: MediaStream[] = [];
+    const containedTracks: unknown[] = [];
+    (global as unknown as { MediaStream: unknown }).MediaStream = class {
+      constructor(tracks: unknown[]) {
+        containedTracks.push(...tracks);
+      }
+    };
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      media: (stream: MediaStream) => void seen.push(stream),
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "anything" },
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    handler?.onResult({
+      type: "answer",
+      sdp: "remote-answer",
+      request_id: "answer",
+    });
+    await opening;
+
+    const track = { kind: "video" };
+    (peer.ontrack as unknown as (event: unknown) => void)({
+      streams: [],
+      track,
+    });
+    expect(seen).toHaveLength(1);
+    expect(containedTracks).toEqual([track]);
+  });
+
+  it("rejects immediately when signaling is aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user left");
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const cleanups: Array<() => void | Promise<void>> = [];
+    const diagnostics: unknown[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      signal: controller.signal,
+      run: jest.fn(),
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+      addCleanup: (cleanup: () => void | Promise<void>) =>
+        cleanups.push(cleanup),
+      close: jest.fn(),
+      diagnostic: (event: unknown) => diagnostics.push(event),
+      fail: jest.fn(),
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "make it cinematic" },
+    });
+    controller.abort(reason);
+
+    await expect(opening).rejects.toBe(reason);
+    await Promise.all(cleanups.map((cleanup) => cleanup()));
+    expect(handler).toBeDefined();
+  });
+
+  it("honors an abort issued synchronously from the negotiating diagnostic", async () => {
+    // The initial "negotiating" report fires after open()'s throwIfAborted but before the
+    // negotiation abort listener exists, and an AbortSignal does not replay its event. Without the
+    // recheck, negotiation waits out its timeout and reports that instead of the caller's reason.
+    const controller = new AbortController();
+    const reason = new Error("aborted mid-diagnostic");
+    const connect = jest.fn(() => ({
+      send: jest.fn(),
+      close: jest.fn(),
+    }));
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      signal: controller.signal,
+      connect: connect as unknown as RealtimeExtensionContext["connect"],
+      diagnostic: () => controller.abort(reason),
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "make it cinematic" },
+    });
+
+    await expect(opening).rejects.toBe(reason);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("observes the negotiation rejection when setup fails before awaiting it", async () => {
+    const controller = new AbortController();
+    const setupFailure = new Error("signaling setup failed");
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      signal: controller.signal,
+      connect: (() => {
+        throw setupFailure;
+      }) as RealtimeExtensionContext["connect"],
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "anything" },
+    });
+    await expect(opening).rejects.toBe(setupFailure);
+
+    // The kernel aborts the managed context after setup rejects. The negotiation promise already
+    // exists but open() never reached its await, so this must not become a second, unhandled error.
+    controller.abort(new Error("managed teardown"));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+  it("rejects when fallback peer initialization fails", async () => {
+    const failure = new Error("could not create an offer");
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockRejectedValue(failure),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "anything" },
+      iceServerGraceMs: 0,
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({ type: "ready", request_id: "ready" });
+
+    await expect(opening).rejects.toBe(failure);
+  });
+
+  it("keeps waiting when ICE servers arrive without an SDP answer", async () => {
+    let handler: RealtimeConnectionHandler<Record<string, unknown>> | undefined;
+    const peer = {
+      addTransceiver: jest.fn(),
+      createOffer: jest.fn().mockResolvedValue({ sdp: "local-offer" }),
+      setLocalDescription: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+      connectionState: "connecting",
+      ontrack: null,
+      onicecandidate: null,
+      onconnectionstatechange: null,
+    } as unknown as RTCPeerConnection;
+    const context = fakeExtensionContext({
+      endpointId: "decart/lucy-2-5/realtime",
+      connect: ((_endpointId: string, nextHandler: typeof handler) => {
+        handler = nextHandler;
+        return { send: jest.fn(), close: jest.fn() };
+      }) as RealtimeExtensionContext["connect"],
+    });
+
+    const opening = lucyRealtime().open(context, {
+      input: { prompt: "anything" },
+      negotiationTimeoutMs: 1,
+      peerConnectionFactory: () => peer,
+    });
+    handler?.onResult({
+      type: "iceServers",
+      iceServers: [],
+      request_id: "ready",
+    });
+
+    await expect(opening).rejects.toThrow(
+      "Lucy signaling did not return an SDP answer within 1ms",
+    );
+  });
+});

--- a/libs/client/src/realtime/lucy.ts
+++ b/libs/client/src/realtime/lucy.ts
@@ -1,0 +1,385 @@
+import type { TokenProvider } from "../auth";
+import { throwIfRealtimeAborted } from "./abort";
+import { defineRealtimeExtension, type RealtimeSession } from "./extension";
+
+const DEFAULT_ENDPOINTS = [
+  "decart/lucy-2-5/realtime",
+  "decart/lucy-2/realtime",
+] as const;
+
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+  { urls: "stun:stun.l.google.com:19302" },
+];
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export type LucyConnectionState = "negotiating" | RTCPeerConnectionState;
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface LucyRealtimeOptions<Input = Record<string, unknown>> {
+  /** First model input. Sending it starts the fal WebSocket session. */
+  input: Input;
+  /** Camera, canvas, or video stream sent to Lucy. */
+  localStream?: MediaStream | null;
+  /** Used only when the endpoint does not supply STUN/TURN configuration. */
+  fallbackIceServers?: RTCIceServer[];
+  /** How long to wait for the endpoint's remote SDP answer. */
+  negotiationTimeoutMs?: number;
+  /** How long to wait after `ready` for a separate ICE-server message. */
+  iceServerGraceMs?: number;
+  tokenProvider?: TokenProvider;
+  tokenExpirationSeconds?: number;
+  /** Injectable for tests and non-window browser runtimes. */
+  peerConnectionFactory?: (
+    configuration: RTCConfiguration,
+  ) => RTCPeerConnection;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface LucyRealtimeSession<Input = Record<string, unknown>>
+  extends RealtimeSession {
+  readonly remoteStream: MediaStream | null;
+  send(input: Partial<Input> & Record<string, unknown>): void;
+}
+
+type SignalingMessage = {
+  type?: string;
+  sdp?: string;
+  candidate?: RTCIceCandidateInit | null;
+  iceServers?: RTCIceServer[];
+  ice_servers?: RTCIceServer[];
+  iceservers?: RTCIceServer[];
+};
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface LucyRealtimeExtensionConfig {
+  endpoints?: readonly string[];
+}
+
+/**
+ * Lucy's fal-WebSocket + WebRTC signaling protocol.
+ *
+ * The extension owns SDP/ICE ordering, remote-candidate buffering, and
+ * teardown. The application only provides media, observes the remote stream,
+ * and sends model controls.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function lucyRealtime<Input = Record<string, unknown>>(
+  config: LucyRealtimeExtensionConfig = {},
+) {
+  const endpoints = config.endpoints ?? DEFAULT_ENDPOINTS;
+
+  return defineRealtimeExtension<
+    LucyRealtimeOptions<Input>,
+    LucyRealtimeSession<Input>
+  >({
+    id: "fal/lucy-webrtc",
+    defaultEndpoint: endpoints[0],
+    supports: (endpointId) => endpoints.includes(endpointId),
+    async open(context, options) {
+      throwIfRealtimeAborted(context.signal);
+      const createPeerConnection =
+        options.peerConnectionFactory ??
+        ((configuration: RTCConfiguration) =>
+          new RTCPeerConnection(configuration));
+      let peer: RTCPeerConnection | null = null;
+      const transport: {
+        connection?: {
+          send(input: Record<string, unknown>): void;
+          close(): void;
+        };
+      } = {};
+      let remoteStream: MediaStream | null = null;
+      const publishedStreams = new WeakSet<MediaStream>();
+      let hasRemoteDescription = false;
+      let applyingRemoteDescription = false;
+      let initialized = false;
+      let settled = false;
+      let iceGraceTimer: ReturnType<typeof setTimeout> | undefined;
+      const pendingCandidates: RTCIceCandidateInit[] = [];
+
+      // Reported as PROGRESS DETAIL, not as lifecycle. Lucy's own vocabulary — "negotiating", then
+      // the peer connection's states — is meaningful to someone debugging Lucy and meaningless as a
+      // cross-protocol signal, so the kernel owns "opening/live/failed/closed" and this carries the
+      // specifics underneath it.
+      const reportState = (next: LucyConnectionState) => {
+        context.diagnostic({
+          kind: "progress",
+          phase: "connection-state",
+          detail: { state: next },
+        });
+      };
+      reportState("negotiating");
+
+      let resolveNegotiationRaw!: () => void;
+      let rejectNegotiationRaw!: (error: Error) => void;
+      const negotiation = new Promise<void>((resolve, reject) => {
+        resolveNegotiationRaw = resolve;
+        rejectNegotiationRaw = reject;
+      });
+      // Setup below can throw before execution reaches `await negotiation`. Teardown then aborts
+      // the context and rejects this promise, so mark that rejection observed immediately while
+      // preserving the original promise for the later await to propagate the same failure.
+      void negotiation.catch(() => undefined);
+      // `settled` flips the moment the promise SETTLES, not when open()'s awaiting continuation
+      // runs — otherwise an error frame landing in the microtask gap between the answer's resolve
+      // and that continuation would call rejectNegotiation on an already-resolved promise (a
+      // silent no-op) instead of context.fail, and a terminal failure would vanish entirely.
+      const resolveNegotiation = () => {
+        settled = true;
+        resolveNegotiationRaw();
+      };
+      const rejectNegotiation = (error: Error) => {
+        settled = true;
+        rejectNegotiationRaw(error);
+      };
+      const negotiationTimer = setTimeout(() => {
+        rejectNegotiation(
+          new Error(
+            `Lucy signaling did not return an SDP answer within ${
+              options.negotiationTimeoutMs ?? 15_000
+            }ms`,
+          ),
+        );
+      }, options.negotiationTimeoutMs ?? 15_000);
+
+      const fail = (error: unknown) => {
+        const resolved =
+          error instanceof Error ? error : new Error(String(error));
+        if (!settled) {
+          // Before the session exists, the failure travels by rejecting open() — the caller is still
+          // awaiting it, so a diagnostic would be a second copy of something they already get.
+          rejectNegotiation(resolved);
+        } else {
+          // After open() resolves, a throw has no awaiting caller. context.fail publishes the
+          // failure, latches state as "failed", and tears down the session.
+          void context.fail(resolved.message);
+        }
+      };
+      const abortNegotiation = () => {
+        if (settled) return;
+        fail(
+          context.signal.reason ??
+            new DOMException("Lucy signaling aborted", "AbortError"),
+        );
+      };
+      context.signal.addEventListener("abort", abortNegotiation, {
+        once: true,
+      });
+      // A caller can abort synchronously from the "negotiating" diagnostic, before this listener
+      // exists — and an AbortSignal does not replay its event. Without the recheck, negotiation
+      // waits out its timeout and reports that instead of the caller's abort reason.
+      if (context.signal.aborted) {
+        throw (
+          context.signal.reason ??
+          new DOMException("Lucy signaling aborted", "AbortError")
+        );
+      }
+
+      const flushCandidates = async () => {
+        if (!peer || !hasRemoteDescription) return;
+        for (const candidate of pendingCandidates.splice(0)) {
+          await peer.addIceCandidate(new RTCIceCandidate(candidate));
+        }
+      };
+
+      const initializePeer = async (iceServers?: RTCIceServer[]) => {
+        if (initialized || context.signal.aborted) return;
+        initialized = true;
+        clearTimeout(iceGraceTimer);
+        peer = createPeerConnection({
+          iceServers:
+            iceServers ?? options.fallbackIceServers ?? DEFAULT_ICE_SERVERS,
+        });
+        const localStream = options.localStream;
+        const localTracks = localStream?.getTracks() ?? [];
+        // Track COUNT, not stream truthiness: a valid-but-empty MediaStream (created before its
+        // camera track attached) would otherwise add no tracks AND skip the receive-only
+        // transceiver, producing an offer with no video media section at all — and tracks added
+        // to the stream later never reach the peer connection.
+        if (localTracks.length > 0) {
+          for (const track of localTracks) {
+            peer.addTrack(track, localStream as MediaStream);
+          }
+        } else {
+          peer.addTransceiver("video", { direction: "recvonly" });
+        }
+        peer.ontrack = (event) => {
+          const streams =
+            event.streams.length > 0
+              ? event.streams
+              : [new MediaStream([event.track])];
+          remoteStream = streams[0];
+          for (const stream of streams) {
+            if (!publishedStreams.has(stream)) {
+              publishedStreams.add(stream);
+              context.media(stream);
+            }
+          }
+        };
+        peer.onicecandidate = (event) => {
+          if (!event.candidate) return;
+          transport.connection?.send({
+            type: "icecandidate",
+            candidate: {
+              candidate: event.candidate.candidate,
+              sdpMid: event.candidate.sdpMid,
+              sdpMLineIndex: event.candidate.sdpMLineIndex,
+            },
+          });
+        };
+        peer.onconnectionstatechange = () => {
+          if (!peer) return;
+          // A dead peer is a failure; a closed peer is an orderly teardown. Status UIs need that
+          // distinction even though both paths release the same resources.
+          if (peer.connectionState === "failed") {
+            void context.fail(
+              "Lucy peer connection failed — no candidate pair survived",
+              { iceConnectionState: peer.iceConnectionState },
+            );
+          }
+          // context.fail() latches the terminal cause synchronously before this user-visible
+          // progress callback can re-enter close() and misclassify the failure as orderly.
+          reportState(peer.connectionState);
+          if (peer.connectionState === "closed") {
+            void context.close();
+          }
+        };
+
+        const offer = await peer.createOffer();
+        await peer.setLocalDescription(offer);
+        if (!offer.sdp) throw new Error("Lucy WebRTC offer has no SDP");
+        transport.connection?.send({ type: "offer", sdp: offer.sdp });
+      };
+
+      const handleMessage = async (message: SignalingMessage) => {
+        switch (message.type?.toLowerCase()) {
+          case "ready": {
+            // Every spelling SignalingMessage declares — the separate "iceservers" handler and
+            // the type both accept the all-lowercase key, and a ready frame carrying TURN under
+            // it must not be treated as carrying none.
+            const supplied =
+              message.iceServers ?? message.ice_servers ?? message.iceservers;
+            if (supplied) {
+              await initializePeer(supplied);
+            } else {
+              iceGraceTimer = setTimeout(
+                () => void initializePeer().catch(fail),
+                options.iceServerGraceMs ?? 1_000,
+              );
+            }
+            break;
+          }
+          case "iceservers": {
+            if (initialized) {
+              // The grace timer already built the peer with fallback servers; a config arriving
+              // now cannot join this negotiation. Surface the drop — on TURN-requiring networks
+              // this is the difference between "failed 20s later, silently" and a lead.
+              context.diagnostic({
+                kind: "warning",
+                message:
+                  "ICE servers arrived after the peer connection was created and were ignored; " +
+                  "consider raising iceServerGraceMs.",
+              });
+              break;
+            }
+            await initializePeer(
+              message.iceServers ?? message.ice_servers ?? message.iceservers,
+            );
+            break;
+          }
+          case "answer": {
+            if (!peer || !message.sdp) return;
+            // Idempotent against at-least-once signaling delivery: a second answer would call
+            // setRemoteDescription in signalingState "stable", throw InvalidStateError, and the
+            // .catch(fail) would tear down a perfectly live session.
+            if (hasRemoteDescription || applyingRemoteDescription) return;
+            applyingRemoteDescription = true;
+            try {
+              await peer.setRemoteDescription({
+                type: "answer",
+                sdp: message.sdp,
+              });
+              hasRemoteDescription = true;
+            } finally {
+              applyingRemoteDescription = false;
+            }
+            await flushCandidates();
+            resolveNegotiation();
+            break;
+          }
+          case "icecandidate": {
+            if (!message.candidate) return;
+            if (!peer || !hasRemoteDescription) {
+              pendingCandidates.push(message.candidate);
+            } else {
+              await peer.addIceCandidate(
+                new RTCIceCandidate(message.candidate),
+              );
+            }
+            break;
+          }
+          case "error":
+            fail(new Error("Lucy signaling endpoint reported an error"));
+            break;
+        }
+      };
+
+      transport.connection = context.connect(context.endpointId, {
+        connectionKey: `lucy-${crypto.randomUUID()}`,
+        throttleInterval: 0,
+        tokenProvider: options.tokenProvider,
+        tokenExpirationSeconds: options.tokenExpirationSeconds,
+        onResult: (message) => {
+          void handleMessage(message as SignalingMessage).catch(fail);
+        },
+        onError: fail,
+        // A NORMAL remote closure of the signaling socket is not an error, but this session's
+        // controls ride on it: before the answer it means negotiation can never complete, and
+        // after it the session cannot be steered — either way "live" would be a lie.
+        onClose: () => {
+          if (!settled) {
+            fail(
+              new Error("Lucy signaling closed before negotiation completed"),
+            );
+            return;
+          }
+          void context.close();
+        },
+      });
+      context.addCleanup(() => {
+        context.signal.removeEventListener("abort", abortNegotiation);
+        clearTimeout(negotiationTimer);
+        clearTimeout(iceGraceTimer);
+        const connection = transport.connection;
+        transport.connection = undefined;
+        connection?.close();
+        peer?.close();
+        peer = null;
+        reportState("closed");
+      });
+
+      transport.connection.send(options.input as Record<string, unknown>);
+      try {
+        // `settled` is already latched by resolveNegotiation/rejectNegotiation — the only
+        // settlers of this promise — before it can observably settle here.
+        await negotiation;
+        context.signal.removeEventListener("abort", abortNegotiation);
+      } finally {
+        clearTimeout(negotiationTimer);
+      }
+
+      return {
+        get remoteStream() {
+          return remoteStream;
+        },
+        send(input) {
+          transport.connection?.send(input);
+        },
+        close() {
+          // The client wraps this with the managed, idempotent cleanup.
+        },
+      };
+    },
+  });
+}

--- a/libs/client/src/realtime/protocol.ts
+++ b/libs/client/src/realtime/protocol.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * The fal realtime wire protocol: URL, framing, and result classification.
+ *
+ * `connect()` and the `websocket()` extension use these shared functions rather than parallel
+ * implementations that can drift. The two differ only in
+ * WHEN they open a socket and who owns its lifecycle; if they also differed in what they put on it,
+ * offering both would be offering two protocols under one name.
+ */
+import { decode, encode } from "@msgpack/msgpack";
+import { ensureEndpointIdFormat, resolveEndpointPath } from "../utils";
+
+/** Matches `connect()`'s default, and the interval realtime apps were tuned against. */
+export const DEFAULT_THROTTLE_INTERVAL = 128;
+
+/** See https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1 */
+export const WebSocketErrorCodes = {
+  NORMAL_CLOSURE: 1000,
+  GOING_AWAY: 1001,
+};
+
+export type WithRequestId = {
+  request_id: string;
+};
+
+export type RealtimeUrlParams = {
+  token: string;
+  maxBuffering?: number;
+  path?: string;
+};
+
+export function buildRealtimeUrl(
+  app: string,
+  { token, maxBuffering, path }: RealtimeUrlParams,
+): string {
+  if (maxBuffering !== undefined && (maxBuffering < 1 || maxBuffering > 60)) {
+    throw new Error("The `maxBuffering` must be between 1 and 60 (inclusive)");
+  }
+  const queryParams = new URLSearchParams({
+    fal_jwt_token: token,
+  });
+  if (maxBuffering !== undefined) {
+    queryParams.set("max_buffering", maxBuffering.toFixed(0));
+  }
+  const appId = ensureEndpointIdFormat(app);
+  const resolvedPath = resolveEndpointPath(app, path, "/realtime") ?? "";
+  return `wss://fal.run/${appId}${resolvedPath}?${queryParams.toString()}`;
+}
+
+/** The endpoint the token is minted for: the app id plus the resolved realtime path. */
+export function realtimeTokenScope(app: string, path?: string): string {
+  // Deliberately stricter than run()/stream(), which accept full fal URLs: the realtime socket
+  // address is DERIVED from the id (wss://fal.run/<id>/...), so a URL can never resolve to a
+  // valid socket — the error names that instead of a generic invalid-endpoint.
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(app.trim())) {
+    throw new Error(
+      'Realtime endpoints take an app id like "owner/app", not a URL — the socket address ' +
+        "is derived from the id.",
+    );
+  }
+  return `${ensureEndpointIdFormat(app)}${resolveEndpointPath(app, path, "/realtime") ?? ""}`;
+}
+
+export function isUnauthorizedError(message: any): boolean {
+  // TODO we need better protocol definition with error codes
+  return message["status"] === "error" && message["error"] === "Unauthorized";
+}
+
+export function isSuccessfulResult(data: any): boolean {
+  return (
+    data.status !== "error" &&
+    data.type !== "x-fal-message" &&
+    !isFalErrorResult(data)
+  );
+}
+
+export type FalErrorResult = {
+  type: "x-fal-error";
+  error: string;
+  reason: string;
+};
+
+export function isFalErrorResult(data: any): data is FalErrorResult {
+  return data.type === "x-fal-error";
+}
+
+export async function decodeRealtimeMessage(data: any): Promise<any> {
+  if (typeof data === "string") {
+    return JSON.parse(data);
+  }
+
+  const toUint8Array = async (
+    value: ArrayBuffer | Uint8Array | Blob,
+  ): Promise<Uint8Array> => {
+    if (value instanceof Uint8Array) {
+      return value;
+    }
+    if (value instanceof Blob) {
+      return new Uint8Array(await value.arrayBuffer());
+    }
+    return new Uint8Array(value);
+  };
+
+  if (data instanceof ArrayBuffer || data instanceof Uint8Array) {
+    return decode(await toUint8Array(data));
+  }
+  if (data instanceof Blob) {
+    return decode(await toUint8Array(data));
+  }
+
+  return data;
+}
+
+export function encodeRealtimeMessage(input: any): Uint8Array | string {
+  if (input instanceof Uint8Array) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return encode(input);
+  }
+  return encode(input);
+}

--- a/libs/client/src/realtime/testing.ts
+++ b/libs/client/src/realtime/testing.ts
@@ -1,0 +1,43 @@
+import type {
+  IceGatheringResult,
+  RealtimeDiagnostic,
+  RealtimeExtensionContext,
+} from "./extension";
+
+/**
+ * A complete, compiler-checked `RealtimeExtensionContext` for extension tests.
+ *
+ * Returning the interface directly means a new required context member produces a compile error in
+ * extension tests instead of a later "method is not a function" failure. Overrides keep individual
+ * tests small without weakening the rest of the contract.
+ *
+ * Exported from `@fal-ai/client/realtime/testing` so external extensions can use the same checked
+ * fixture. It stays out of the `./realtime` barrel so production bundles do not include it.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function fakeExtensionContext(
+  overrides: Partial<RealtimeExtensionContext> = {},
+): RealtimeExtensionContext {
+  const ice: IceGatheringResult = {
+    host: 0,
+    srflx: 0,
+    relay: 0,
+    state: "complete",
+  };
+  return {
+    endpointId: "test/endpoint",
+    signal: new AbortController().signal,
+    run: async () => ({ data: undefined, requestId: "test" }) as never,
+    connect: () => ({ send: () => undefined, close: () => undefined }) as never,
+    addCleanup: () => undefined,
+    close: async () => undefined,
+    fetch: async () => new Response("{}"),
+    gatherIce: async () => ice,
+    diagnostic: (_event: RealtimeDiagnostic) => undefined,
+    media: (_stream: MediaStream) => undefined,
+    data: (_raw: string) => undefined,
+    fail: async () => undefined,
+    ...overrides,
+  };
+}

--- a/libs/client/src/realtime/websocket.spec.ts
+++ b/libs/client/src/realtime/websocket.spec.ts
@@ -1,0 +1,468 @@
+import { decode, encode } from "@msgpack/msgpack";
+import { fakeExtensionContext } from "./testing";
+import { websocket } from "./websocket";
+
+/** A socket that opens only when a test says so, which is the whole point of the extension. */
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static last: FakeWebSocket | undefined;
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: Array<Uint8Array | string> = [];
+  closedWith: number | undefined;
+
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.last = this;
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(payload: unknown) {
+    this.onmessage?.({ data: encode(payload) });
+  }
+
+  serverClose(code: number, reason = "") {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  send(frame: Uint8Array | string) {
+    this.sent.push(frame);
+  }
+
+  close(code?: number) {
+    this.closedWith = code;
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("websocket", () => {
+  const original = global.WebSocket;
+
+  beforeEach(() => {
+    FakeWebSocket.last = undefined;
+    global.WebSocket = FakeWebSocket as never;
+  });
+
+  afterEach(() => {
+    global.WebSocket = original;
+    jest.restoreAllMocks();
+  });
+
+  const tokenProvider = jest.fn(async () => "a-token");
+
+  function start(overrides: Record<string, unknown> = {}) {
+    const context = fakeExtensionContext({ endpointId: "fal-ai/fast-sdxl" });
+    const onResult = jest.fn();
+    const session = websocket().open(context, {
+      tokenProvider,
+      onResult,
+      ...overrides,
+    });
+    // Swallowed so a rejection in a test that expects one does not trip the runner first.
+    session.catch(() => undefined);
+    return { context, onResult, session };
+  }
+
+  it("does not resolve until the socket is open", async () => {
+    const { session } = start();
+    await flush();
+
+    let settled = false;
+    void session.then(() => (settled = true));
+    await flush();
+    // The difference from connect(), which hands back a sendable object immediately and buffers.
+    expect(settled).toBe(false);
+
+    FakeWebSocket.last?.open();
+    await expect(session).resolves.toMatchObject({
+      send: expect.any(Function),
+    });
+  });
+
+  it("rejects a handshake that fails instead of buffering into a dead socket", async () => {
+    const { session } = start();
+    await flush();
+    FakeWebSocket.last?.onerror?.();
+
+    await expect(session).rejects.toThrow(
+      /Could not open a realtime connection/,
+    );
+  });
+
+  it("reports a handshake the server closes rather than errors", async () => {
+    const { session } = start();
+    await flush();
+    FakeWebSocket.last?.serverClose(1008, "policy violation");
+
+    await expect(session).rejects.toThrow(/policy violation/);
+  });
+
+  it("times out a WebSocket handshake that remains connecting", async () => {
+    jest.useFakeTimers();
+    try {
+      const { session } = start();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(FakeWebSocket.last?.readyState).toBe(FakeWebSocket.CONNECTING);
+
+      jest.advanceTimersByTime(15_000);
+      await expect(session).rejects.toThrow(/Timed out opening/);
+      expect(FakeWebSocket.last?.onopen).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("mints the token for the realtime path and carries it in the url", async () => {
+    const { session } = start();
+    await flush();
+    FakeWebSocket.last?.open();
+    await session;
+
+    expect(tokenProvider).toHaveBeenCalledWith("fal-ai/fast-sdxl/realtime");
+    const url = new URL(FakeWebSocket.last?.url ?? "");
+    expect(url.protocol).toBe("wss:");
+    expect(url.pathname).toBe("/fal-ai/fast-sdxl/realtime");
+    expect(url.searchParams.get("fal_jwt_token")).toBe("a-token");
+  });
+
+  it("delivers decoded results and drops what is not one", async () => {
+    const { session, onResult } = start();
+    await flush();
+    const ws = FakeWebSocket.last!;
+    ws.open();
+    await session;
+
+    ws.receive({ request_id: "r1", images: [] });
+    ws.receive({ type: "x-fal-message", message: "queued" });
+    ws.receive({ type: "x-fal-error", error: "TIMEOUT", reason: "idle" });
+    await flush();
+
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith({ request_id: "r1", images: [] });
+  });
+
+  it("drops an asynchronous decode that finishes after teardown", async () => {
+    const controller = new AbortController();
+    let finishDecode: (value: unknown) => void = () => undefined;
+    const decoded = new Promise<unknown>((resolve) => {
+      finishDecode = resolve;
+    });
+    const onResult = jest.fn();
+    const context = fakeExtensionContext({
+      endpointId: "fal-ai/fast-sdxl",
+      signal: controller.signal,
+    });
+    const session = websocket().open(context, {
+      tokenProvider,
+      decodeMessage: () => decoded,
+      onResult,
+    });
+    await flush();
+    const ws = FakeWebSocket.last;
+    expect(ws).toBeDefined();
+    ws?.open();
+    await session;
+
+    ws?.onmessage?.({ data: "pending" });
+    controller.abort(new Error("session closed"));
+    finishDecode({ request_id: "too-late", images: [] });
+    await flush();
+
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it("contains a synchronous decoder throw after teardown", async () => {
+    const controller = new AbortController();
+    const diagnostic = jest.fn();
+    const context = fakeExtensionContext({
+      endpointId: "fal-ai/fast-sdxl",
+      signal: controller.signal,
+      diagnostic,
+    });
+    const session = websocket().open(context, {
+      tokenProvider,
+      decodeMessage: () => {
+        throw new Error("bad frame");
+      },
+      onResult: jest.fn(),
+    });
+    await flush();
+    const ws = FakeWebSocket.last;
+    ws?.open();
+    await session;
+    const diagnosticsBeforeTeardown = diagnostic.mock.calls.length;
+    controller.abort(new Error("session closed"));
+
+    expect(() => ws?.onmessage?.({ data: "bad" })).not.toThrow();
+    await flush();
+
+    expect(diagnostic).toHaveBeenCalledTimes(diagnosticsBeforeTeardown);
+  });
+
+  it("reports a synchronous decoder throw while live", async () => {
+    const diagnostic = jest.fn();
+    const context = fakeExtensionContext({ diagnostic });
+    const session = websocket().open(context, {
+      tokenProvider,
+      decodeMessage: () => {
+        throw new Error("bad frame");
+      },
+      onResult: jest.fn(),
+    });
+    await flush();
+    const ws = FakeWebSocket.last;
+    ws?.open();
+    await session;
+
+    ws?.onmessage?.({ data: "bad" });
+    await flush();
+
+    expect(diagnostic).toHaveBeenCalledWith({
+      kind: "warning",
+      message: "bad frame",
+    });
+  });
+
+  it("fails the session when the server rejects the token", async () => {
+    const fail = jest.fn(async () => undefined);
+    const context = fakeExtensionContext({
+      endpointId: "fal-ai/fast-sdxl",
+      fail,
+    });
+    const session = websocket().open(context, {
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    await flush();
+    const ws = FakeWebSocket.last!;
+    ws.open();
+    await session;
+
+    ws.receive({ status: "error", error: "Unauthorized" });
+    await flush();
+
+    // connect() would reconnect on the next send; here the caller can see it died.
+    expect(fail).toHaveBeenCalledWith("realtime connection is unauthorized");
+  });
+
+  it("separates a clean close from a transport that died", async () => {
+    for (const [code, expected] of [
+      [1000, "close"],
+      [1006, "fail"],
+    ] as const) {
+      const close = jest.fn(async () => undefined);
+      const fail = jest.fn(async () => undefined);
+      const context = fakeExtensionContext({ close, fail });
+      const session = websocket().open(context, {
+        tokenProvider,
+        onResult: jest.fn(),
+      });
+      await flush();
+      const ws = FakeWebSocket.last!;
+      ws.open();
+      await session;
+
+      ws.serverClose(code);
+      expect(close).toHaveBeenCalledTimes(expected === "close" ? 1 : 0);
+      expect(fail).toHaveBeenCalledTimes(expected === "fail" ? 1 : 0);
+    }
+  });
+
+  it("sends the first input immediately, and nothing once the socket is gone", async () => {
+    // Short enough that the trailing call below lands inside the test rather than after it.
+    const { session } = start({ throttleInterval: 10 });
+    await flush();
+    const ws = FakeWebSocket.last!;
+    ws.open();
+    const live = await session;
+
+    live.send({ prompt: "a cat" });
+    // Leading edge: a realtime app's first keystroke must not wait out the interval.
+    expect(ws.sent).toHaveLength(1);
+    expect(decode(ws.sent[0] as Uint8Array)).toEqual({ prompt: "a cat" });
+
+    ws.serverClose(1006);
+    live.send({ prompt: "a dog" });
+    // Deferred by the throttle, and still dropped when it fires: a trailing call cannot resurrect a
+    // socket the transport has already given up on.
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(ws.sent).toHaveLength(1);
+  });
+
+  it("paces rapid sends as a FIFO, delivering every message in order", async () => {
+    // A leading+trailing throttle keeps only the last pending call, so a synchronous burst — the
+    // kernel's pre-live queue flush is exactly that — would drop everything in the middle. The
+    // pacer must deliver all messages, in order, at the configured rate.
+    const context = fakeExtensionContext();
+    const session = websocket().open(context, {
+      tokenProvider,
+      throttleInterval: 10,
+      onResult: jest.fn(),
+    });
+    await flush();
+    const ws = FakeWebSocket.last!;
+    ws.open();
+    const live = await session;
+
+    live.send({ n: 1 });
+    live.send({ n: 2 });
+    live.send({ n: 3 });
+    expect(ws.sent).toHaveLength(1); // leading edge
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(ws.sent).toHaveLength(3);
+    expect(decode(ws.sent[0] as Uint8Array)).toEqual({ n: 1 });
+    expect(decode(ws.sent[1] as Uint8Array)).toEqual({ n: 2 });
+    expect(decode(ws.sent[2] as Uint8Array)).toEqual({ n: 3 });
+  });
+
+  it("keeps draining the pacer when a deferred message fails to encode", async () => {
+    // The drain timer has no caller to observe a throw; an encoding failure must become a
+    // diagnostic and the rest of the queue must still be delivered.
+    const diagnostics: string[] = [];
+    const context = fakeExtensionContext({
+      diagnostic: (event) => {
+        if (event.kind === "warning") diagnostics.push(event.message);
+      },
+    });
+    const session = websocket().open(context, {
+      tokenProvider,
+      throttleInterval: 10,
+      encodeMessage: (input: { n: number }) => {
+        if (input.n === 2) throw new Error("unencodable");
+        return JSON.stringify(input);
+      },
+      onResult: jest.fn(),
+    });
+    await flush();
+    const ws = FakeWebSocket.last!;
+    ws.open();
+    const live = await session;
+
+    live.send({ n: 1 });
+    live.send({ n: 2 }); // deferred, throws in the drain timer
+    live.send({ n: 3 });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(ws.sent).toEqual(['{"n":1}', '{"n":3}']);
+    expect(diagnostics).toEqual([
+      "A paced message could not be encoded and was dropped.",
+    ]);
+  });
+
+  it("stops opening when the caller aborts", async () => {
+    const controller = new AbortController();
+    const context = fakeExtensionContext({ signal: controller.signal });
+    const session = websocket().open(context, {
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    await flush();
+    controller.abort(new Error("caller went away"));
+
+    await expect(session).rejects.toThrow("caller went away");
+  });
+
+  it("opens when an older AbortSignal lacks throwIfAborted", async () => {
+    const controller = new AbortController();
+    Object.defineProperty(controller.signal, "throwIfAborted", {
+      value: undefined,
+    });
+    const context = fakeExtensionContext({ signal: controller.signal });
+    const opening = websocket().open(context, {
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+    await flush();
+    FakeWebSocket.last?.open();
+
+    const session = await opening;
+
+    await session.close();
+  });
+
+  it("does not mint a token when authenticating diagnostics cancel opening", async () => {
+    const controller = new AbortController();
+    const reason = new Error("aborted before authentication");
+    const provider = jest.fn(async () => "unused-token");
+    const context = fakeExtensionContext({
+      signal: controller.signal,
+      diagnostic: (event) => {
+        if (event.kind === "progress" && event.phase === "authenticating") {
+          controller.abort(reason);
+        }
+      },
+    });
+
+    const session = websocket().open(context, {
+      tokenProvider: provider,
+      onResult: jest.fn(),
+    });
+
+    await expect(session).rejects.toBe(reason);
+    expect(provider).not.toHaveBeenCalled();
+    expect(FakeWebSocket.last).toBeUndefined();
+  });
+
+  it("honors an abort issued synchronously from the connecting diagnostic", async () => {
+    // The abort lands after the handshake promise's throw-if-aborted moment but before its abort
+    // listener exists, and an AbortSignal does not replay its event. Without the recheck, the open
+    // waits out the 15-second handshake timeout and reports that instead of the caller's reason.
+    const controller = new AbortController();
+    const reason = new Error("aborted mid-diagnostic");
+    const context = fakeExtensionContext({
+      signal: controller.signal,
+      diagnostic: (event) => {
+        if (event.kind === "progress" && event.phase === "connecting") {
+          controller.abort(reason);
+        }
+      },
+    });
+    const session = websocket().open(context, {
+      tokenProvider,
+      onResult: jest.fn(),
+    });
+
+    await expect(session).rejects.toBe(reason);
+    expect(FakeWebSocket.last).toBeUndefined();
+  });
+
+  it("stops opening when token acquisition is still pending", async () => {
+    const controller = new AbortController();
+    const context = fakeExtensionContext({ signal: controller.signal });
+    const pendingToken = jest.fn(() => new Promise<string>(() => undefined));
+    const session = websocket().open(context, {
+      tokenProvider: pendingToken,
+      onResult: jest.fn(),
+    });
+    const reason = new Error("caller left during auth");
+
+    controller.abort(reason);
+
+    await expect(session).rejects.toBe(reason);
+    expect(FakeWebSocket.last).toBeUndefined();
+  });
+
+  it("claims no endpoints, and opens the one it was given", () => {
+    expect(websocket("fal-ai/fast-sdxl").supports).toBeUndefined();
+    expect(websocket("fal-ai/fast-sdxl").defaultEndpoint).toBe(
+      "fal-ai/fast-sdxl",
+    );
+  });
+});

--- a/libs/client/src/realtime/websocket.ts
+++ b/libs/client/src/realtime/websocket.ts
@@ -1,0 +1,408 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { TokenProvider } from "../auth";
+import { ApiError } from "../response";
+import { throwIfRealtimeAborted } from "./abort";
+import { defineRealtimeExtension, type RealtimeSession } from "./extension";
+import {
+  DEFAULT_THROTTLE_INTERVAL,
+  WebSocketErrorCodes,
+  buildRealtimeUrl,
+  decodeRealtimeMessage,
+  encodeRealtimeMessage,
+  isFalErrorResult,
+  isSuccessfulResult,
+  isUnauthorizedError,
+  realtimeTokenScope,
+  type WithRequestId,
+} from "./protocol";
+
+const MAX_PACED_MESSAGES = 64;
+
+const WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 15_000;
+
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    new DOMException("Realtime authentication aborted", "AbortError")
+  );
+}
+
+function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    if (signal.aborted) onAbort();
+  });
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WebsocketOptions<Output = any> {
+  /**
+   * Mints the short-lived token the socket authenticates with.
+   *
+   * Required, where `connect()` makes it optional and falls back to minting from the client's
+   * long-lived credentials. That fallback already warns that it is deprecated and points here, and it
+   * needs the parent config, which an extension is deliberately not given. The eager API therefore
+   * requires the supported short-lived-token path explicitly.
+   */
+  tokenProvider: TokenProvider;
+
+  /** Appended after the app id. Defaults to `/realtime`. */
+  path?: string;
+
+  /**
+   * Frames the server keeps buffered before dropping old ones for new. Between 1 and 60; the app
+   * decides when left unset.
+   */
+  maxBuffering?: number;
+
+  /**
+   * Minimum gap between sends, in milliseconds. Realtime apps react to typing and pointer movement,
+   * which produce far more input than a model can consume. Paced FIFO: the first input goes
+   * immediately and later ones drain in order at this rate — nothing in the middle is dropped,
+   * unlike a throttle — bounded at 64 pending with oldest-first eviction and a warning.
+   */
+  throttleInterval?: number;
+
+  /** Outgoing framing. Defaults to msgpack. */
+  encodeMessage?: (input: any) => Uint8Array | string;
+
+  /** Incoming framing. Defaults to msgpack, with JSON for text frames. */
+  decodeMessage?: (data: any) => Promise<any> | any;
+
+  /**
+   * One inference result.
+   *
+   * Not routed through the kernel's `onData`, which is deliberately a raw string because a transport
+   * cannot know a model's schema. This protocol does: results arrive msgpack-framed and are decoded
+   * before anything else looks at them, so handing back a re-serialized string would discard the one
+   * thing this transport knows that the others do not.
+   */
+  onResult(result: Output & WithRequestId): void;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WebsocketRealtimeSession<Input = any> extends RealtimeSession {
+  /**
+   * Queue one input. Paced FIFO — every message is delivered, in order, at the configured rate;
+   * nothing is coalesced or dropped short of the queue bound. A no-op once the session is no
+   * longer live — a dead socket is a dead session here, and `state` is where that is visible.
+   */
+  send(input: Input & Partial<WithRequestId>): void;
+}
+
+/**
+ * fal's own realtime inference protocol — msgpack over a fal WebSocket — behind `open()`.
+ *
+ * The same wire protocol as {@link RealtimeClient.connect}, through the same functions in
+ * `./protocol`, and the reason it is worth having twice is WHEN the socket opens. `connect()` is
+ * lazy: it returns synchronously, opens on the first `send()`, and buffers anything sent before the
+ * socket is up. That laziness is where its five-state machine, its single-slot buffer, and its
+ * connection cache all come from.
+ *
+ * `open()` starts negotiation eagerly the moment it returns, so none of that has anything to do.
+ * Pre-live sends ride the kernel's bounded queue and flush in order at "live"; a failed handshake
+ * reaches `onError` once, immediately (and rejects `ready` for callers who hold it), rather than
+ * arriving as a callback that may never fire; and `state` says `"live"` only when the transport
+ * agrees.
+ *
+ * What is deliberately NOT carried over:
+ *
+ * - **Implicit reconnect.** `connect()` reconnects on the next `send()` after any failure, which
+ *   falls out of its transitions rather than having been designed. Here a dead socket surfaces as
+ *   `state: "failed"` and the application reopens, because an application that can see the failure
+ *   can say something true about it instead of appearing to work while dropping every send.
+ * - **Token refresh.** `connect()` refreshes at 90% of expiry, but nothing sends a token over an
+ *   already-open socket and every exit from its active state discards the fetched value, so the
+ *   refreshed token reaches nothing. Whether that is dead code or a missing feature turns on whether
+ *   the server enforces expiry mid-connection, which is not answerable from the client;
+ *   reimplementing the timer here would copy a mechanism with no demonstrated effect.
+ *
+ * Both APIs intentionally coexist: `connect()` is synchronous and lazy; `open(websocket())` is
+ * asynchronous and eager.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function websocket<Input = any, Output = any>(endpointId?: string) {
+  return defineRealtimeExtension<
+    WebsocketOptions<Output>,
+    WebsocketRealtimeSession<Input>
+  >({
+    id: "fal/websocket",
+    defaultEndpoint: endpointId,
+    // No `supports`: any fal endpoint could plausibly expose a realtime path, and an extension with
+    // no closed set to check should state no constraint rather than assert one it cannot back up.
+    async open(context, options) {
+      const {
+        tokenProvider,
+        path,
+        maxBuffering,
+        throttleInterval = DEFAULT_THROTTLE_INTERVAL,
+        encodeMessage = encodeRealtimeMessage,
+        decodeMessage = decodeRealtimeMessage,
+        onResult,
+      } = options;
+
+      context.diagnostic({ kind: "progress", phase: "authenticating" });
+      throwIfRealtimeAborted(context.signal);
+      const token = await raceWithAbort(
+        tokenProvider(realtimeTokenScope(context.endpointId, path)),
+        context.signal,
+      );
+
+      context.diagnostic({ kind: "progress", phase: "connecting" });
+      throwIfRealtimeAborted(context.signal);
+      const ws = new WebSocket(
+        buildRealtimeUrl(context.endpointId, { token, maxBuffering, path }),
+      );
+      // Browsers default binaryType to "blob", whose decode is async (blob.arrayBuffer());
+      // ArrayBuffer frames decode synchronously, which both avoids that extra latency and
+      // removes the widest source of decode-time variance between neighboring frames.
+      ws.binaryType = "arraybuffer";
+      context.addCleanup(() => {
+        if (
+          ws.readyState === WebSocket.OPEN ||
+          ws.readyState === WebSocket.CONNECTING
+        ) {
+          ws.close(WebSocketErrorCodes.NORMAL_CLOSURE);
+        }
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const settle = (finish: () => void) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(handshakeTimeout);
+          ws.onopen = null;
+          ws.onerror = null;
+          ws.onclose = null;
+          context.signal.removeEventListener("abort", onAbort);
+          finish();
+        };
+        // A handshake that never completes is the case `connect()` cannot report at all: it has no
+        // promise to reject and no state to enter, so a wrong key or a missing endpoint looks
+        // exactly like a model that has not answered yet.
+        function onAbort() {
+          settle(() => reject(context.signal.reason));
+        }
+        ws.onopen = () => settle(resolve);
+        ws.onerror = () =>
+          settle(() =>
+            reject(
+              new ApiError({
+                message: `Could not open a realtime connection to ${context.endpointId}`,
+                status: 500,
+              }),
+            ),
+          );
+        // Some browsers report a rejected handshake only as a close.
+        ws.onclose = (event) =>
+          settle(() =>
+            reject(
+              new ApiError({
+                message: `Realtime connection to ${context.endpointId} closed during negotiation: ${
+                  event.reason || `code ${event.code}`
+                }`,
+                status: event.code,
+              }),
+            ),
+          );
+        context.signal.addEventListener("abort", onAbort, { once: true });
+        const handshakeTimeout = setTimeout(
+          () =>
+            settle(() =>
+              reject(
+                new ApiError({
+                  message: `Timed out opening a realtime connection to ${context.endpointId}`,
+                  status: 504,
+                }),
+              ),
+            ),
+          WEBSOCKET_HANDSHAKE_TIMEOUT_MS,
+        );
+        // A caller can abort synchronously from the "connecting" diagnostic, before the listener
+        // above exists — and an AbortSignal does not replay its event. Without this recheck (after
+        // `handshakeTimeout` exists, because settle clears it), the open waits out the handshake
+        // timeout and reports it instead of the caller's abort reason.
+        if (context.signal.aborted) {
+          onAbort();
+        }
+      });
+
+      // Decodes are SERIALIZED on one chain: each onmessage used to start an independent async
+      // decode, so a fast-decoding later frame (a short text frame) could overtake an earlier
+      // binary frame still awaiting its decode — out-of-order onResult delivery. The chain keeps
+      // wire order; a failed decode is contained per-link so the chain never sticks rejected.
+      let decodeChain: Promise<void> = Promise.resolve();
+      // Bounded like the send-side pacer: each chain link retains its frame until decoded, so a
+      // custom async decoder slower than frame arrival would otherwise grow memory without limit.
+      // Overflow drops the NEWEST frame with a warning — order stays intact for what's kept.
+      let pendingDecodes = 0;
+      let warnedDecodeBacklog = false;
+      ws.onmessage = (event) => {
+        if (pendingDecodes >= MAX_PACED_MESSAGES) {
+          if (!warnedDecodeBacklog) {
+            warnedDecodeBacklog = true;
+            context.diagnostic({
+              kind: "warning",
+              message:
+                "Inbound frames are decoding slower than they arrive; the newest are being dropped.",
+            });
+          }
+          return;
+        }
+        pendingDecodes++;
+        decodeChain = decodeChain
+          .then(() => decodeMessage(event.data))
+          .then((decoded) => {
+            if (context.signal.aborted) return;
+            if (isUnauthorizedError(decoded)) {
+              void context.fail("realtime connection is unauthorized");
+              return;
+            }
+            if (isSuccessfulResult(decoded)) {
+              onResult(decoded);
+              return;
+            }
+            if (isFalErrorResult(decoded)) {
+              // TIMEOUT means only that nothing has arrived for a while. The connection is fine.
+              if (decoded.error === "TIMEOUT") return;
+              context.diagnostic({
+                kind: "failure",
+                message: `${decoded.error}: ${decoded.reason}`,
+              });
+            }
+          })
+          .catch((error: unknown) => {
+            if (context.signal.aborted) return;
+            context.diagnostic({
+              kind: "warning",
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to decode a realtime message",
+            });
+          })
+          .finally(() => {
+            pendingDecodes--;
+          });
+      };
+
+      // A clean close and a dead transport are the two cases a status UI most needs to tell apart,
+      // and `connect()` reported both through the same callback.
+      ws.onclose = (event) => {
+        if (event.code === WebSocketErrorCodes.NORMAL_CLOSURE) {
+          void context.close();
+          return;
+        }
+        void context.fail(
+          `Realtime connection closed: ${event.reason || "no reason given"}`,
+          { code: event.code },
+        );
+      };
+
+      const write = (input: Input & Partial<WithRequestId>) => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        ws.send(encodeMessage(input));
+      };
+      // A paced FIFO rather than a leading+trailing throttle: the throttle keeps only the last
+      // pending call, so the kernel's pre-live queue flush — a synchronous burst of distinct
+      // messages — would deliver the first and last and silently drop everything between, the
+      // exact single-slot data loss connect() is criticized for. Pacing preserves every message
+      // in order at the same wire rate. Bounded like the kernel queue; overflow drops the oldest
+      // with one warning. Zero disables pacing, as in `connect()`.
+      let send: (input: Input & Partial<WithRequestId>) => void = write;
+      if (throttleInterval > 0) {
+        const pending: Array<Input & Partial<WithRequestId>> = [];
+        let lastSentAt = 0;
+        let drainTimer: ReturnType<typeof setTimeout> | undefined;
+        let warnedOverflow = false;
+        context.addCleanup(() => {
+          if (drainTimer !== undefined) clearTimeout(drainTimer);
+          pending.length = 0;
+        });
+        const drain = () => {
+          drainTimer = undefined;
+          const next = pending.shift();
+          if (next === undefined) return;
+          lastSentAt = Date.now();
+          // The drain runs inside a timer with no caller to observe a throw: an encoding failure
+          // (a circular object handed to the msgpack encoder, say) becomes a diagnostic and the
+          // remaining queue keeps draining, instead of an uncaught error that strands it.
+          try {
+            write(next);
+          } catch {
+            context.diagnostic({
+              kind: "warning",
+              message: "A paced message could not be encoded and was dropped.",
+            });
+          }
+          if (pending.length > 0) {
+            drainTimer = setTimeout(drain, throttleInterval);
+          }
+        };
+        send = (input) => {
+          const now = Date.now();
+          if (pending.length === 0 && now - lastSentAt >= throttleInterval) {
+            // Contained exactly like the drain path: the same unencodable message must not
+            // throw into the app's input handler on an empty queue yet quietly warn five
+            // milliseconds later with one message queued. The pacing slot is only consumed
+            // when something actually went out.
+            try {
+              write(input);
+              lastSentAt = now;
+            } catch {
+              context.diagnostic({
+                kind: "warning",
+                message:
+                  "A paced message could not be encoded and was dropped.",
+              });
+            }
+            return;
+          }
+          if (pending.length >= MAX_PACED_MESSAGES) {
+            pending.shift();
+            if (!warnedOverflow) {
+              warnedOverflow = true;
+              context.diagnostic({
+                kind: "warning",
+                message: `More than ${MAX_PACED_MESSAGES} messages are waiting for the send pacer; the oldest are being dropped.`,
+              });
+            }
+          }
+          pending.push(input);
+          if (drainTimer === undefined) {
+            drainTimer = setTimeout(
+              drain,
+              Math.max(0, throttleInterval - (now - lastSentAt)),
+            );
+          }
+        };
+      }
+
+      return {
+        send,
+        close: () => ws.close(WebSocketErrorCodes.NORMAL_CLOSURE),
+      };
+    },
+  });
+}

--- a/libs/client/src/realtime/wma.spec.ts
+++ b/libs/client/src/realtime/wma.spec.ts
@@ -1,0 +1,1413 @@
+import { fakeExtensionContext } from "./testing";
+import { wma } from "./wma";
+
+/** A peer connection just real enough to drive the raw-path handshake. */
+function fakePeer() {
+  const listeners: Record<string, Array<(event: unknown) => void>> = {};
+  const channel = {
+    label: "control",
+    readyState: "connecting" as RTCDataChannelState,
+    send: jest.fn(),
+    close: jest.fn(),
+    onopen: undefined as (() => void) | undefined,
+    onmessage: undefined as ((event: { data: string }) => void) | undefined,
+    onclose: undefined as (() => void) | undefined,
+    onerror: undefined as (() => void) | undefined,
+  };
+  return {
+    channel,
+    peer: {
+      iceGatheringState: "complete" as RTCIceGatheringState,
+      connectionState: "new" as RTCPeerConnectionState,
+      iceConnectionState: "new" as RTCIceConnectionState,
+      localDescription: { sdp: "local-offer", type: "offer" as RTCSdpType },
+      addTransceiver: jest.fn(),
+      createDataChannel: jest.fn(() => channel),
+      addTrack: jest.fn(),
+      createOffer: jest.fn(async () => ({ sdp: "local-offer", type: "offer" })),
+      setLocalDescription: jest.fn(async () => undefined),
+      setRemoteDescription: jest.fn(async () => undefined),
+      close: jest.fn(),
+      addEventListener: (type: string, fn: (event: unknown) => void) => {
+        (listeners[type] ??= []).push(fn);
+      },
+      removeEventListener: () => undefined,
+      onconnectionstatechange: undefined as (() => void) | undefined,
+      ontrack: undefined as unknown,
+    },
+  };
+}
+
+describe("wma", () => {
+  const originalPeerConnection = global.RTCPeerConnection;
+
+  afterEach(() => {
+    global.RTCPeerConnection = originalPeerConnection;
+    jest.restoreAllMocks();
+  });
+
+  function install() {
+    const { peer, channel } = fakePeer();
+    global.RTCPeerConnection = jest.fn(() => peer) as never;
+    return { peer, channel };
+  }
+
+  it("rejects a stopped direction before creating a peer", async () => {
+    const PeerConnection = jest.fn();
+    global.RTCPeerConnection = PeerConnection as never;
+
+    await expect(
+      wma("me/world").open(fakeExtensionContext(), { direction: "stopped" }),
+    ).rejects.toThrow('direction cannot be "stopped"');
+    expect(PeerConnection).not.toHaveBeenCalled();
+  });
+
+  it("registers peer cleanup before transceiver setup can throw", async () => {
+    const { peer } = install();
+    const setupFailure = new Error("transceiver setup failed");
+    peer.addTransceiver.mockImplementation(() => {
+      throw setupFailure;
+    });
+    let cleanup: (() => void | Promise<void>) | undefined;
+    const context = fakeExtensionContext({
+      addCleanup: (release) => {
+        cleanup = release;
+      },
+    });
+
+    await expect(
+      wma("me/world").open(context, { iceServers: [] }),
+    ).rejects.toBe(setupFailure);
+    expect(cleanup).toBeDefined();
+
+    await cleanup?.();
+    expect(peer.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("gets bridge ICE before creating the offer, then reaches the bridge through context.fetch", async () => {
+    // The extension needs a credentialed request to a host that is not a fal endpoint, so bridge
+    // access belongs to the shared context rather than application-supplied fetch plumbing.
+    const { channel } = install();
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:example" }], status: "turn" },
+        requestId: "r",
+      })) as never,
+      fetch: async (url: string, init?: RequestInit) => {
+        calls.push({ url, body: init?.body });
+        if (url.endsWith("/ice")) {
+          return new Response(
+            JSON.stringify({
+              ice_servers: [
+                { urls: "turn:bridge", username: "u", credential: "p" },
+              ],
+              status: "turn",
+              credential_age_seconds: 31,
+            }),
+          );
+        }
+        return new Response(
+          JSON.stringify({ session_id: "s-1", sdp: "answer", type: "answer" }),
+        );
+      },
+    });
+
+    const session = await wma("me/my-world").open(context, {});
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe("https://wma.fal.run/ice");
+    expect(JSON.parse(String(calls[0].body))).toEqual({
+      app_id: "me/my-world",
+    });
+    expect(calls[1].url).toBe("https://wma.fal.run/session");
+    expect(JSON.parse(String(calls[1].body))).toEqual({
+      app_id: "me/my-world",
+      sdp: "local-offer",
+      type: "offer",
+    });
+    expect(session.sessionId).toBe("s-1");
+    // Bounded queue rather than a lost message: callers enable input on "connected", which precedes
+    // the channel opening.
+    session.send({ type: "keys", pressed: ["W"] });
+    expect(channel.send).not.toHaveBeenCalled();
+    channel.readyState = "open";
+    channel.onopen?.();
+    expect(channel.send).toHaveBeenCalledWith(
+      '{"type":"keys","pressed":["W"]}',
+    );
+  });
+
+  it("falls back to an app-local /ice route when bridge ICE is unavailable", async () => {
+    const { peer } = install();
+    const events: unknown[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      run: (async () => ({
+        data: {
+          ice_servers: [{ urls: "turn:app", username: "u", credential: "p" }],
+          status: "turn",
+        },
+        requestId: "r",
+      })) as never,
+      diagnostic: (event) => events.push(event),
+      fetch: async (url: string) => {
+        if (url.endsWith("/ice")) return new Response("down", { status: 503 });
+        return new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        );
+      },
+    });
+
+    await wma().open(context, {});
+    expect(peer.addTransceiver).toHaveBeenCalled();
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "ice-servers",
+          detail: expect.objectContaining({
+            source: "bridge-unavailable; trying app fallback",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "ice-servers",
+          detail: expect.objectContaining({
+            source: "app-fallback",
+            status: "turn",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("drains a failed bridge /ice response before falling back", async () => {
+    // The kernel releases each request's signal bookkeeping when its body is consumed; a fallback
+    // session that outlives the failed probe must not pin the error response for its lifetime.
+    const { peer } = install();
+    const drained = jest.fn(async () => new ArrayBuffer(0));
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:app" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async (url: string) => {
+        if (url.endsWith("/ice")) {
+          return {
+            ok: false,
+            status: 503,
+            arrayBuffer: drained,
+          } as unknown as Response;
+        }
+        return new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        );
+      },
+    });
+
+    await wma().open(context, {});
+    expect(peer.addTransceiver).toHaveBeenCalled();
+    expect(drained).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out stalled bridge ICE discovery before app fallback", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      const bridgeSignals: AbortSignal[] = [];
+      const run = jest.fn(async () => ({
+        data: {
+          ice_servers: [{ urls: "turn:app", username: "u", credential: "p" }],
+          status: "turn",
+        },
+        requestId: "r",
+      }));
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        run: run as never,
+        fetch: async (url: string, init?: RequestInit) => {
+          if (!url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+            );
+          }
+          const signal = init?.signal as AbortSignal;
+          bridgeSignals.push(signal);
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        },
+      });
+
+      const opening = wma().open(context, {});
+      await Promise.resolve();
+      expect(bridgeSignals).toHaveLength(1);
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const session = await opening;
+      expect(bridgeSignals[0].aborted).toBe(true);
+      expect(run).toHaveBeenCalledWith("me/my-world/ice", {
+        input: {},
+        abortSignal: expect.any(AbortSignal),
+      });
+      await session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("times out stalled app-local ICE before STUN fallback", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      jest.spyOn(console, "warn").mockImplementation(() => undefined);
+      const appSignals: AbortSignal[] = [];
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        run: (async (
+          _endpoint: string,
+          options: { abortSignal: AbortSignal },
+        ) => {
+          appSignals.push(options.abortSignal);
+          return new Promise((_resolve, reject) => {
+            options.abortSignal.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }) as never,
+        fetch: async (url: string) => {
+          if (url.endsWith("/ice")) {
+            return new Response("down", { status: 503 });
+          }
+          return new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          );
+        },
+      });
+
+      const opening = wma().open(context, {});
+      // Extra flushes: the failed bridge probe now drains its error body (a real Response read,
+      // several microtasks) before the app fallback starts.
+      for (let flushes = 0; flushes < 20; flushes += 1) {
+        await Promise.resolve();
+      }
+      expect(appSignals).toHaveLength(1);
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const session = await opening;
+      expect(appSignals[0].aborted).toBe(true);
+      expect(global.RTCPeerConnection).toHaveBeenCalledWith({
+        iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+        iceTransportPolicy: undefined,
+      });
+      await session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("falls back to app-managed ICE when the bridge withholds managed TURN", async () => {
+    install();
+    const events: unknown[] = [];
+    const run = jest.fn(async () => ({
+      data: {
+        ice_servers: [{ urls: "turn:app", username: "u", credential: "p" }],
+        status: "turn",
+      },
+      requestId: "r",
+    }));
+    const context = fakeExtensionContext({
+      endpointId: "partner/my-world",
+      run: run as never,
+      diagnostic: (event) => events.push(event),
+      fetch: async (url: string) =>
+        new Response(
+          url.endsWith("/ice")
+            ? JSON.stringify({ ice_servers: [], status: "app_managed" })
+            : JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    await wma().open(context, {});
+
+    expect(run).toHaveBeenCalledWith("partner/my-world/ice", {
+      input: {},
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(global.RTCPeerConnection).toHaveBeenCalledWith({
+      iceServers: [{ urls: "turn:app", username: "u", credential: "p" }],
+      iceTransportPolicy: undefined,
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "ice-servers",
+          detail: { source: "app-managed; trying app fallback" },
+        }),
+      ]),
+    );
+  });
+
+  it("times out a stalled session negotiation request", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      const sessionSignals: AbortSignal[] = [];
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fetch: async (url: string, init?: RequestInit) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({
+                ice_servers: [{ urls: "stun:example" }],
+                status: "stun_only",
+              }),
+            );
+          }
+          const signal = init?.signal as AbortSignal;
+          sessionSignals.push(signal);
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        },
+      });
+
+      const opening = wma().open(context, {
+        iceServers: [{ urls: "stun:example" }],
+      });
+      for (let turn = 0; turn < 10 && sessionSignals.length === 0; turn++) {
+        await Promise.resolve();
+      }
+      expect(sessionSignals).toHaveLength(1);
+
+      jest.advanceTimersByTime(120_000);
+      await expect(opening).rejects.toThrow(/aborted/i);
+      expect(sessionSignals[0].aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not create a bridge session after cancellation during ICE gathering", async () => {
+    install();
+    const controller = new AbortController();
+    const reason = new Error("cancelled from ICE progress");
+    const fetch = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    );
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      signal: controller.signal,
+      fetch,
+      gatherIce: async () => {
+        controller.abort(reason);
+        return { host: 1, srflx: 0, relay: 0, state: "complete" };
+      },
+    });
+
+    await expect(
+      wma().open(context, {
+        iceServers: [{ urls: "stun:example" }],
+      }),
+    ).rejects.toBe(reason);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("asks the kernel to gather ICE rather than reimplementing it", async () => {
+    install();
+    const gatherIce = jest.fn(
+      async (_pc: RTCPeerConnection, _options?: unknown) => ({
+        host: 1,
+        srflx: 1,
+        relay: 2,
+        state: "sufficient" as const,
+      }),
+    );
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      gatherIce,
+      run: (async () => ({
+        data: {
+          ice_servers: [
+            { urls: "turn:example", username: "u", credential: "p" },
+          ],
+        },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    await wma().open(context, {
+      iceTransportPolicy: "relay",
+    });
+    expect(gatherIce).toHaveBeenCalledTimes(1);
+    // The servers must reach it, or "sufficient" cannot know a relay is required.
+    expect(gatherIce.mock.calls[0][1]).toEqual({
+      iceServers: [{ urls: "turn:example", username: "u", credential: "p" }],
+      iceTransportPolicy: "relay",
+    });
+  });
+
+  it("can require a TURN relay path", async () => {
+    install();
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      gatherIce: async () => ({
+        host: 0,
+        srflx: 0,
+        relay: 1,
+        state: "sufficient",
+      }),
+      fetch: async (url: string) =>
+        new Response(
+          url.endsWith("/ice")
+            ? JSON.stringify({
+                ice_servers: [
+                  {
+                    urls: "turn:example",
+                    username: "fixture-user",
+                    credential: "fixture-credential",
+                  },
+                ],
+                status: "turn",
+              })
+            : JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    await wma().open(context, {
+      iceTransportPolicy: "relay",
+    });
+
+    expect(global.RTCPeerConnection).toHaveBeenCalledWith({
+      iceServers: [
+        {
+          urls: "turn:example",
+          username: "fixture-user",
+          credential: "fixture-credential",
+        },
+      ],
+      iceTransportPolicy: "relay",
+    });
+  });
+
+  it("does not start a relay-only session without a gathered relay candidate", async () => {
+    install();
+    const fetch = jest.fn(
+      async (url: string) =>
+        new Response(
+          url.endsWith("/ice")
+            ? JSON.stringify({
+                ice_servers: [
+                  {
+                    urls: "turn:example",
+                    username: "fixture-user",
+                    credential: "fixture-credential",
+                  },
+                ],
+                status: "turn",
+              })
+            : JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    );
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      fetch,
+      gatherIce: async () => ({
+        host: 0,
+        srflx: 0,
+        relay: 0,
+        state: "timeout",
+      }),
+    });
+
+    await expect(
+      wma().open(context, {
+        iceTransportPolicy: "relay",
+      }),
+    ).rejects.toThrow("ICE gathering produced no relay candidate");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://wma.fal.run/ice",
+      expect.any(Object),
+    );
+  });
+
+  it("degrades to STUN and says so when /ice is unavailable", async () => {
+    install();
+    const events: unknown[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      run: (async () => {
+        throw new Error("ice endpoint exploded");
+      }) as never,
+      diagnostic: (event) => events.push(event),
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await wma().open(context, {});
+    // Reported, not swallowed: "no relay" is the difference between working and not for anyone behind
+    // blocked UDP, so a silent fallback to STUN is the one thing this must never do.
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "progress",
+          phase: "ice-servers",
+          detail: expect.objectContaining({
+            source: expect.stringContaining("ice-endpoint-failed"),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("does not start app ICE fallback after bridge discovery is aborted", async () => {
+    install();
+    const controller = new AbortController();
+    const reason = new Error("user cancelled");
+    const run = jest.fn();
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      signal: controller.signal,
+      run: run as never,
+      fetch: async (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    });
+
+    const opening = wma().open(context, {});
+    controller.abort(reason);
+
+    await expect(opening).rejects.toBe(reason);
+    expect(run).not.toHaveBeenCalled();
+    expect(global.RTCPeerConnection).not.toHaveBeenCalled();
+  });
+
+  it("observes ICE gathering when setting the local description fails", async () => {
+    const { peer } = install();
+    const localFailure = new Error("local description failed");
+    const gatherFailure = new Error("gathering aborted");
+    peer.setLocalDescription.mockRejectedValue(localFailure);
+    let rejectGathering: (error: Error) => void = () => undefined;
+    const gathering = new Promise<never>((_resolve, reject) => {
+      rejectGathering = reject;
+    });
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      gatherIce: () => gathering,
+      fetch: async () =>
+        new Response(JSON.stringify({ ice_servers: [{ urls: "stun:x" }] })),
+    });
+
+    const opening = wma().open(context, {});
+    await expect(opening).rejects.toBe(localFailure);
+    rejectGathering(gatherFailure);
+    await Promise.resolve();
+  });
+
+  it("reports peer and control-channel transport death through context.fail", async () => {
+    const { peer, channel } = install();
+    const fail = jest.fn(async () => undefined);
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      fail,
+      fetch: async (url: string) =>
+        new Response(
+          url.endsWith("/ice")
+            ? JSON.stringify({ ice_servers: [{ urls: "stun:x" }] })
+            : JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+    await wma().open(context, {});
+
+    peer.connectionState = "failed";
+    peer.onconnectionstatechange?.();
+    expect(fail).toHaveBeenCalledWith(
+      expect.stringContaining("ICE could not establish a path"),
+      expect.objectContaining({ host: 0, srflx: 0, relay: 0 }),
+    );
+
+    channel.onclose?.();
+    expect(fail).toHaveBeenCalledWith(
+      expect.stringContaining("control data channel closed or errored"),
+    );
+  });
+
+  it("fails when the bridge heartbeat reports that the session is gone", async () => {
+    jest.useFakeTimers();
+    try {
+      const { channel } = install();
+      const fail = jest.fn(async () => undefined);
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fail,
+        fetch: async (url: string) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({ ice_servers: [{ urls: "stun:x" }] }),
+            );
+          }
+          if (url.endsWith("/heartbeat")) {
+            return {
+              ok: true,
+              json: async () => ({ alive: false }),
+            } as Response;
+          }
+          return new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          );
+        },
+      });
+      const session = await wma().open(context, {});
+
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fail).toHaveBeenCalledWith(
+        "WMA bridge reports that the session is no longer alive",
+      );
+      await session.close();
+      expect(channel.close).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("drains the body of a non-OK heartbeat response", async () => {
+    // The kernel releases each request's signal bookkeeping when the body is consumed, so a
+    // degraded bridge answering every beat with an error must not retain one combination per
+    // heartbeat for the life of the session.
+    jest.useFakeTimers();
+    try {
+      install();
+      const drained = jest.fn(async () => new ArrayBuffer(0));
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fetch: async (url: string) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({ ice_servers: [{ urls: "stun:x" }] }),
+            );
+          }
+          if (url.endsWith("/heartbeat")) {
+            return {
+              ok: false,
+              status: 503,
+              arrayBuffer: drained,
+            } as unknown as Response;
+          }
+          return new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          );
+        },
+      });
+      const session = await wma().open(context, {});
+
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(drained).toHaveBeenCalledTimes(1);
+      await session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("ignores a dead heartbeat response that finishes after close", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      let finishHeartbeat!: (status: { alive: boolean }) => void;
+      const heartbeatStatus = new Promise<{ alive: boolean }>((resolve) => {
+        finishHeartbeat = resolve;
+      });
+      const heartbeatJson = jest.fn(() => heartbeatStatus);
+      const fail = jest.fn(async () => undefined);
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fail,
+        fetch: async (url: string) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({ ice_servers: [{ urls: "stun:x" }] }),
+            );
+          }
+          if (url.endsWith("/heartbeat")) {
+            return { ok: true, json: heartbeatJson } as unknown as Response;
+          }
+          return new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          );
+        },
+      });
+      const session = await wma().open(context, {});
+
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(heartbeatJson).toHaveBeenCalledTimes(1);
+
+      await session.close();
+      finishHeartbeat({ alive: false });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fail).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("times out a stalled heartbeat and retries on the next tick", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      const heartbeatSignals: AbortSignal[] = [];
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fetch: async (url: string, init?: RequestInit) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({ ice_servers: [{ urls: "stun:x" }] }),
+            );
+          }
+          if (!url.endsWith("/heartbeat")) {
+            return new Response(
+              JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+            );
+          }
+          const signal = init?.signal as AbortSignal;
+          heartbeatSignals.push(signal);
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        },
+      });
+      const session = await wma().open(context, {});
+
+      jest.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      expect(heartbeatSignals).toHaveLength(1);
+      expect(heartbeatSignals[0].aborted).toBe(false);
+
+      jest.advanceTimersByTime(3_999);
+      expect(heartbeatSignals[0].aborted).toBe(false);
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(heartbeatSignals[0].aborted).toBe(true);
+
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      expect(heartbeatSignals).toHaveLength(2);
+      await session.close();
+      expect(heartbeatSignals[1].aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("surfaces a bridge error message instead of a bare status code", async () => {
+    install();
+    const context = fakeExtensionContext({
+      endpointId: "me/my-world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(JSON.stringify({ detail: "app is not deployed" }), {
+          status: 422,
+        }),
+    });
+    await expect(wma().open(context, {})).rejects.toThrow(
+      "app is not deployed",
+    );
+  });
+
+  it("adds local tracks instead of a recvonly transceiver, and never both", async () => {
+    // Both would negotiate two video m-lines, and the runner would answer a stream nobody reads.
+    const { peer } = install();
+    const track = { kind: "video", stop: jest.fn() };
+    const stream = { getTracks: () => [track] } as unknown as MediaStream;
+    const context = fakeExtensionContext({
+      endpointId: "me/transform",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    const session = await wma().open(context, {
+      localStream: stream,
+      direction: "sendonly",
+    });
+
+    expect(peer.addTrack).not.toHaveBeenCalled();
+    expect(peer.addTransceiver).toHaveBeenCalledWith(track, {
+      direction: "sendonly",
+      streams: [stream],
+    });
+    // The caller owns the camera. Closing the session must not turn their device off.
+    await session.close();
+    expect(track.stop).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a recvonly transceiver with no local stream", async () => {
+    const { peer } = install();
+    const context = fakeExtensionContext({
+      endpointId: "me/out",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+    await wma().open(context, {});
+    expect(peer.addTransceiver).toHaveBeenCalledWith("video", {
+      direction: "recvonly",
+    });
+  });
+
+  it("publishes inbound media and data through the KERNEL, not its own options", async () => {
+    // Guards the seam rather than the behaviour. An extension that published these through options of
+    // its own would compile and work, and would force an application offering two protocols to branch
+    // per protocol to do one thing: attach a video element.
+    const { peer, channel } = install();
+    const seenMedia: MediaStream[] = [];
+    const seenData: string[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+      media: (stream: MediaStream) => void seenMedia.push(stream),
+      data: (raw: string) => void seenData.push(raw),
+    });
+
+    await wma().open(context, {});
+
+    const stream = { id: "remote" } as unknown as MediaStream;
+    const secondStream = { id: "remote-secondary" } as unknown as MediaStream;
+    (peer.ontrack as (event: unknown) => void)({
+      streams: [stream, secondStream],
+      track: {},
+    });
+    (peer.ontrack as (event: unknown) => void)({
+      streams: [stream, secondStream],
+      track: {},
+    });
+    expect(seenMedia).toEqual([stream, secondStream]);
+
+    channel.onmessage?.({ data: '{"type":"session_info"}' });
+    channel.onmessage?.({ data: '{"type":"pong","ts":1}' });
+    expect(seenData).toEqual([
+      '{"type":"session_info"}',
+      '{"type":"pong","ts":1}',
+    ]);
+  });
+
+  it("intercepts reserved network-info responses and answers getConnectionInfo", async () => {
+    // The session-affine network query rides the data channel itself: the request goes out as
+    // reserved JSON, the response is intercepted BEFORE context.data, and application frames
+    // keep flowing untouched.
+    const { peer, channel } = install();
+    const seenData: string[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+      data: (raw: string) => void seenData.push(raw),
+    });
+
+    const session = await wma().open(context, {});
+    channel.readyState = "open";
+    // The browser side resolves from the SCTP transport's selected ICE pair on the first
+    // attempt — no stats polling, which would otherwise run the probe's full bounded loop.
+    (
+      peer as unknown as { getStats: () => Promise<Map<string, unknown>> }
+    ).getStats = async () => new Map();
+    (peer as unknown as { sctp?: unknown }).sctp = {
+      transport: {
+        state: "connected",
+        iceTransport: {
+          role: "controlling",
+          getSelectedCandidatePair: () => ({
+            local: {
+              candidateType: "relay",
+              protocol: "udp",
+              address: "9.9.9.9",
+              port: 1111,
+            },
+            remote: {
+              candidateType: "srflx",
+              protocol: "udp",
+              address: "5.6.7.8",
+              port: 9000,
+            },
+          }),
+        },
+      },
+    };
+
+    const info = session.getConnectionInfo();
+    // The request went out as reserved JSON carrying a request id.
+    const request = JSON.parse(
+      (channel.send as jest.Mock).mock.calls.at(-1)?.[0] as string,
+    ) as { type: string; request_id: string };
+    expect(request.type).toBe("wma.network-info.request");
+
+    // An unrelated application frame keeps flowing to context.data...
+    channel.onmessage?.({ data: '{"type":"pong","ts":1}' });
+    // ...while the reserved response is intercepted and never reaches it.
+    channel.onmessage?.({
+      data: JSON.stringify({
+        type: "wma.network-info.response",
+        request_id: request.request_id,
+        path: {
+          session_id: "s",
+          observed_at_ms: 1,
+          available: true,
+          connection_state: "connected",
+          ice_connection_state: "connected",
+          uses_turn: true,
+          local_candidate: {
+            type: "relay",
+            protocol: "udp",
+            endpoint: "1.2.3.4:5000",
+            relay_protocol: "tcp",
+          },
+          remote_candidate: {
+            type: "srflx",
+            protocol: "udp",
+            endpoint: "5.6.7.8:9000",
+          },
+        },
+      }),
+    });
+
+    const resolved = await info;
+    expect(seenData).toEqual(['{"type":"pong","ts":1}']);
+    expect(resolved.runner.side).toBe("runner");
+    expect(resolved.runner.usesTurn).toBe(true);
+    expect(resolved.runner.localCandidate?.endpoint).toBe("1.2.3.4:5000");
+    expect(resolved.runner.localCandidate?.relayProtocol).toBe("tcp");
+    expect(resolved.browser.available).toBe(true);
+    expect(resolved.browser.pairSelection).toBe("browser-sctp-ice-transport");
+    expect(resolved.browser.browserUsesTurn).toBe(true);
+    expect(resolved.browser.localCandidate?.endpoint).toBe("9.9.9.9:1111");
+    await session.close();
+  });
+
+  it("matches both endpoints when stats contain multiple succeeded ICE pairs", async () => {
+    const { peer, channel } = install();
+    const stats = new Map<string, Record<string, unknown>>([
+      [
+        "browser-local",
+        {
+          id: "browser-local",
+          type: "local-candidate",
+          candidateType: "srflx",
+          protocol: "udp",
+          address: "5.6.7.8",
+          port: 9000,
+        },
+      ],
+      [
+        "wrong-runner",
+        {
+          id: "wrong-runner",
+          type: "remote-candidate",
+          candidateType: "host",
+          protocol: "udp",
+          address: "10.0.0.2",
+          port: 4000,
+        },
+      ],
+      [
+        "runner-local",
+        {
+          id: "runner-local",
+          type: "remote-candidate",
+          candidateType: "relay",
+          protocol: "udp",
+          address: "1.2.3.4",
+          port: 5000,
+        },
+      ],
+      [
+        "wrong-pair",
+        {
+          id: "wrong-pair",
+          type: "candidate-pair",
+          state: "succeeded",
+          localCandidateId: "browser-local",
+          remoteCandidateId: "wrong-runner",
+          currentRoundTripTime: 0.9,
+        },
+      ],
+      [
+        "selected-pair",
+        {
+          id: "selected-pair",
+          type: "candidate-pair",
+          state: "succeeded",
+          localCandidateId: "browser-local",
+          remoteCandidateId: "runner-local",
+          currentRoundTripTime: 0.05,
+        },
+      ],
+    ]);
+    (
+      peer as unknown as { getStats: () => Promise<Map<string, unknown>> }
+    ).getStats = async () => stats;
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    const session = await wma().open(context, {});
+    channel.readyState = "open";
+    const info = session.getConnectionInfo();
+    const request = JSON.parse(
+      (channel.send as jest.Mock).mock.calls.at(-1)?.[0] as string,
+    ) as { request_id: string };
+    channel.onmessage?.({
+      data: JSON.stringify({
+        type: "wma.network-info.response",
+        request_id: request.request_id,
+        path: {
+          session_id: "s",
+          observed_at_ms: 1,
+          available: true,
+          connection_state: "connected",
+          ice_connection_state: "connected",
+          local_candidate: {
+            type: "relay",
+            protocol: "udp",
+            endpoint: "1.2.3.4:5000",
+          },
+          remote_candidate: {
+            type: "srflx",
+            protocol: "udp",
+            endpoint: "5.6.7.8:9000",
+          },
+        },
+      }),
+    });
+
+    const resolved = await info;
+    expect(resolved.browser.remoteCandidate?.endpoint).toBe("1.2.3.4:5000");
+    expect(resolved.browser.currentRoundTripTimeMs).toBe(50);
+    expect(resolved.browser.runnerUsesTurn).toBe(true);
+    await session.close();
+  });
+
+  it("bounds the probe's wait for the channel, and never times out early", async () => {
+    jest.useFakeTimers();
+    try {
+      const { channel } = install();
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        run: (async () => ({
+          data: { ice_servers: [{ urls: "stun:x" }] },
+          requestId: "r",
+        })) as never,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          ),
+      });
+
+      const session = await wma().open(context, {});
+      expect(channel.readyState).toBe("connecting");
+
+      // Under the bound: still pending — the 10s response timeout measures wire time, and the
+      // open-wait has not hit its own deadline yet.
+      const probe = session.getConnectionInfo();
+      let outcome: "pending" | "resolved" | "rejected" = "pending";
+      probe.then(
+        () => (outcome = "resolved"),
+        () => (outcome = "rejected"),
+      );
+      jest.advanceTimersByTime(5_000);
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(outcome).toBe("pending");
+
+      // Past the bound: a channel a middlebox holds in "connecting" forever must not hang the
+      // probe — every wait in this extension has a deadline, including this one.
+      jest.advanceTimersByTime(6_000);
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(outcome).toBe("rejected");
+      await expect(probe).rejects.toThrow(/did not open/);
+      await session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("rejects a pending network probe promptly at teardown", async () => {
+    // A probe whose reply can no longer arrive must settle at close — not sit on its 10s timer
+    // and reject long after close() resolved.
+    const { channel } = install();
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    const session = await wma().open(context, {});
+    channel.readyState = "open";
+    const probe = session.getConnectionInfo();
+    session.close();
+
+    await expect(probe).rejects.toThrow(/closed before the network probe/);
+  });
+
+  it("cancels browser stats collection after the runner reply when closing", async () => {
+    const { peer, channel } = install();
+    const getStats = jest.fn(
+      () => new Promise<RTCStatsReport>(() => undefined),
+    );
+    (peer as unknown as { getStats: typeof getStats }).getStats = getStats;
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+
+    const session = await wma().open(context, {});
+    channel.readyState = "open";
+    const probe = session.getConnectionInfo();
+    const request = JSON.parse(
+      (channel.send as jest.Mock).mock.calls.at(-1)?.[0] as string,
+    ) as { request_id: string };
+    channel.onmessage?.({
+      data: JSON.stringify({
+        type: "wma.network-info.response",
+        request_id: request.request_id,
+        path: {
+          session_id: "s",
+          observed_at_ms: 1,
+          available: false,
+          connection_state: "connected",
+          ice_connection_state: "connected",
+        },
+      }),
+    });
+    await Promise.resolve();
+    expect(getStats).toHaveBeenCalledTimes(1);
+
+    session.close();
+
+    await expect(probe).rejects.toThrow(/closed before the network probe/);
+  });
+
+  it("bounds a browser getStats call that never settles", async () => {
+    jest.useFakeTimers();
+    try {
+      const { peer, channel } = install();
+      const getStats = jest.fn(
+        () => new Promise<RTCStatsReport>(() => undefined),
+      );
+      (peer as unknown as { getStats: typeof getStats }).getStats = getStats;
+      const context = fakeExtensionContext({
+        endpointId: "me/world",
+        run: (async () => ({
+          data: { ice_servers: [{ urls: "stun:x" }] },
+          requestId: "r",
+        })) as never,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+          ),
+      });
+
+      const session = await wma().open(context, {});
+      channel.readyState = "open";
+      const probe = session.getConnectionInfo();
+      const request = JSON.parse(
+        (channel.send as jest.Mock).mock.calls.at(-1)?.[0] as string,
+      ) as { request_id: string };
+      channel.onmessage?.({
+        data: JSON.stringify({
+          type: "wma.network-info.response",
+          request_id: request.request_id,
+          path: {
+            session_id: "s",
+            observed_at_ms: 1,
+            available: false,
+            connection_state: "connected",
+            ice_connection_state: "connected",
+          },
+        }),
+      });
+      await Promise.resolve();
+
+      jest.advanceTimersByTime(5_000);
+      const info = await probe;
+
+      expect(info.browser.available).toBe(false);
+      expect(info.browser.reason).toMatch(/did not expose/);
+      expect(getStats).toHaveBeenCalledTimes(1);
+      session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("decodes binary control-channel frames instead of stringifying them", async () => {
+    // A data channel delivers ArrayBuffer for binary sends; String(event.data) would hand the
+    // application the literal "[object ArrayBuffer]" — silent data destruction.
+    const { channel } = install();
+    const seenData: string[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+      data: (raw: string) => void seenData.push(raw),
+    });
+
+    await wma().open(context, {});
+
+    const bytes = new TextEncoder().encode('{"type":"binary_frame"}');
+    (channel.onmessage as (event: { data: unknown }) => void)?.({
+      data: bytes.buffer,
+    });
+    (channel.onmessage as (event: { data: unknown }) => void)?.({
+      data: bytes,
+    });
+    expect(seenData).toEqual([
+      '{"type":"binary_frame"}',
+      '{"type":"binary_frame"}',
+    ]);
+  });
+
+  it("synthesises a stream when the track arrives without one", async () => {
+    // Some implementations deliver `track` with an empty `streams`. Dropping the media entirely in
+    // that case would be a silent black video.
+    //
+    // MediaStream is stubbed because jsdom has none — every browser does, so this is a gap in the
+    // test environment rather than in the code. Worth stating: the construction happens INSIDE
+    // pc.ontrack, before the kernel's error guard can wrap it, so an environment that provides
+    // RTCPeerConnection without MediaStream would throw where no caller can catch it.
+    const tracks: unknown[] = [];
+    (global as unknown as { MediaStream: unknown }).MediaStream = class {
+      constructor(input: unknown[]) {
+        tracks.push(...input);
+      }
+    };
+    const { peer } = install();
+    const seen: MediaStream[] = [];
+    const context = fakeExtensionContext({
+      endpointId: "me/world",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+      media: (stream: MediaStream) => void seen.push(stream),
+    });
+    await wma().open(context, {});
+    const track = { kind: "video" };
+    (peer.ontrack as (event: unknown) => void)({ streams: [], track });
+    expect(seen).toHaveLength(1);
+    expect(tracks).toEqual([track]);
+  });
+
+  it("claims no endpoints, and opens the one it was given", async () => {
+    // An endpoint's NAME cannot reveal whether it speaks this transport, so this extension states no
+    // constraint at all rather than asserting one it cannot back up.
+    expect(wma().supports).toBeUndefined();
+    expect(wma("me/my-world").defaultEndpoint).toBe("me/my-world");
+    expect(wma().defaultEndpoint).toBeUndefined();
+  });
+});

--- a/libs/client/src/realtime/wma.ts
+++ b/libs/client/src/realtime/wma.ts
@@ -1,0 +1,1189 @@
+/**
+ * WMA extension for `fal.realtime.open()`.
+ *
+ * The browser POSTs a complete SDP offer to the WMA signalling bridge, while media flows directly
+ * between the browser and fal runner (or through TURN). This supports receive-only generation and
+ * bidirectional transforms without putting media through the bridge.
+ *
+ * This fal-operated protocol ships with the client and uses the same extension contract available to
+ * separately versioned vendor adapters.
+ *
+ * Four protocol invariants shape the implementation:
+ *
+ *  1. NO TRICKLE ICE. The bridge takes one complete SDP, so the offer can only be sent once gathering
+ *     has produced a usable candidate set — `context.gatherIce` is that strategy, and it is in the
+ *     kernel precisely because this is not the last protocol that will need it.
+ *  2. THE DATA CHANNEL CAN DIE WHILE ICE SAYS "connected". SCTP state is independent of
+ *     `pc.connectionState`, so a caller watching only the latter believes the session is live while
+ *     every control message is dropped.
+ *  3. MESSAGES SENT BEFORE THE CHANNEL OPENS ARE LOST. Callers enable input on "connected", which
+ *     precedes channel "open". Queue and flush, bounded.
+ *  4. HEARTBEATS CAN PILE UP. A stalled bridge plus a naive setInterval produces an unbounded number
+ *     of in-flight requests. Skip a tick if the last is unsettled.
+ */
+import { throwIfRealtimeAborted } from "./abort";
+import {
+  defineRealtimeExtension,
+  type RealtimeExtensionContext,
+  type RealtimeSession,
+} from "./extension";
+import { countTurnServers } from "./ice";
+
+const WMA_URL = "https://wma.fal.run";
+const ICE_DISCOVERY_TIMEOUT_MS = 5_000;
+const SESSION_NEGOTIATION_TIMEOUT_MS = 120_000;
+const HEARTBEAT_INTERVAL_MS = 5_000;
+const HEARTBEAT_TIMEOUT_MS = 4_000;
+// Reserved control-channel vocabulary for the session-affine network query: the request reaches
+// the exact runner holding this peer connection over the data channel itself, which no
+// out-of-band API can promise. Responses are intercepted before context.data.
+const NETWORK_INFO_REQUEST_TYPE = "wma.network-info.request";
+const NETWORK_INFO_RESPONSE_TYPE = "wma.network-info.response";
+const NETWORK_INFO_TIMEOUT_MS = 10_000;
+const BROWSER_NETWORK_INFO_TIMEOUT_MS = 5_000;
+const BROWSER_NETWORK_INFO_POLL_MS = 100;
+const MAX_QUEUED_MESSAGES = 64;
+const DEFAULT_STUN_URL = "stun:stun.l.google.com:19302";
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export type WmaControlMessage = object;
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WmaOptions {
+  /**
+   * Media direction. Sessions without a local stream default to `"recvonly"`; sessions with local
+   * tracks preserve addTrack's `"sendrecv"` behavior. Pass an explicit direction for other flows.
+   */
+  direction?: RTCRtpTransceiverDirection;
+  /**
+   * Media to send UP, on the same peer connection the output comes back on.
+   *
+   * Supplying this is what makes a transform app possible — camera in, transformed video out — and it
+   * is deliberately the same connection rather than a second one: WebRTC negotiates both directions
+   * in one SDP exchange, and a second connection would double the ICE work to carry half the session.
+   *
+   * The tracks are NOT stopped on close. They belong to the caller, who may be showing the camera in
+   * a local preview or sharing it with another session; stopping them would turn off a device this
+   * extension does not own.
+   */
+  localStream?: MediaStream | null;
+  /**
+   * ICE servers. OPTIONAL — when omitted the extension first sends the routed endpoint identity to
+   * the authenticated WMA bridge for short-lived TURN credentials, then falls back to the app's own
+   * `/ice` endpoint for deployments that manage their own credential vending.
+   *
+   * That self-provisioning is the answer to "who fetches ICE servers?", and it is possible
+   * because the bridge is reached through credentialed `context.fetch`, while the app fallback route
+   * is a fal endpoint reached through `context.run`. The browser never sees the Metered secret,
+   * only a credential minted for it.
+   *
+   * Pass this to override (your own TURN provider, or to force STUN for testing).
+   */
+  iceServers?: RTCIceServer[];
+  /**
+   * Which ICE candidate types the browser may use.
+   *
+   * The browser default, `"all"`, prefers direct host or server-reflexive paths and uses TURN only
+   * when needed. Set this to `"relay"` to require a TURN path, primarily for connectivity tests.
+   * Opening fails if none of the configured TURN servers can allocate a relay candidate.
+   */
+  iceTransportPolicy?: RTCIceTransportPolicy;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WmaRealtimeSession extends RealtimeSession {
+  sessionId: string;
+  /** Bounded-queued until the control channel opens; dropped once closing. */
+  send(message: WmaControlMessage): void;
+  /**
+   * Both ends of THIS session's selected network path: the browser's view from getStats()/the
+   * SCTP ICE transport, and the runner's view queried over the data channel itself — so the two
+   * rows always describe the same peer connection, never a neighboring session's.
+   */
+  getConnectionInfo(): Promise<WmaConnectionInfo>;
+  close(): void;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WmaIceCandidateInfo {
+  type: string;
+  protocol: string;
+  endpoint: string;
+  address?: string;
+  port?: number;
+  relayProtocol?: string;
+  tcpType?: string;
+  relatedAddress?: string;
+  relatedPort?: number;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WmaNetworkPath {
+  side: "browser" | "runner";
+  sessionId?: string;
+  observedAtMs: number;
+  available: boolean;
+  reason?: string;
+  connectionState: string;
+  iceConnectionState: string;
+  iceRole?: string;
+  dtlsState?: string;
+  pairSelection?: string;
+  localCandidate?: WmaIceCandidateInfo;
+  remoteCandidate?: WmaIceCandidateInfo;
+  usesTurn?: boolean;
+  browserUsesTurn?: boolean;
+  runnerUsesTurn?: boolean;
+  currentRoundTripTimeMs?: number;
+  availableOutgoingBitrate?: number;
+}
+
+/** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
+export interface WmaConnectionInfo {
+  browser: WmaNetworkPath;
+  runner: WmaNetworkPath;
+}
+
+/**
+ * Ask the bridge for ephemeral TURN credentials, retaining the app route as a compatibility
+ * fallback. This must complete before `createOffer()`: that is when the browser starts gathering
+ * candidates, and adding TURN credentials afterwards cannot produce a relay candidate for the
+ * one-shot SDP the bridge accepts.
+ *
+ * Degrades to STUN rather than failing the connect: an app without Metered configured, or a
+ * provider outage, should still work for everyone on a permissive network. The failure is
+ * logged rather than swallowed silently, because "no relay" is the difference between working
+ * and not for anyone behind blocked UDP.
+ */
+/*
+ * Credential propagation is enforced by the vending endpoint, not by a client-side delay. The
+ * server is the only side that knows which replica minted a credential and therefore the only side
+ * that can guarantee the returned credential is already usable.
+ */
+async function fetchIceServers(
+  context: RealtimeExtensionContext,
+): Promise<RTCIceServer[]> {
+  const controller = new AbortController();
+  const abortDiscovery = () => controller.abort(context.signal.reason);
+  if (context.signal.aborted) {
+    abortDiscovery();
+  } else {
+    context.signal.addEventListener("abort", abortDiscovery, { once: true });
+  }
+  const discoveryTimeout = setTimeout(
+    () => controller.abort(),
+    ICE_DISCOVERY_TIMEOUT_MS,
+  );
+  try {
+    const response = await context.fetch(`${WMA_URL}/ice`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ app_id: context.endpointId }),
+    });
+    if (!response.ok) {
+      // Drain before throwing: the kernel releases this request's signal bookkeeping when the
+      // body is consumed, and a fallback session that outlives a failed bridge probe must not
+      // pin the response for its whole lifetime. Same rule as the heartbeat's error drain.
+      await response.arrayBuffer().catch(() => undefined);
+      throw new Error(`bridge /ice request failed (HTTP ${response.status})`);
+    }
+    const payload = (await response.json()) as {
+      ice_servers?: RTCIceServer[];
+      status?: string;
+      credential_age_seconds?: number;
+    };
+    if (Array.isArray(payload.ice_servers) && payload.ice_servers.length > 0) {
+      context.diagnostic({
+        kind: "progress",
+        phase: "ice-servers",
+        detail: {
+          source: "bridge",
+          status: payload.status ?? "unknown",
+          credentialAgeSeconds: payload.credential_age_seconds ?? 0,
+        },
+      });
+      return payload.ice_servers;
+    }
+    if (payload.status === "app_managed") {
+      context.diagnostic({
+        kind: "progress",
+        phase: "ice-servers",
+        detail: { source: "app-managed; trying app fallback" },
+      });
+    } else {
+      throw new Error("bridge /ice response contained no ICE servers");
+    }
+  } catch {
+    if (context.signal.aborted) {
+      throw (
+        context.signal.reason ??
+        new DOMException("WMA ICE discovery aborted", "AbortError")
+      );
+    }
+    // A bridge rollout must not strand existing apps which vend their own credentials.
+    // Do not include the error in diagnostics: fetch implementations may include credentials in
+    // their message, while the source is enough to make the fallback visible to the caller.
+    context.diagnostic({
+      kind: "progress",
+      phase: "ice-servers",
+      detail: { source: "bridge-unavailable; trying app fallback" },
+    });
+  } finally {
+    clearTimeout(discoveryTimeout);
+    context.signal.removeEventListener("abort", abortDiscovery);
+  }
+  // Fallback to the app's own /ice endpoint.
+  const fallbackController = new AbortController();
+  const abortFallback = () => fallbackController.abort(context.signal.reason);
+  if (context.signal.aborted) {
+    abortFallback();
+  } else {
+    context.signal.addEventListener("abort", abortFallback, { once: true });
+  }
+  const fallbackTimeout = setTimeout(
+    () => fallbackController.abort(),
+    ICE_DISCOVERY_TIMEOUT_MS,
+  );
+  try {
+    const result = await context.run(`${context.endpointId}/ice`, {
+      input: {},
+      abortSignal: fallbackController.signal,
+    });
+    const payload = result.data as {
+      ice_servers?: RTCIceServer[];
+      status?: string;
+      credential_age_seconds?: number;
+    };
+    if (Array.isArray(payload?.ice_servers) && payload.ice_servers.length > 0) {
+      // The age is reported for observability only — the runner has already waited it out, so there
+      // is nothing for this side to do with it beyond showing it.
+      context.diagnostic({
+        kind: "progress",
+        phase: "ice-servers",
+        detail: {
+          source: "app-fallback",
+          status: payload.status ?? "unknown",
+          credentialAgeSeconds: payload.credential_age_seconds ?? 0,
+        },
+      });
+      return payload.ice_servers;
+    }
+    context.diagnostic({
+      kind: "progress",
+      phase: "ice-servers",
+      detail: { source: "empty-ice-response" },
+    });
+  } catch (exc) {
+    if (context.signal.aborted) {
+      throw (
+        context.signal.reason ??
+        new DOMException("WMA ICE discovery aborted", "AbortError")
+      );
+    }
+    console.warn("[wma] /ice unavailable, falling back to STUN:", exc);
+    context.diagnostic({
+      kind: "progress",
+      phase: "ice-servers",
+      detail: {
+        source: `ice-endpoint-failed: ${exc instanceof Error ? exc.message : String(exc)}`,
+      },
+    });
+  } finally {
+    clearTimeout(fallbackTimeout);
+    context.signal.removeEventListener("abort", abortFallback);
+  }
+  return [{ urls: DEFAULT_STUN_URL }];
+}
+
+/** fal error payloads are inconsistent; dig out something a human can act on. */
+async function readErrorMessage(response: Response): Promise<string> {
+  const fallback = `WMA session request failed (HTTP ${response.status})`;
+  try {
+    const data: unknown = await response.json();
+    if (typeof data === "object" && data !== null) {
+      const record = data as Record<string, unknown>;
+      for (const field of ["error", "message", "detail"]) {
+        const value = record[field];
+        if (typeof value === "string" && value) return value;
+        if (
+          Array.isArray(value) &&
+          typeof (value[0] as any)?.msg === "string"
+        ) {
+          return (value[0] as any).msg;
+        }
+      }
+    }
+  } catch {
+    /* non-JSON body */
+  }
+  return fallback;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function candidateInfo(candidate: any): WmaIceCandidateInfo {
+  const address = String(candidate.address ?? candidate.ip ?? "unknown");
+  const port = Number(candidate.port ?? 0);
+  return {
+    type: String(candidate.candidateType ?? candidate.type ?? "unknown"),
+    protocol: String(candidate.protocol ?? "unknown").toLowerCase(),
+    endpoint: address.includes(":")
+      ? `[${address}]:${port}`
+      : `${address}:${port}`,
+    address,
+    port,
+    relayProtocol: candidate.relayProtocol,
+    tcpType: candidate.tcpType,
+    relatedAddress: candidate.relatedAddress,
+    relatedPort: candidate.relatedPort,
+  };
+}
+
+function raceProbeStep<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  throwIfRealtimeAborted(signal);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () => finish(() => reject(signal.reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    const timeout = setTimeout(
+      () => finish(() => resolve({ timedOut: true })),
+      timeoutMs,
+    );
+    operation.then(
+      (value) => finish(() => resolve({ timedOut: false, value })),
+      (error) => finish(() => reject(error)),
+    );
+    if (signal.aborted) onAbort();
+  });
+}
+
+function probeDelay(ms: number, signal: AbortSignal): Promise<void> {
+  throwIfRealtimeAborted(signal);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () => finish(() => reject(signal.reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    const timeout = setTimeout(() => finish(resolve), ms);
+    if (signal.aborted) onAbort();
+  });
+}
+
+/**
+ * The browser's half of the selected path, from the SCTP transport's ICE pair when the browser
+ * exposes it, with a stats-based fallback that only accepts a pair whose local endpoint matches
+ * the endpoint the RUNNER observed — never "the first media transport", which produced
+ * plausible-looking but contradictory rows.
+ */
+async function browserNetworkPath(
+  pc: RTCPeerConnection,
+  sessionId: string,
+  runnerPath: WmaNetworkPath | undefined,
+  signal: AbortSignal,
+): Promise<WmaNetworkPath> {
+  const deadline = Date.now() + BROWSER_NETWORK_INFO_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const statsResult = await raceProbeStep(
+      pc.getStats(),
+      signal,
+      Math.max(0, deadline - Date.now()),
+    );
+    if (statsResult.timedOut === true) break;
+    const report = statsResult.value;
+    const stats = new Map<string, any>();
+    report.forEach((item: any) => stats.set(item.id, item));
+
+    const sctp = (pc as any).sctp;
+    const dtls = sctp?.transport;
+    const ice = dtls?.iceTransport;
+    const selected =
+      ice && typeof ice.getSelectedCandidatePair === "function"
+        ? ice.getSelectedCandidatePair()
+        : undefined;
+
+    let localCandidate: WmaIceCandidateInfo | undefined;
+    let remoteCandidate: WmaIceCandidateInfo | undefined;
+    let pairSelection: string | undefined;
+    if (selected) {
+      const local = selected.local || selected.localCandidate;
+      const remote = selected.remote || selected.remoteCandidate;
+      if (local && remote) {
+        localCandidate = candidateInfo(local);
+        remoteCandidate = candidateInfo(remote);
+        pairSelection = "browser-sctp-ice-transport";
+      }
+    }
+
+    const runnerRemoteEndpoint = runnerPath?.remoteCandidate?.endpoint;
+    const runnerLocalEndpoint = runnerPath?.localCandidate?.endpoint;
+    let pair: any;
+    let transport: any;
+    if (!localCandidate && runnerRemoteEndpoint && runnerLocalEndpoint) {
+      for (const item of stats.values()) {
+        if (item.type !== "candidate-pair" || item.state !== "succeeded")
+          continue;
+        const local = stats.get(item.localCandidateId);
+        const remote = stats.get(item.remoteCandidateId);
+        if (
+          local &&
+          remote &&
+          candidateInfo(local).endpoint === runnerRemoteEndpoint &&
+          candidateInfo(remote).endpoint === runnerLocalEndpoint
+        ) {
+          pair = item;
+          pairSelection = "cross-peer-endpoint-match";
+          localCandidate = candidateInfo(local);
+          remoteCandidate = candidateInfo(remote);
+          for (const maybeTransport of stats.values()) {
+            if (
+              maybeTransport.type === "transport" &&
+              maybeTransport.selectedCandidatePairId === item.id
+            ) {
+              transport = maybeTransport;
+              break;
+            }
+          }
+          break;
+        }
+      }
+    }
+
+    // Candidate-pair stats carry RTT even when the selected pair came from RTCIceTransport.
+    if (localCandidate && remoteCandidate && !pair) {
+      for (const item of stats.values()) {
+        if (item.type !== "candidate-pair" || item.state !== "succeeded")
+          continue;
+        const local = stats.get(item.localCandidateId);
+        const remote = stats.get(item.remoteCandidateId);
+        if (
+          local &&
+          remote &&
+          candidateInfo(local).endpoint === localCandidate.endpoint &&
+          candidateInfo(remote).endpoint === remoteCandidate.endpoint
+        ) {
+          pair = item;
+          break;
+        }
+      }
+    }
+
+    if (localCandidate && remoteCandidate) {
+      return {
+        side: "browser",
+        sessionId,
+        observedAtMs: Date.now(),
+        available: true,
+        connectionState: pc.connectionState,
+        iceConnectionState: pc.iceConnectionState,
+        iceRole: ice?.role || transport?.iceRole,
+        dtlsState: dtls?.state || transport?.dtlsState,
+        pairSelection,
+        localCandidate,
+        remoteCandidate,
+        usesTurn:
+          localCandidate.type === "relay" || remoteCandidate.type === "relay",
+        browserUsesTurn: localCandidate.type === "relay",
+        runnerUsesTurn: remoteCandidate.type === "relay",
+        currentRoundTripTimeMs:
+          pair && typeof pair.currentRoundTripTime === "number"
+            ? pair.currentRoundTripTime * 1000
+            : undefined,
+        availableOutgoingBitrate: pair?.availableOutgoingBitrate,
+      };
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await probeDelay(Math.min(BROWSER_NETWORK_INFO_POLL_MS, remaining), signal);
+  }
+  return {
+    side: "browser",
+    sessionId,
+    observedAtMs: Date.now(),
+    available: false,
+    reason: "browser did not expose the selected SCTP ICE pair",
+    connectionState: pc.connectionState,
+    iceConnectionState: pc.iceConnectionState,
+  };
+}
+
+/** The runner reports snake_case over the wire; the client surface is camelCase. */
+function normalizeRunnerPath(path: any): WmaNetworkPath {
+  const candidate = (value: any): WmaIceCandidateInfo | undefined =>
+    value
+      ? {
+          type: value.type,
+          protocol: value.protocol,
+          endpoint: value.endpoint,
+          address: value.address,
+          port: value.port,
+          relayProtocol: value.relay_protocol,
+          tcpType: value.tcp_type,
+          relatedAddress: value.related_address,
+          relatedPort: value.related_port,
+        }
+      : undefined;
+  return {
+    side: "runner",
+    sessionId: path.session_id,
+    observedAtMs: path.observed_at_ms,
+    available: path.available,
+    reason: path.reason,
+    connectionState: path.connection_state,
+    iceConnectionState: path.ice_connection_state,
+    iceRole: path.ice_role,
+    dtlsState: path.dtls_state,
+    pairSelection: "runner-sctp-nominated-pair",
+    localCandidate: candidate(path.local_candidate),
+    remoteCandidate: candidate(path.remote_candidate),
+    usesTurn: path.uses_turn,
+    runnerUsesTurn: path.runner_uses_turn,
+    browserUsesTurn: path.browser_uses_turn,
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * The WMA transport: a complete SDP offer POSTed to the signalling bridge, media peer-to-peer from
+ * the fal runner. This is what every app that generates its own video speaks.
+ *
+ * Takes the endpoint it opens rather than a set it claims, because it cannot recognize one. Any
+ * customer can build an app on this transport, so `fal-ai/wma-outstream` is indistinguishable by
+ * name from an endpoint with no realtime path at all. That is also why there is no `supports()`
+ * here: whether a model speaks WMA is declared — by the caller naming this extension, or by the
+ * model's own `x-fal-realtime` contract — and never inferred from a string.
+ *
+ * @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release.
+ */
+export function wma(endpointId?: string) {
+  return defineRealtimeExtension<WmaOptions, WmaRealtimeSession>({
+    id: "fal/wma",
+    defaultEndpoint: endpointId,
+    async open(context, options) {
+      if (options.direction === "stopped") {
+        throw new Error('WMA direction cannot be "stopped".');
+      }
+      const iceServers = options.iceServers ?? (await fetchIceServers(context));
+      const pc = new RTCPeerConnection({
+        iceServers,
+        iceTransportPolicy: options.iceTransportPolicy,
+      });
+      let peerClosed = false;
+      const closePeer = () => {
+        if (peerClosed) return;
+        peerClosed = true;
+        pc.close();
+      };
+      // Resource ownership starts at construction, before addTransceiver/createDataChannel can
+      // throw. The later full teardown is registered separately once its dependent state exists.
+      context.addCleanup(closePeer);
+
+      // The default that matters: recvonly. A generated stream never needs an inbound track,
+      // and asking for one would make the runner negotiate media it will not send.
+      // A local track is added through a transceiver so the caller's requested direction reaches
+      // SDP. Never add a second media transceiver for the same track.
+      const localTracks = options.localStream?.getTracks() ?? [];
+      if (localTracks.length > 0) {
+        for (const track of localTracks) {
+          pc.addTransceiver(track, {
+            direction: options.direction ?? "sendrecv",
+            streams: [options.localStream!],
+          });
+        }
+      } else {
+        pc.addTransceiver("video", {
+          direction: options.direction ?? "recvonly",
+        });
+      }
+
+      /**
+       * Observed ICE evidence for failure diagnostics. Candidate counts and `icecandidateerror`
+       * identify what was available and which server calls failed without guessing at an unseen NAT
+       * or firewall cause. Errors are deduplicated because a retrying server repeats the same line.
+       */
+      const observed = {
+        host: 0,
+        srflx: 0,
+        relay: 0,
+        errors: new Set<string>(),
+      };
+      pc.addEventListener("icecandidateerror", (event) => {
+        const error = event as RTCPeerConnectionIceErrorEvent;
+        observed.errors.add(
+          `${error.url ?? "unknown server"} → ${error.errorCode} ${error.errorText ?? ""}`.trim(),
+        );
+      });
+
+      const channel = pc.createDataChannel("control");
+      // Published through context.data rather than an option of this extension's own: "a message
+      // arrived" means the same thing in every protocol, so the kernel names it once and an
+      // application offering two extensions learns one name. See RealtimeOpenOptions.onData.
+      //
+      // Binary frames are DECODED, not stringified: a data channel delivers ArrayBuffer (or Blob,
+      // per browser) for binary sends, and String() would hand the application the literal
+      // "[object ArrayBuffer]". onData's contract is a raw string, so bytes decode as UTF-8; a
+      // Blob decodes asynchronously, which can reorder around neighboring text frames — a
+      // documented trade for not losing the payload entirely.
+      // One decoder for every binary frame — a per-frame `new TextDecoder()` is allocation
+      // churn at frame rate for identical output.
+      const controlFrameDecoder = new TextDecoder();
+      // Outstanding network-info queries by request id; responses are reserved JSON intercepted
+      // before application data flows through context.data.
+      const networkRequests = new Map<
+        string,
+        {
+          resolve: (value: WmaNetworkPath) => void;
+          reject: (error: Error) => void;
+        }
+      >();
+      const deliverControlFrame = (raw: string) => {
+        try {
+          const message = JSON.parse(raw) as {
+            type?: string;
+            request_id?: string;
+            path?: unknown;
+          };
+          if (message?.type === NETWORK_INFO_RESPONSE_TYPE) {
+            // Reserved by TYPE alone: a malformed reserved frame (missing or non-string
+            // request_id — a runner bug or version skew) is dropped with a warning, never
+            // forwarded as application data the app has no schema for. A late response whose
+            // waiter timed out is likewise absorbed here.
+            if (typeof message.request_id !== "string") {
+              context.diagnostic({
+                kind: "warning",
+                message: "A malformed reserved network-info frame was dropped.",
+              });
+              return;
+            }
+            const request = networkRequests.get(message.request_id);
+            if (request) {
+              networkRequests.delete(message.request_id);
+              try {
+                request.resolve(normalizeRunnerPath(message.path));
+              } catch (error) {
+                request.reject(
+                  error instanceof Error
+                    ? error
+                    : new Error("WMA runner returned invalid network info"),
+                );
+              }
+            }
+            return;
+          }
+        } catch {
+          // Application data may be any string; only reserved JSON is intercepted.
+        }
+        context.data(raw);
+      };
+      channel.onmessage = (event) => {
+        const payload: unknown = event.data;
+        if (typeof payload === "string") {
+          deliverControlFrame(payload);
+          return;
+        }
+        if (payload instanceof ArrayBuffer || ArrayBuffer.isView(payload)) {
+          const bytes =
+            payload instanceof ArrayBuffer ? new Uint8Array(payload) : payload;
+          deliverControlFrame(controlFrameDecoder.decode(bytes as Uint8Array));
+          return;
+        }
+        if (
+          typeof Blob !== "undefined" &&
+          payload instanceof Blob &&
+          typeof payload.text === "function"
+        ) {
+          void payload.text().then(
+            (text) => deliverControlFrame(text),
+            () =>
+              context.diagnostic({
+                kind: "warning",
+                message:
+                  "A binary control-channel frame could not be decoded and was dropped.",
+              }),
+          );
+          return;
+        }
+        context.diagnostic({
+          kind: "warning",
+          message:
+            "A control-channel frame with an unsupported payload type was dropped.",
+        });
+      };
+      const publishedStreams = new WeakSet<MediaStream>();
+      pc.ontrack = (event) => {
+        const streams =
+          event.streams.length > 0
+            ? event.streams
+            : [new MediaStream([event.track])];
+        for (const stream of streams) {
+          if (!publishedStreams.has(stream)) {
+            publishedStreams.add(stream);
+            context.media(stream);
+          }
+        }
+      };
+      pc.onconnectionstatechange = () => {
+        if (pc.connectionState === "failed") {
+          const turnOffered = countTurnServers(iceServers);
+          const parts = [
+            `ICE could not establish a path (iceConnectionState=${pc.iceConnectionState}).`,
+            `Gathered host ${observed.host}, srflx ${observed.srflx}, relay ${observed.relay}` +
+              ` from ${turnOffered} TURN server${turnOffered === 1 ? "" : "s"} offered.`,
+          ];
+          // Named servers with their codes. 701 is a DNS/host-lookup failure and 401/400 on an
+          // allocate is the credential being refused — different fixes, and the code is the only
+          // thing that distinguishes them.
+          parts.push(
+            observed.errors.size > 0
+              ? `Servers that errored: ${[...observed.errors].join("; ")}.`
+              : "No ICE server reported an error.",
+          );
+          // Stated only when it is true of THIS session, and as an observation rather than a cause.
+          if (turnOffered > 0 && observed.relay === 0) {
+            parts.push(
+              "TURN was configured and no relay candidate was allocated, so a relayed path was " +
+                "never available to try.",
+            );
+          }
+          void context.fail(parts.join(" "), {
+            ...observed,
+            turnOffered,
+            errors: [...observed.errors].join("; "),
+          });
+          return;
+        }
+        // Detail, not lifecycle. The kernel reports opening/live/failed/closed; the peer connection's
+        // own vocabulary is useful for debugging WMA and meaningless as a cross-protocol signal.
+        context.diagnostic({
+          kind: "progress",
+          phase: "connection-state",
+          detail: { state: pc.connectionState },
+        });
+      };
+
+      const pending: string[] = [];
+      let resolveControlChannelOpen!: () => void;
+      let rejectControlChannelOpen!: (error: Error) => void;
+      const controlChannelOpen = new Promise<void>((resolve, reject) => {
+        resolveControlChannelOpen = resolve;
+        rejectControlChannelOpen = reject;
+      });
+      // Most callers never query connection info. A channel that dies before opening should not
+      // create an unhandled rejection merely because nobody awaited this internal readiness gate.
+      void controlChannelOpen.catch(() => undefined);
+      let heartbeat: ReturnType<typeof setInterval> | null = null;
+      let heartbeatController: AbortController | null = null;
+      let heartbeatInFlight = false;
+      const networkProbeController = new AbortController();
+      let closed = false;
+      const teardown = () => {
+        if (closed) return;
+        closed = true;
+        networkProbeController.abort(
+          new Error("WMA session closed before the network probe completed"),
+        );
+        rejectControlChannelOpen(
+          new Error("WMA control channel closed before it opened"),
+        );
+        // Settle outstanding network probes NOW: their reply can no longer arrive over a channel
+        // this teardown is closing, their 10s timers must not outlive the session, and a caller
+        // awaiting one must hear "closed" promptly rather than a timeout after close() resolved.
+        for (const [id, request] of [...networkRequests]) {
+          networkRequests.delete(id);
+          request.reject(
+            new Error("WMA session closed before the network probe completed"),
+          );
+        }
+        pending.length = 0;
+        if (heartbeat !== null) clearInterval(heartbeat);
+        heartbeatController?.abort();
+        heartbeatController = null;
+        channel.close();
+        closePeer();
+      };
+      // Registered rather than only called by hand: the client runs cleanups once, in reverse
+      // order, when opening fails, the signal aborts, OR the session closes. That covers the
+      // abort path, which a local close() alone would leak.
+      context.addCleanup(teardown);
+
+      // Trap 2, resolved properly by the managed lifecycle: SCTP state is independent of
+      // `pc.connectionState`, so the channel can die while ICE still claims "connected" and
+      // every control message is silently dropped. Report it as a failed session rather than
+      // laundering transport death into a clean close.
+      const channelDied = () => {
+        if (closed) return;
+        rejectControlChannelOpen(
+          new Error("WMA control channel closed before it opened"),
+        );
+        void context.fail(
+          "control data channel closed or errored — SCTP died while ICE may still say connected",
+        );
+      };
+      channel.onclose = channelDied;
+      channel.onerror = channelDied;
+
+      // Trap 3.
+      // Session messages: open → send now, connecting → queue (bounded, oldest-first), anything
+      // else → drop. Request/response probes wait for controlChannelOpen instead.
+      const sendPayload = (payload: string) => {
+        if (channel.readyState === "open") {
+          channel.send(payload);
+        } else if (channel.readyState === "connecting") {
+          if (pending.length >= MAX_QUEUED_MESSAGES) pending.shift();
+          pending.push(payload);
+        }
+      };
+      channel.onopen = () => {
+        resolveControlChannelOpen();
+        // Guarded like the websocket pacer's drain: a channel can die between the open event
+        // queuing and this handler running, and one throwing send must not escape a browser
+        // event handler uncaught — nor mask that the remaining queued messages are gone.
+        const queued = pending.splice(0);
+        for (let i = 0; i < queued.length; i++) {
+          try {
+            channel.send(queued[i]);
+          } catch {
+            context.diagnostic({
+              kind: "warning",
+              message: `The control channel died while flushing; ${queued.length - i} queued message(s) were dropped.`,
+            });
+            break;
+          }
+        }
+      };
+
+      try {
+        const offer = await pc.createOffer();
+        // Attach listeners BEFORE setLocalDescription starts gathering — fast host/srflx
+        // candidates otherwise fire before the waiter exists and are never counted.
+        // Non-trickle signalling needs the kernel's sufficient-set / quiet-period / hard-bound
+        // strategy so the one SDP offer contains a usable, settled candidate set.
+        const gathering = context.gatherIce(pc, {
+          iceServers,
+          iceTransportPolicy: options.iceTransportPolicy,
+        });
+        const [gathered_ice] = await Promise.all([
+          gathering,
+          pc.setLocalDescription(offer),
+        ]);
+        observed.host = gathered_ice.host;
+        observed.srflx = gathered_ice.srflx;
+        observed.relay = gathered_ice.relay;
+
+        if (
+          options.iceTransportPolicy === "relay" &&
+          gathered_ice.relay === 0
+        ) {
+          throw new Error(
+            "WMA requires a TURN relay, but ICE gathering produced no relay candidate",
+          );
+        }
+
+        const gathered = pc.localDescription;
+        if (!gathered) throw new Error("failed to create WebRTC offer");
+        // gatherIce reports progress through application callbacks. A callback may cancel the
+        // session synchronously; never create a remote bridge resource after that cancellation.
+        throwIfRealtimeAborted(context.signal);
+
+        const sessionController = new AbortController();
+        const abortSession = () =>
+          sessionController.abort(context.signal.reason);
+        if (context.signal.aborted) {
+          abortSession();
+        } else {
+          context.signal.addEventListener("abort", abortSession, {
+            once: true,
+          });
+        }
+        const sessionTimeout = setTimeout(
+          () => sessionController.abort(),
+          SESSION_NEGOTIATION_TIMEOUT_MS,
+        );
+        let answer: {
+          session_id: string;
+          sdp: string;
+          type: RTCSdpType;
+        };
+        try {
+          // Auth comes from the client's configured credentials rather than a pasted key. The child
+          // signal preserves caller cancellation while bounding a bridge that accepts but never
+          // answers the negotiation request.
+          const response = await context.fetch(`${WMA_URL}/session`, {
+            method: "POST",
+            signal: sessionController.signal,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              app_id: context.endpointId,
+              sdp: gathered.sdp,
+              type: gathered.type,
+            }),
+          });
+          if (!response.ok) throw new Error(await readErrorMessage(response));
+          answer = (await response.json()) as typeof answer;
+        } finally {
+          clearTimeout(sessionTimeout);
+          context.signal.removeEventListener("abort", abortSession);
+        }
+
+        if (context.signal.aborted)
+          throw new Error("cancelled before answer applied");
+        await pc.setRemoteDescription({ sdp: answer.sdp, type: answer.type });
+        // Recheck AFTER the await: a close or abort landing while the remote description was
+        // being applied has already run the registered teardown with no heartbeat to clear —
+        // creating the interval now would leave a timer firing aborted requests forever, since
+        // the late session's close hits the already-latched teardown.
+        if (closed || context.signal.aborted) {
+          throw new Error("cancelled while applying the answer");
+        }
+
+        // Trap 4.
+        // A single missed beat is a transient gap the bridge tolerates; a RUN of them is a dead
+        // lease. A bridge that restarts answers every beat with 404/410 forever, and treating
+        // that as transient left the handle "live" over frozen media with no diagnostic.
+        let heartbeatStrikes = 0;
+        const HEARTBEAT_MAX_STRIKES = 3;
+        heartbeat = setInterval(() => {
+          if (heartbeatInFlight) return;
+          heartbeatInFlight = true;
+          // Only the per-beat timeout lives here: session abort already cancels the request
+          // through the kernel, which combines this signal with the session's.
+          const controller = new AbortController();
+          heartbeatController = controller;
+          const heartbeatTimeout = setTimeout(
+            () => controller.abort(),
+            HEARTBEAT_TIMEOUT_MS,
+          );
+          context
+            .fetch(`${WMA_URL}/session/heartbeat`, {
+              method: "POST",
+              signal: controller.signal,
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ session_id: answer.session_id }),
+            })
+            .then(async (response) => {
+              if (!response.ok) {
+                // Drain the body even though it carries nothing useful: the kernel releases each
+                // request's signal bookkeeping when the body is consumed, so a degraded bridge
+                // returning errors every beat must not retain one combination per heartbeat.
+                await response.arrayBuffer().catch(() => undefined);
+                heartbeatStrikes++;
+                if (
+                  heartbeatStrikes >= HEARTBEAT_MAX_STRIKES &&
+                  !closed &&
+                  !context.signal.aborted
+                ) {
+                  await context.fail(
+                    `WMA heartbeat rejected ${heartbeatStrikes} times in a row (last status ${response.status}) — the session lease is gone`,
+                    {
+                      consecutiveFailures: heartbeatStrikes,
+                      lastStatus: response.status,
+                    },
+                  );
+                }
+                return;
+              }
+              let status: { alive?: boolean };
+              try {
+                status = (await response.json()) as { alive?: boolean };
+              } catch {
+                // A 200 whose body is not JSON (captive portal, half-broken rollout) is as dead
+                // as a 404 — it must count a strike, not reset the counter and slip past the
+                // alive check into the transient-network bucket.
+                heartbeatStrikes++;
+                if (
+                  heartbeatStrikes >= HEARTBEAT_MAX_STRIKES &&
+                  !closed &&
+                  !context.signal.aborted
+                ) {
+                  await context.fail(
+                    `WMA heartbeat returned unparseable responses ${heartbeatStrikes} times in a row — the session lease is gone`,
+                    { consecutiveFailures: heartbeatStrikes },
+                  );
+                }
+                return;
+              }
+              heartbeatStrikes = 0;
+              if (
+                status.alive === false &&
+                !closed &&
+                !context.signal.aborted
+              ) {
+                await context.fail(
+                  "WMA bridge reports that the session is no longer alive",
+                );
+              }
+            })
+            .catch(() => {
+              // A network error here is indistinguishable from a transient gap; unlike an HTTP
+              // rejection it does not count a strike, because the bridge itself said nothing.
+            })
+            .finally(() => {
+              clearTimeout(heartbeatTimeout);
+              if (heartbeatController === controller) {
+                heartbeatController = null;
+              }
+              heartbeatInFlight = false;
+            });
+        }, HEARTBEAT_INTERVAL_MS);
+
+        return {
+          sessionId: answer.session_id,
+          send(message: WmaControlMessage) {
+            // Serialization AFTER the readyState gate: a dead channel drops the message on the
+            // next line, and paying full JSON encoding for it wastes CPU exactly when the app
+            // is already degraded but input handlers are still firing.
+            if (
+              channel.readyState !== "open" &&
+              channel.readyState !== "connecting"
+            ) {
+              return;
+            }
+            sendPayload(JSON.stringify(message));
+          },
+          async getConnectionInfo(): Promise<WmaConnectionInfo> {
+            // The session can exist while SCTP is still connecting. Wait here rather than putting
+            // this request/response exchange in the fire-and-forget control queue: its timeout is
+            // meaningful only once the request can actually reach the runner.
+            if (channel.readyState !== "open") {
+              // Bounded like every other wait in this file: a middlebox silently dropping DTLS
+              // can hold the channel in "connecting" for minutes without ever reaching a state
+              // that rejects controlChannelOpen.
+              let openDeadline: ReturnType<typeof setTimeout> | undefined;
+              try {
+                await Promise.race([
+                  controlChannelOpen,
+                  new Promise<never>((_, reject) => {
+                    openDeadline = setTimeout(
+                      () =>
+                        reject(
+                          new Error(
+                            `WMA control channel did not open within ${NETWORK_INFO_TIMEOUT_MS / 1000}s`,
+                          ),
+                        ),
+                      NETWORK_INFO_TIMEOUT_MS,
+                    );
+                  }),
+                ]);
+              } finally {
+                clearTimeout(openDeadline);
+              }
+            }
+            if (closed || channel.readyState !== "open") {
+              throw new Error("WMA control channel is not available");
+            }
+            const requestId =
+              typeof crypto !== "undefined" &&
+              typeof crypto.randomUUID === "function"
+                ? crypto.randomUUID()
+                : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            const runner = new Promise<WmaNetworkPath>((resolve, reject) => {
+              timeout = setTimeout(() => {
+                const request = networkRequests.get(requestId);
+                if (!request) return;
+                networkRequests.delete(requestId);
+                request.reject(
+                  new Error(
+                    `runner network info timed out after ${NETWORK_INFO_TIMEOUT_MS / 1000}s`,
+                  ),
+                );
+              }, NETWORK_INFO_TIMEOUT_MS);
+              networkRequests.set(requestId, {
+                resolve: (value) => {
+                  clearTimeout(timeout);
+                  resolve(value);
+                },
+                reject: (error) => {
+                  clearTimeout(timeout);
+                  reject(error);
+                },
+              });
+            });
+            try {
+              channel.send(
+                JSON.stringify({
+                  type: NETWORK_INFO_REQUEST_TYPE,
+                  request_id: requestId,
+                }),
+              );
+            } catch (error) {
+              const request = networkRequests.get(requestId);
+              networkRequests.delete(requestId);
+              request?.reject(
+                error instanceof Error
+                  ? error
+                  : new Error("WMA network probe could not be sent"),
+              );
+            }
+            // Runner first: its response comes over this exact data channel and gives the
+            // browser probe an endpoint to cross-match when getStats() does not expose an
+            // SCTP-to-transport relationship.
+            const runnerPath = await runner;
+            const browser = await browserNetworkPath(
+              pc,
+              answer.session_id,
+              runnerPath,
+              networkProbeController.signal,
+            );
+            for (const path of [browser, runnerPath]) {
+              const local = path.localCandidate;
+              const remote = path.remoteCandidate;
+              context.diagnostic({
+                kind: "progress",
+                phase: "network-path",
+                detail: {
+                  side: path.side,
+                  local: local
+                    ? `${local.type}/${local.protocol} ${local.endpoint}`
+                    : "unavailable",
+                  remote: remote
+                    ? `${remote.type}/${remote.protocol} ${remote.endpoint}`
+                    : "unavailable",
+                  usesTurn: path.usesTurn ? "yes" : "no",
+                  rttMs:
+                    path.currentRoundTripTimeMs === undefined
+                      ? "unavailable"
+                      : Math.round(path.currentRoundTripTimeMs),
+                },
+              });
+            }
+            return { browser, runner: runnerPath };
+          },
+          close: teardown,
+        };
+      } catch (exc) {
+        teardown();
+        throw exc;
+      }
+    },
+  });
+}
+
+/*
+ * Usage — a pure output stream is the degenerate case, which is the point:
+ *
+ *   const stream = fal.realtime.open(wma("fal-ai/wma-outstream"), {
+ *     onMedia: (s) => { videoEl.srcObject = s },
+ *     onState: (s) => { if (s === "failed") console.warn("died") },
+ *   });
+ *
+ * The handle returns synchronously in state "opening" (await `.ready` for the promise style).
+ * No `send`, no message schema, no key handling. An interactive world model is the same
+ * call plus `onData` and `send({ type: "keys", pressed, activated })`.
+ */

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -5,7 +5,11 @@ import { buildUrl, dispatchRequest } from "./request";
 import { ApiError, defaultResponseHandler } from "./response";
 import { type StorageClient } from "./storage";
 import { EndpointType, InputType, OutputType } from "./types/client";
-import { ensureEndpointIdFormat, resolveEndpointPath } from "./utils";
+import {
+  ensureEndpointIdFormat,
+  isValidUrl,
+  resolveEndpointPath,
+} from "./utils";
 
 export type StreamingConnectionMode = "client" | "server";
 
@@ -167,7 +171,12 @@ export class FalStream<Input, Output> {
       if (connectionMode === "client") {
         // if we are in the browser, we need to get a temporary token
         // to authenticate the request
-        const appId = ensureEndpointIdFormat(endpointId);
+        // A full fal URL is a valid endpoint here, exactly as buildUrl accepts it — the token
+        // scope is then the URL itself, which a custom tokenProvider resolves. Only bare ids go
+        // through the endpoint-format check (which throws on scheme-bearing strings).
+        const appId = isValidUrl(endpointId)
+          ? endpointId
+          : ensureEndpointIdFormat(endpointId);
         const resolvedPath =
           resolveEndpointPath(endpointId, undefined, "/stream") ?? "";
         const fetchToken = tokenProvider

--- a/libs/client/src/utils.spec.ts
+++ b/libs/client/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { ensureEndpointIdFormat, parseEndpointId } from "./utils";
+import { ensureEndpointIdFormat, isValidUrl, parseEndpointId } from "./utils";
 
 describe("The utils test suite", () => {
   it("shoud match a current appOwner/appId format", () => {
@@ -14,6 +14,17 @@ describe("The utils test suite", () => {
   it("should throw on an invalid app id format", () => {
     const id = "just-an-id";
     expect(() => ensureEndpointIdFormat(id)).toThrowError();
+  });
+
+  it("should reject URLs that failed validation instead of passing them through", () => {
+    // An http:// fal URL fails isValidUrl (https-only); slipping it through as an "endpoint id"
+    // would build https://fal.run/http://… — a silently mangled 404. Reject loudly instead.
+    expect(() =>
+      ensureEndpointIdFormat("http://fal.run/fal-ai/flux"),
+    ).toThrowError(/https/);
+    expect(() =>
+      ensureEndpointIdFormat("https://evil.example/fal-ai/flux"),
+    ).toThrowError(/https/);
   });
 
   it("should parse a current app id", () => {
@@ -43,5 +54,18 @@ describe("The utils test suite", () => {
       alias: "fast-sdxl",
       namespace: "workflows",
     });
+  });
+
+  it("accepts only HTTPS URLs on actual fal domains", () => {
+    expect(isValidUrl("https://fal.run/fal-ai/flux")).toBe(true);
+    expect(isValidUrl("https://queue.fal.run/fal-ai/flux")).toBe(true);
+    expect(isValidUrl("https://api.fal.ai/models")).toBe(true);
+    expect(isValidUrl("https://notfal.run/steal")).toBe(false);
+    expect(isValidUrl("https://fal.run.attacker.example/steal")).toBe(false);
+    expect(isValidUrl("http://fal.run/fal-ai/flux")).toBe(false);
+    // The default :443 normalizes away; any surviving explicit port is another listener and
+    // credentials must not follow a fal hostname to it.
+    expect(isValidUrl("https://fal.run:443/fal-ai/flux")).toBe(true);
+    expect(isValidUrl("https://fal.run:8443/fal-ai/flux")).toBe(false);
   });
 });

--- a/libs/client/src/utils.ts
+++ b/libs/client/src/utils.ts
@@ -1,4 +1,13 @@
 export function ensureEndpointIdFormat(id: string): string {
+  // A scheme-bearing string is a URL that already failed isValidUrl (http://, a non-fal host…).
+  // Passing it through as an "endpoint id" would build https://fal.run/http://… — a silently
+  // mangled 404 — so reject it loudly with the actual constraint instead.
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(id)) {
+    throw new Error(
+      `Invalid endpoint: ${id}. URLs must be https:// and point at a fal.run or fal.ai host; ` +
+        "anything else must be an endpoint id in the format <appOwner>/<appId>.",
+    );
+  }
   const parts = id.split("/");
   if (parts.length > 1) {
     return id;
@@ -67,8 +76,18 @@ export function resolveEndpointPath(
 
 export function isValidUrl(url: string) {
   try {
-    const { host } = new URL(url);
-    return /(fal\.(ai|run))$/.test(host);
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return (
+      parsed.protocol === "https:" &&
+      // No explicit nonstandard port: the URL parser normalizes :443 away, so any remaining port
+      // targets a different listener — credentials must not follow a fal hostname to it.
+      parsed.port === "" &&
+      (hostname === "fal.ai" ||
+        hostname.endsWith(".fal.ai") ||
+        hostname === "fal.run" ||
+        hostname.endsWith(".fal.run"))
+    );
   } catch (_) {
     return false;
   }

--- a/libs/proxy/package.json
+++ b/libs/proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/server-proxy",
   "description": "The fal.ai server proxy adapter for JavaScript and TypeScript Web frameworks",
-  "version": "1.2.1",
+  "version": "1.3.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/proxy/src/config.ts
+++ b/libs/proxy/src/config.ts
@@ -53,6 +53,15 @@ export interface ProxyConfig {
   allowedUrlPatterns?: string[];
 
   /**
+   * fal-operated service hosts whose paths are infrastructure routes rather than app ids.
+   * Only the proxy's known service routes are forwarded, and app-scoped routes still enforce
+   * `allowedEndpoints` against the `app_id` in their JSON body. Set to `[]` to disable them.
+   *
+   * @default ["wma.fal.run"]
+   */
+  serviceHosts?: string[];
+
+  /**
    * Endpoint patterns (glob-style) that are allowed to be called via POST requests.
    * The endpoint is the path portion of the URL without the leading slash.
    *
@@ -124,6 +133,7 @@ export async function isAuthorizationHeaderPresent(
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   allowedUrlPatterns: DEFAULT_ALLOWED_URL_PATTERNS,
+  serviceHosts: ["wma.fal.run"],
   allowedEndpoints: [],
   allowUnauthorizedRequests: true,
   isAuthenticated: isAuthorizationHeaderPresent,

--- a/libs/proxy/src/index.spec.ts
+++ b/libs/proxy/src/index.spec.ts
@@ -1,5 +1,10 @@
 import { createUrlMatcher, DEFAULT_ALLOWED_URL_PATTERNS } from "./config";
-import { getEndpoint, isAllowedEndpoint, isAllowedUrl } from "./index";
+import {
+  getEndpoint,
+  handleRequest,
+  isAllowedEndpoint,
+  isAllowedUrl,
+} from "./index";
 
 const FAL_REST_API_URL = "rest.fal.ai";
 
@@ -338,5 +343,229 @@ describe("isAllowedEndpoint", () => {
         isAllowedEndpoint("fal-ai/flux-dev/requests/abc123/status", patterns),
       ).toBe(true);
     });
+  });
+});
+
+describe("WMA service-host proxying", () => {
+  function behaviorFor(targetUrl: string, method = "POST", requestBody = "{}") {
+    const responses: Array<{ status: number; data: unknown }> = [];
+    return {
+      responses,
+      behavior: {
+        id: "test",
+        method,
+        getRequestBody: jest.fn(async () => requestBody),
+        getHeaders: () => ({}),
+        getHeader: (name: string) =>
+          name === "x-fal-target-url" ? targetUrl : undefined,
+        sendHeader: () => undefined,
+        respondWith: (status: number, data: unknown) => {
+          responses.push({ status, data });
+          return undefined as never;
+        },
+        sendResponse: async () => undefined as never,
+      },
+    };
+  }
+
+  const run = async (
+    targetUrl: string,
+    config: Record<string, unknown> = {},
+    method = "POST",
+    requestBody = "{}",
+  ) => {
+    const { behavior, responses } = behaviorFor(targetUrl, method, requestBody);
+    await handleRequest(
+      behavior as never,
+      {
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async () => false,
+        ...config,
+      } as never,
+    );
+    return responses[0];
+  };
+
+  it("allows the known bridge routes without widening allowedUrlPatterns", async () => {
+    expect(await run("https://wma.fal.run/session/heartbeat")).toEqual({
+      status: 401,
+      data: "Unauthorized",
+    });
+    expect(
+      await run(
+        "https://wma.fal.run/session",
+        {
+          allowedUrlPatterns: ["fal.run/me/my-app/**"],
+          allowedEndpoints: ["me/my-app/**"],
+        },
+        "POST",
+        JSON.stringify({ app_id: "me/my-app/world" }),
+      ),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+  });
+
+  it("rejects non-POST methods and unknown bridge routes", async () => {
+    for (const method of ["GET", "PUT", "PATCH", "DELETE"]) {
+      expect(
+        await run("https://wma.fal.run/session", {}, method),
+      ).toMatchObject({ status: 400 });
+    }
+    for (const path of [
+      "/upload",
+      "/session;x=1",
+      "/session%00",
+      "/session/v2",
+    ]) {
+      expect(await run(`https://wma.fal.run${path}`)).toMatchObject({
+        status: 400,
+      });
+    }
+  });
+
+  it("does not grant service-host treatment over HTTP", async () => {
+    expect(
+      await run("http://wma.fal.run/session", {
+        allowedUrlPatterns: ["fal.run/me/my-app/**"],
+      }),
+    ).toMatchObject({ status: 400 });
+  });
+
+  it("lets operators disable service hosts", async () => {
+    expect(
+      await run("https://wma.fal.run/session", { serviceHosts: [] }),
+    ).toMatchObject({ status: 400 });
+  });
+
+  it("enforces allowedEndpoints against /ice and /session app_id", async () => {
+    for (const path of ["ice", "session"]) {
+      expect(
+        await run(
+          `https://wma.fal.run/${path}`,
+          {
+            allowedEndpoints: ["me/my-app/**"],
+            isAuthenticated: async () => true,
+            resolveFalAuth: async () => undefined,
+          },
+          "POST",
+          JSON.stringify({ app_id: "someone/other-app" }),
+        ),
+      ).toMatchObject({ status: 400 });
+      expect(
+        await run(
+          `https://wma.fal.run/${path}`,
+          {
+            allowedEndpoints: ["me/my-app/**"],
+            isAuthenticated: async () => true,
+            resolveFalAuth: async () => undefined,
+          },
+          "POST",
+          JSON.stringify({ app_id: "me/my-app/world" }),
+        ),
+      ).toEqual({ status: 401, data: "Unauthorized" });
+    }
+  });
+
+  it("allows heartbeat without app_id under endpoint restrictions", async () => {
+    expect(
+      await run("https://wma.fal.run/session/heartbeat", {
+        allowedEndpoints: ["me/my-app/**"],
+      }),
+    ).toEqual({ status: 401, data: "Unauthorized" });
+  });
+
+  it("rejects missing, duplicate, and escaped duplicate app_id keys", async () => {
+    for (const body of [
+      "{}",
+      '{"app_id":"me/my-app","app_id":"someone/other-app"}',
+      '{"app_id":"me/my-app","app_\\u0069d":"someone/other-app"}',
+      '{"app_\\u0069d":"me/my-app","app_id":"someone/other-app"}',
+    ]) {
+      expect(
+        await run(
+          "https://wma.fal.run/session",
+          {
+            allowedEndpoints: ["me/my-app/**"],
+            isAuthenticated: async () => true,
+          },
+          "POST",
+          body,
+        ),
+      ).toMatchObject({ status: 400 });
+    }
+  });
+
+  it("applies app policy to normalized route spellings", async () => {
+    expect(
+      await run(
+        "https://wma.fal.run/%73ession//",
+        {
+          allowedEndpoints: ["me/my-app/**"],
+          isAuthenticated: async () => true,
+        },
+        "POST",
+        JSON.stringify({ app_id: "someone/other-app" }),
+      ),
+    ).toMatchObject({ status: 400 });
+  });
+
+  it("keeps allowedEndpoints enforced for normal fal.run app hosts", async () => {
+    for (const host of ["fal.run", "queue.fal.run"]) {
+      expect(
+        await run(`https://${host}/someone/other-app`, {
+          allowedEndpoints: ["me/my-app/**"],
+        }),
+      ).toMatchObject({ status: 400 });
+    }
+  });
+
+  it("reads an app-scoped body once and forwards that same value", async () => {
+    const body = JSON.stringify({ app_id: "me/my-app/world", sdp: "offer" });
+    const { behavior } = behaviorFor(
+      "https://wma.fal.run/session",
+      "POST",
+      body,
+    );
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("{}"));
+    try {
+      await handleRequest(behavior as never, {
+        allowedEndpoints: ["me/my-app/**"],
+        allowUnauthorizedRequests: false,
+        isAuthenticated: async (authBehavior) => {
+          expect(await authBehavior.getRequestBody()).toBe(body);
+          return true;
+        },
+        resolveFalAuth: async (authBehavior) => {
+          expect(await authBehavior.getRequestBody()).toBe(body);
+          return "Key secret";
+        },
+      });
+
+      expect(behavior.getRequestBody).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://wma.fal.run/session",
+        expect.objectContaining({ body }),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects unauthenticated app-scoped requests before reading their body", async () => {
+    const { behavior, responses } = behaviorFor(
+      "https://wma.fal.run/session",
+      "POST",
+      JSON.stringify({ app_id: "me/my-app/world" }),
+    );
+
+    await handleRequest(behavior as never, {
+      allowedEndpoints: ["me/my-app/**"],
+      allowUnauthorizedRequests: false,
+      isAuthenticated: async () => false,
+    });
+
+    expect(responses[0]).toEqual({ status: 401, data: "Unauthorized" });
+    expect(behavior.getRequestBody).not.toHaveBeenCalled();
   });
 });

--- a/libs/proxy/src/index.ts
+++ b/libs/proxy/src/index.ts
@@ -40,14 +40,55 @@ export function isAllowedUrl(url: string, patterns?: string[]): boolean {
   return defaultUrlMatcher(url);
 }
 
-/**
- * Extracts the URL without the scheme for validation purposes.
- * @param targetUrl the full URL including scheme.
- * @returns the URL without the scheme (host + path + query).
- */
-function getUrlWithoutScheme(targetUrl: string): string {
-  const url = new URL(targetUrl);
-  return `${url.host}${url.pathname}${url.search}`;
+// Only these WMA bridge routes may use the service-host allowlist bypass. App-scoped routes carry
+// the fal app identity in JSON; the heartbeat acts only on an already-authorized session.
+const SERVICE_APP_SCOPED_PATHS = new Set(["/ice", "/session"]);
+const SERVICE_SESSION_SCOPED_PATHS = new Set(["/session/heartbeat"]);
+
+function normalizeServicePath(url: URL): string | undefined {
+  try {
+    const path = decodeURIComponent(url.pathname).replace(/\/{2,}/g, "/");
+    return path.replace(/\/+$/, "") || "/";
+  } catch {
+    return undefined;
+  }
+}
+
+function countJsonKeys(body: string, key: string): number {
+  let count = 0;
+  for (let index = 0; index < body.length; index++) {
+    if (body[index] !== '"') continue;
+    const start = index;
+    for (index++; index < body.length; index++) {
+      if (body[index] === "\\") {
+        index++;
+        continue;
+      }
+      if (body[index] !== '"') continue;
+
+      let next = index + 1;
+      while (/\s/.test(body[next] ?? "")) next++;
+      if (body[next] === ":") {
+        try {
+          if (JSON.parse(body.slice(start, index + 1)) === key) count++;
+        } catch {
+          // The full parse below rejects malformed JSON. This scan only detects duplicate keys.
+        }
+      }
+      break;
+    }
+  }
+  return count;
+}
+
+function appIdFromRequestBody(body: string | undefined): string | undefined {
+  if (!body || countJsonKeys(body, "app_id") > 1) return undefined;
+  try {
+    const value = JSON.parse(body) as { app_id?: unknown };
+    return typeof value.app_id === "string" ? value.app_id : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -131,27 +172,84 @@ export async function handleRequest<ResponseType>(
     ? (config as ProxyConfig)
     : applyProxyConfig(config);
 
-  const urlToValidate = getUrlWithoutScheme(targetUrl);
-  if (!isAllowedUrl(urlToValidate, resolvedConfig.allowedUrlPatterns)) {
+  let requestBodyPromise: Promise<string | undefined> | undefined;
+  const readRequestBody = () =>
+    (requestBodyPromise ??= behavior.getRequestBody());
+  const behaviorWithCachedBody: ProxyBehavior<ResponseType> = {
+    id: behavior.id,
+    method: behavior.method,
+    respondWith: (status, data) => behavior.respondWith(status, data),
+    sendResponse: (response) => behavior.sendResponse(response),
+    getHeaders: () => behavior.getHeaders(),
+    getHeader: (name) => behavior.getHeader(name),
+    sendHeader: (name, value) => behavior.sendHeader(name, value),
+    getRequestBody: readRequestBody,
+    resolveApiKey: behavior.resolveApiKey?.bind(behavior),
+  };
+  let authenticationPromise: Promise<boolean> | undefined;
+  const authenticate = () =>
+    (authenticationPromise ??= (async () =>
+      (await resolvedConfig.isAuthenticated?.(behaviorWithCachedBody)) ??
+      false)());
+
+  const target = new URL(targetUrl);
+  const serviceHosts = new Set(
+    (resolvedConfig.serviceHosts ?? ["wma.fal.run"]).map((host) =>
+      host.toLowerCase(),
+    ),
+  );
+  const isServiceHost =
+    target.protocol === "https:" && serviceHosts.has(target.host.toLowerCase());
+
+  const urlToValidate = `${target.host}${target.pathname}${target.search}`;
+  if (
+    !isServiceHost &&
+    !isAllowedUrl(urlToValidate, resolvedConfig.allowedUrlPatterns)
+  ) {
     return behavior.respondWith(400, "Invalid request");
   }
 
-  // Check allowed endpoints for POST requests only, skip for *.fal.ai domains
-  if (behavior.method?.toUpperCase() === "POST" && !isFalAiDomain(targetUrl)) {
+  const method = behavior.method?.toUpperCase();
+  if (isServiceHost) {
+    if (method !== "POST") {
+      return behavior.respondWith(400, "Invalid request");
+    }
+    const path = normalizeServicePath(target);
+    const isAppScoped =
+      path !== undefined && SERVICE_APP_SCOPED_PATHS.has(path);
+    if (
+      !isAppScoped &&
+      (path === undefined || !SERVICE_SESSION_SCOPED_PATHS.has(path))
+    ) {
+      return behavior.respondWith(400, "Invalid request");
+    }
+
+    const allowedEndpoints = resolvedConfig.allowedEndpoints ?? [];
+    if (isAppScoped && allowedEndpoints.length > 0) {
+      const isAuthenticated = await authenticate();
+      if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
+        return behavior.respondWith(401, "Unauthorized");
+      }
+      const appId = appIdFromRequestBody(await readRequestBody());
+      if (!appId || !isAllowedEndpoint(appId, allowedEndpoints)) {
+        return behavior.respondWith(400, "Invalid request");
+      }
+    }
+  } else if (method === "POST" && !isFalAiDomain(targetUrl)) {
+    // Normal app-serving URLs keep the existing path-based endpoint check.
     const endpoint = getEndpoint(targetUrl);
     if (!isAllowedEndpoint(endpoint, resolvedConfig.allowedEndpoints ?? [])) {
       return behavior.respondWith(400, "Invalid request");
     }
   }
 
-  const isAuthenticated =
-    (await resolvedConfig.isAuthenticated?.(behavior)) ?? false;
+  const isAuthenticated = await authenticate();
   if (!isAuthenticated && !resolvedConfig.allowUnauthorizedRequests) {
     return behavior.respondWith(401, "Unauthorized");
   }
 
   const authorization =
-    (await resolvedConfig.resolveFalAuth?.(behavior)) ??
+    (await resolvedConfig.resolveFalAuth?.(behaviorWithCachedBody)) ??
     (await behavior.resolveApiKey?.());
   if (!authorization) {
     return behavior.respondWith(401, "Unauthorized");
@@ -180,7 +278,7 @@ export async function handleRequest<ResponseType>(
     body:
       behavior.method?.toUpperCase() === "GET"
         ? undefined
-        : await behavior.getRequestBody(),
+        : await readRequestBody(),
   });
 
   // copy headers from fal to the proxied response

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "paths": {
       "@fal-ai/client": ["libs/client/src/index.ts"],
       "@fal-ai/client/endpoints": ["libs/client/src/types/endpoints.ts"],
+      "@fal-ai/client/realtime": ["libs/client/src/realtime/index.ts"],
       "@fal-ai/create-app": ["libs/create-app/src/index.ts"],
       "@fal-ai/server-proxy": ["libs/proxy/src/index.ts"],
       "@fal-ai/server-proxy/express": ["libs/proxy/src/express.ts"],


### PR DESCRIPTION
## What this PR adds

https://gist.github.com/noahgsolomon/9c36a99c7943c71ffc8071a95d001363

This PR adds an experimental, protocol-extension API for realtime model sessions:

```ts
const session = fal.realtime.open(wma("fal-ai/my-world-model"), {
  localStream: cameraStream,
  onMedia: (stream) => (video.srcObject = stream),
  onState: setStatus,
  onError: console.error,
});

session.send({ type: "keys", pressed: ["w"], activated: [] });
await session.close();
```

## Complete React example

This receive-only client component assumes the application exposes a Next.js proxy at `/api/fal/proxy`, backed by a server-side `FAL_KEY`. It opens on mount, attaches inbound media to the video element, and keeps the one essential piece of React lifecycle handling: closing the WebRTC session on unmount.

```tsx
"use client";

import { createFalClient } from "@fal-ai/client";
import { wma } from "@fal-ai/client/realtime";
import { useEffect, useRef } from "react";

const fal = createFalClient({ proxyUrl: "/api/fal/proxy" });

export default function WorldModel() {
  const videoRef = useRef<HTMLVideoElement>(null);

  useEffect(() => {
    const session = fal.realtime.open(
      wma("fal-ai/my-world-model"),
      {
        onMedia(stream) {
          if (videoRef.current) {
            videoRef.current.srcObject = stream;
          }
        },
        onError: console.error,
      },
    );

    return () => {
      void session.close();
    };
  }, []);

  return <video ref={videoRef} autoPlay playsInline muted />;
}
```

Input-driven models use the same handle: keep it in a ref only when the component needs to call `session.send(...)`. To use custom STUN/TURN infrastructure, add an `iceServers` array to the `open()` options; supplying it bypasses WMA's automatic bridge and app-managed ICE discovery.

It also includes the small `@fal-ai/server-proxy` change required for that WMA session to work when browser traffic is routed through an application's server. The client and proxy support ship together so there is no intermediate release where the client advertises proxied WMA but the proxy rejects it.

## Scope

| Area | What changes | Why it is here |
|---|---|---|
| Realtime extension kernel | Adds `fal.realtime.open()`, synchronous handles, lifecycle, cancellation, cleanup, bounded pre-live sends, diagnostics, media/data callbacks, and shared protocol helpers | Core public API |
| WMA extension | Adds WebRTC negotiation through `wma.fal.run`, ICE discovery, heartbeat leases, control-channel messaging, and connection diagnostics | Primary use case |
| Lucy extension | Adds Lucy video-to-video WebRTC signaling over fal's existing realtime WebSocket | Validates a second negotiation protocol |
| WebSocket extension | Exposes fal's existing WebSocket protocol through `open()` with ordered paced sending | Gives the new API a first-party WebSocket path |
| Existing `connect()` fixes | Makes the newest same-key handle own the connection and prevents an explicitly closed handle from reconnecting | Fixes lifecycle behavior used by the extensions |
| WMA proxy support | Allows only the known WMA bridge routes and keeps `allowedEndpoints` enforcement for app-scoped requests | Required for browser clients using `@fal-ai/server-proxy` |
| Packaging and docs | Adds subpath exports, versions client `1.11.0-alpha.0` and proxy `1.3.0-alpha.0`, and documents the experimental API | Makes both halves testable without moving either package's `latest` tag |

No general proxy hardening is included. This PR does **not** change framework body parsers, arbitrary request-header forwarding, request-size limits, multipart/binary behavior, response status/byte handling, or adapter error propagation.

To keep that boundary explicit, the extension infrastructure's `context.fetch` accepts JSON string request bodies only. That is the body format every supported proxy adapter already preserves and the only format WMA needs; multipart and arbitrary binary forwarding remain outside this PR.

## Alpha release

This ships first as a matched prerelease pair: `@fal-ai/client@1.11.0-alpha.0` and `@fal-ai/server-proxy@1.3.0-alpha.0`. The repository's release workflow derives the `alpha` npm dist-tag from those versions, so existing users of `latest` remain on client `1.10.x` and proxy `1.2.x`. Testers can opt in with `npm install @fal-ai/client@alpha @fal-ai/server-proxy@alpha`; a later stabilization PR can promote the same release lines to `1.11.0` and `1.3.0`.

## How a WMA session works in human terms

1. `open()` immediately returns a small handle with `state`, `send()`, `close()`, and `ready`.
2. The WMA extension asks the bridge for short-lived ICE/TURN configuration. If the bridge cannot provide it, it tries the model's own `/ice` route and finally degrades to public STUN.
3. The browser creates one WebRTC offer and waits for a useful, settled ICE candidate set.
4. The complete offer is posted to `wma.fal.run/session`; the returned answer finishes negotiation.
5. Video/audio flows directly between the browser and runner (or through TURN). It does not flow through the signaling bridge.
6. Control messages use a WebRTC data channel. Messages sent before that channel opens are queued in order with a fixed bound.
7. A single in-flight heartbeat renews the session lease. Closing or failure cancels negotiation, polling, heartbeats, and registered cleanup exactly once.

When a server proxy is configured, steps 2, 4, and 7 go browser → application proxy → `wma.fal.run`. The fal credential remains on the application server.

## API and lifecycle

- `open()` is synchronous; negotiation starts eagerly in the background.
- `ready` resolves with the same handle once live and rejects with the terminal failure.
- State is `opening → live → failed | closed`; both endings are terminal.
- Sends during `opening` queue and flush oldest-first. The queue is bounded and reports a diagnostic if it drops old messages.
- `close()` is idempotent and cancels an opening session.
- Extension-specific values live on `handle.session` once live; the handle stays a plain object.
- Extensions are installed code selected explicitly at the call site, never code loaded from endpoint metadata.
- The new surface is marked `@experimental` and may change in a minor release.

## Bundled extensions

| Extension | Protocol |
|---|---|
| `wma(endpointId)` | World-model WebRTC via `wma.fal.run`: ICE configuration, one-shot SDP offer/answer, heartbeat lease, media, and binary/text data-channel messages |
| `lucyRealtime()` | Lucy video-to-video WebRTC with signaling carried over fal realtime WebSocket |
| `websocket()` | fal realtime WebSocket behind the `open()` lifecycle with a paced FIFO sender |

Shared helpers include credentialed `context.fetch`, endpoint `context.run`, `context.connect`, sufficient-set/quiet-period ICE gathering, cancellation, cleanup registration, failure reporting, and diagnostic/media/data channels.

## Minimal server-proxy support

Normal fal requests identify an app in the URL, such as `fal.run/owner/app`. WMA uses infrastructure routes such as `wma.fal.run/session`, while the app identity lives in JSON. The existing proxy therefore needs a narrow exception:

| Change | Behavior |
|---|---|
| `serviceHosts` | Defaults to the exact host `wma.fal.run`; `[]` disables service-host routing |
| Transport and method restriction | The exception applies only to HTTPS POST requests |
| Route restriction | Only `/ice`, `/session`, and `/session/heartbeat` are accepted; unknown paths fail closed |
| Canonical path check | Percent escapes are decoded, repeated slashes are collapsed, trailing slashes are removed, and malformed escapes are rejected before matching |
| App policy | `/ice` and `/session` read `app_id` from JSON and apply the existing `allowedEndpoints` patterns |
| Parser-difference guard | Missing, duplicate, or escaped-duplicate `app_id` keys are rejected |
| Heartbeat | `/session/heartbeat` is session-scoped and therefore does not require an `app_id` |
| Authenticate before inspection | When authentication is required, unauthenticated app-scoped requests receive 401 before the proxy reads or parses their body |
| One body read | Authentication callbacks, policy inspection, and the eventual upstream POST share the same cached body value |
| Release | `@fal-ai/server-proxy` is bumped from `1.2.1` to `1.3.0-alpha.0` so matching proxy support can be tested without changing `latest` |

Ordinary `fal.run` and `queue.fal.run` endpoint checks remain unchanged.

## Existing `fal.realtime.connect()`

Its signature is unchanged. Two behavioral fixes are included:

- When multiple handles share a `connectionKey`, the newest handle owns the connection. A stale handle can no longer send through or close the replacement.
- Calling `send()` after explicitly closing a handle no longer reconnects it.

## Where the lines come from

| Category | Added | Deleted | Contents |
|---|---:|---:|---|
| Client tests | 5,452 | 3 | Kernel lifecycle, cleanup/cancellation, signal handling, queue ordering, ICE, WMA, Lucy, WebSocket, and existing `connect()` regressions |
| Protocol extensions and shared helpers | 2,769 | 0 | Extension contract plus WMA, Lucy, WebSocket, ICE, protocol, cancellation compatibility, and testing modules |
| Realtime kernel and existing connection implementation | 1,189 | 145 | `open()`, managed lifecycle, request helpers, connection ownership, token refresh, and decoding |
| Client integration, exports, packaging, and small utilities | 97 | 9 | Public exports, client wiring, package subpaths/version, streaming URL support, endpoint parsing, spelling, and TypeScript configuration |
| Client documentation | 255 | 0 | Usage, lifecycle, extension authoring, and bundled-extension examples |
| Proxy production code and package version | 125 | 17 | Exact WMA service-host policy, authentication-before-inspection, shared body cache, body `app_id` check, configuration, and the `1.3.0-alpha.0` prerelease version |
| Proxy tests | 230 | 1 | Allowed routes, HTTPS/POST restrictions, configuration, endpoint policy, duplicate keys, normalization, authentication order, and single-read forwarding |
| **Total** | **10,117** | **175** | **5,682 test additions and 4,435 implementation/docs/config additions** |

## Validation

- Client: 15 test suites, 252 tests passing
- Server proxy: 1 test suite, 65 tests passing
- Client and proxy TypeScript builds passing
- Client and proxy lint passing (zero errors)
- Prettier and `git diff --check` passing
