### PR TITLE
feat(client): negotiate explicit WMA receive tracks

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.11.0-alpha.0",
+  "version": "1.11.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/realtime/wma.spec.ts
+++ b/libs/client/src/realtime/wma.spec.ts
@@ -1,5 +1,5 @@
 import { fakeExtensionContext } from "./testing";
-import { wma } from "./wma";
+import { wma, type WmaOptions } from "./wma";
 
 /** A peer connection just real enough to drive the raw-path handshake. */
 function fakePeer() {
@@ -50,6 +50,23 @@ describe("wma", () => {
     const { peer, channel } = fakePeer();
     global.RTCPeerConnection = jest.fn(() => peer) as never;
     return { peer, channel };
+  }
+
+  async function openWithPeer(options: WmaOptions) {
+    const { peer } = install();
+    const context = fakeExtensionContext({
+      endpointId: "me/media",
+      run: (async () => ({
+        data: { ice_servers: [{ urls: "stun:x" }] },
+        requestId: "r",
+      })) as never,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+    });
+    await wma().open(context, options);
+    return peer;
   }
 
   it("rejects a stopped direction before creating a peer", async () => {
@@ -916,6 +933,69 @@ describe("wma", () => {
     expect(peer.addTransceiver).toHaveBeenCalledWith("video", {
       direction: "recvonly",
     });
+  });
+
+  it("offers explicit output-only audio and video receive tracks", async () => {
+    const peer = await openWithPeer({ receive: ["video", "audio"] });
+
+    expect(peer.addTransceiver.mock.calls).toEqual([
+      ["video", { direction: "recvonly" }],
+      ["audio", { direction: "recvonly" }],
+    ]);
+  });
+
+  it("uses sendrecv for matched local tracks and recvonly for unmatched outputs", async () => {
+    const audioTrack = { kind: "audio", stop: jest.fn() };
+    const stream = {
+      getTracks: () => [audioTrack],
+    } as unknown as MediaStream;
+    const peer = await openWithPeer({
+      localStream: stream,
+      receive: ["video", "audio"],
+    });
+
+    expect(peer.addTransceiver.mock.calls).toEqual([
+      ["video", { direction: "recvonly" }],
+      [
+        audioTrack,
+        {
+          direction: "sendrecv",
+          streams: [stream],
+        },
+      ],
+    ]);
+  });
+
+  it("uses sendonly for local tracks without a matching receive slot", async () => {
+    const videoTrack = { kind: "video", stop: jest.fn() };
+    const stream = {
+      getTracks: () => [videoTrack],
+    } as unknown as MediaStream;
+    const peer = await openWithPeer({ localStream: stream, receive: [] });
+
+    expect(peer.addTransceiver).toHaveBeenCalledTimes(1);
+    expect(peer.addTransceiver).toHaveBeenCalledWith(videoTrack, {
+      direction: "sendonly",
+      streams: [stream],
+    });
+  });
+
+  it("supports a data-channel-only session with an empty receive list", async () => {
+    const peer = await openWithPeer({ receive: [] });
+
+    expect(peer.addTransceiver).not.toHaveBeenCalled();
+  });
+
+  it("rejects receive tracks combined with a legacy direction override", async () => {
+    install();
+    await expect(
+      wma("me/world").open(fakeExtensionContext(), {
+        receive: ["audio"],
+        direction: "recvonly",
+      }),
+    ).rejects.toThrow(
+      "WMA receive tracks cannot be combined with an explicit direction.",
+    );
   });
 
   it("publishes inbound media and data through the KERNEL, not its own options", async () => {

--- a/libs/client/src/realtime/wma.ts
+++ b/libs/client/src/realtime/wma.ts
@@ -48,6 +48,9 @@ const DEFAULT_STUN_URL = "stun:stun.l.google.com:19302";
 /** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
 export type WmaControlMessage = object;
 
+/** A WebRTC media kind the browser should offer to receive from the model. */
+export type WmaReceiveTrackKind = "audio" | "video";
+
 /** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
 export interface WmaOptions {
   /**
@@ -55,6 +58,23 @@ export interface WmaOptions {
    * tracks preserve addTrack's `"sendrecv"` behavior. Pass an explicit direction for other flows.
    */
   direction?: RTCRtpTransceiverDirection;
+  /**
+   * Media tracks to receive from the model, in offer order.
+   *
+   * WebRTC answers cannot introduce media sections that were absent from the browser's offer, so
+   * output-only audio and audio-plus-video apps must declare their receive slots before offer
+   * creation. Repeating a kind requests multiple tracks of that kind; an empty array creates no
+   * receive transceivers and is suitable for send-only or data-channel-only sessions.
+   *
+   * When a local track has the same kind as a requested receive slot, one `sendrecv` transceiver is
+   * used for both directions. Remaining local tracks are `sendonly`, and remaining receive slots are
+   * `recvonly`.
+   *
+   * Omit this option to preserve the legacy behavior: local tracks use `direction` (defaulting to
+   * `sendrecv`), while a session without local tracks offers one `recvonly` video transceiver.
+   * Because this option derives directions per track, it cannot be combined with `direction`.
+   */
+  receive?: readonly WmaReceiveTrackKind[];
   /**
    * Media to send UP, on the same peer connection the output comes back on.
    *
@@ -579,6 +599,11 @@ export function wma(endpointId?: string) {
       if (options.direction === "stopped") {
         throw new Error('WMA direction cannot be "stopped".');
       }
+      if (options.receive !== undefined && options.direction !== undefined) {
+        throw new Error(
+          "WMA receive tracks cannot be combined with an explicit direction.",
+        );
+      }
       const iceServers = options.iceServers ?? (await fetchIceServers(context));
       const pc = new RTCPeerConnection({
         iceServers,
@@ -599,7 +624,30 @@ export function wma(endpointId?: string) {
       // A local track is added through a transceiver so the caller's requested direction reaches
       // SDP. Never add a second media transceiver for the same track.
       const localTracks = options.localStream?.getTracks() ?? [];
-      if (localTracks.length > 0) {
+      if (options.receive !== undefined) {
+        const unmatchedLocalTracks = [...localTracks];
+        for (const kind of options.receive) {
+          const localIndex = unmatchedLocalTracks.findIndex(
+            (track) => track.kind === kind,
+          );
+          if (localIndex === -1) {
+            pc.addTransceiver(kind, { direction: "recvonly" });
+            continue;
+          }
+
+          const [track] = unmatchedLocalTracks.splice(localIndex, 1);
+          pc.addTransceiver(track, {
+            direction: "sendrecv",
+            streams: [options.localStream!],
+          });
+        }
+        for (const track of unmatchedLocalTracks) {
+          pc.addTransceiver(track, {
+            direction: "sendonly",
+            streams: [options.localStream!],
+          });
+        }
+      } else if (localTracks.length > 0) {
         for (const track of localTracks) {
           pc.addTransceiver(track, {
             direction: options.direction ?? "sendrecv",


### PR DESCRIPTION
## Summary

- add an explicit `receive` option for WMA audio and video output tracks
- derive `sendrecv`, `sendonly`, and `recvonly` transceivers by matching requested outputs with the caller's `localStream`
- preserve the existing implicit one-video fallback when `receive` is omitted
- support output-only audio/video, input-only, bidirectional, multiple-output, and data-channel-only sessions

## Why

A WebRTC answer cannot introduce an audio or video media section that was absent from the browser's offer. The existing WMA client infers `sendrecv` slots from local tracks and otherwise offers one `recvonly` video slot, so an output-only app that publishes both video and audio cannot negotiate its audio track.

Contract-aware clients can now map a WMA media contract directly into the offer:

```ts
fal.realtime.open(wma("fal-ai/wma-doom"), {
  receive: ["video", "audio"],
});
```

When `receive` is present, matching local tracks share `sendrecv` transceivers, unmatched local tracks are `sendonly`, and unmatched requested outputs are `recvonly`. Because this derives direction per track, `receive` and the legacy global `direction` override are mutually exclusive.

## Compatibility

Omitting `receive` retains the current behavior exactly:

- local tracks use `direction`, defaulting to `sendrecv`
- no local tracks creates one `recvonly` video transceiver

## Validation

- `npx nx build client`
- `npx nx test client --runInBand` (257 tests passed)
- formatting, secret scanning, TypeDoc generation, and commit hooks passed

## Stack

Stacked on #228, which introduces the WMA realtime extension.
