### PR TITLE
feat(client): allow WMA sessions to wait for capacity

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.11.0-alpha.1",
+  "version": "1.11.0-alpha.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/realtime/wma.spec.ts
+++ b/libs/client/src/realtime/wma.spec.ts
@@ -378,7 +378,54 @@ describe("wma", () => {
     );
   });
 
-  it("times out a stalled session negotiation request", async () => {
+  it("waits beyond the legacy 120-second deadline by default", async () => {
+    jest.useFakeTimers();
+    try {
+      install();
+      const sessionSignals: AbortSignal[] = [];
+      let answerSession!: (response: Response) => void;
+      const context = fakeExtensionContext({
+        endpointId: "me/my-world",
+        fetch: async (url: string, init?: RequestInit) => {
+          if (url.endsWith("/ice")) {
+            return new Response(
+              JSON.stringify({
+                ice_servers: [{ urls: "stun:example" }],
+                status: "stun_only",
+              }),
+            );
+          }
+          sessionSignals.push(init?.signal as AbortSignal);
+          return new Promise<Response>((resolve) => {
+            answerSession = resolve;
+          });
+        },
+      });
+
+      const opening = wma().open(context, {
+        iceServers: [{ urls: "stun:example" }],
+      });
+      for (let turn = 0; turn < 10 && sessionSignals.length === 0; turn++) {
+        await Promise.resolve();
+      }
+      expect(sessionSignals).toHaveLength(1);
+
+      jest.advanceTimersByTime(120_001);
+      expect(sessionSignals[0].aborted).toBe(false);
+
+      answerSession(
+        new Response(
+          JSON.stringify({ session_id: "s", sdp: "a", type: "answer" }),
+        ),
+      );
+      const session = await opening;
+      session.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("honors an application-supplied session negotiation timeout", async () => {
     jest.useFakeTimers();
     try {
       install();
@@ -408,6 +455,7 @@ describe("wma", () => {
 
       const opening = wma().open(context, {
         iceServers: [{ urls: "stun:example" }],
+        negotiationTimeoutMs: 120_000,
       });
       for (let turn = 0; turn < 10 && sessionSignals.length === 0; turn++) {
         await Promise.resolve();
@@ -420,6 +468,18 @@ describe("wma", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it("rejects invalid session negotiation timeouts before creating a peer", async () => {
+    const PeerConnection = jest.fn();
+    global.RTCPeerConnection = PeerConnection as never;
+
+    await expect(
+      wma("me/world").open(fakeExtensionContext(), {
+        negotiationTimeoutMs: 0,
+      }),
+    ).rejects.toThrow("negotiationTimeoutMs must be a positive, finite number");
+    expect(PeerConnection).not.toHaveBeenCalled();
   });
 
   it("does not create a bridge session after cancellation during ICE gathering", async () => {

--- a/libs/client/src/realtime/wma.ts
+++ b/libs/client/src/realtime/wma.ts
@@ -31,7 +31,6 @@ import { countTurnServers } from "./ice";
 
 const WMA_URL = "https://wma.fal.run";
 const ICE_DISCOVERY_TIMEOUT_MS = 5_000;
-const SESSION_NEGOTIATION_TIMEOUT_MS = 120_000;
 const HEARTBEAT_INTERVAL_MS = 5_000;
 const HEARTBEAT_TIMEOUT_MS = 4_000;
 // Reserved control-channel vocabulary for the session-affine network query: the request reaches
@@ -53,6 +52,14 @@ export type WmaReceiveTrackKind = "audio" | "video";
 
 /** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
 export interface WmaOptions {
+  /**
+   * How long to wait for the WMA bridge to acquire a runner and return its SDP answer.
+   *
+   * By default there is no client-side deadline, so an application may wait for capacity. The
+   * caller can still cancel through `abortSignal` or by closing the session. Set a positive number
+   * to impose an application-specific deadline.
+   */
+  negotiationTimeoutMs?: number | null;
   /**
    * Media direction. Sessions without a local stream default to `"recvonly"`; sessions with local
    * tracks preserve addTrack's `"sendrecv"` behavior. Pass an explicit direction for other flows.
@@ -596,6 +603,15 @@ export function wma(endpointId?: string) {
     id: "fal/wma",
     defaultEndpoint: endpointId,
     async open(context, options) {
+      if (
+        options.negotiationTimeoutMs != null &&
+        (!Number.isFinite(options.negotiationTimeoutMs) ||
+          options.negotiationTimeoutMs <= 0)
+      ) {
+        throw new Error(
+          "WMA negotiationTimeoutMs must be a positive, finite number.",
+        );
+      }
       if (options.direction === "stopped") {
         throw new Error('WMA direction cannot be "stopped".');
       }
@@ -959,10 +975,13 @@ export function wma(endpointId?: string) {
             once: true,
           });
         }
-        const sessionTimeout = setTimeout(
-          () => sessionController.abort(),
-          SESSION_NEGOTIATION_TIMEOUT_MS,
-        );
+        const sessionTimeout =
+          options.negotiationTimeoutMs == null
+            ? undefined
+            : setTimeout(
+                () => sessionController.abort(),
+                options.negotiationTimeoutMs,
+              );
         let answer: {
           session_id: string;
           sdp: string;
@@ -970,8 +989,8 @@ export function wma(endpointId?: string) {
         };
         try {
           // Auth comes from the client's configured credentials rather than a pasted key. The child
-          // signal preserves caller cancellation while bounding a bridge that accepts but never
-          // answers the negotiation request.
+          // signal preserves caller cancellation. Applications that want a bounded capacity wait
+          // can opt into negotiationTimeoutMs; by default the bridge may wait for a runner.
           const response = await context.fetch(`${WMA_URL}/session`, {
             method: "POST",
             signal: sessionController.signal,
@@ -985,7 +1004,7 @@ export function wma(endpointId?: string) {
           if (!response.ok) throw new Error(await readErrorMessage(response));
           answer = (await response.json()) as typeof answer;
         } finally {
-          clearTimeout(sessionTimeout);
+          if (sessionTimeout !== undefined) clearTimeout(sessionTimeout);
           context.signal.removeEventListener("abort", abortSession);
         }
 


### PR DESCRIPTION
## Summary

- remove the default 120-second WMA negotiation deadline so sessions can wait for runner capacity
- add an optional positive `negotiationTimeoutMs` for callers that want an application-specific limit
- cover both waits beyond the legacy deadline and explicit timeout behavior

## Testing

- `nx test client --runInBand`
- `nx run-many -t build,lint -p client`

## Stack

Stacked on the WMA receive-tracks branch because the WMA client is not on `main` yet.