### PR TITLE
feat(client): add `tags` request option

### DIFF
--- a/libs/client/src/client.spec.ts
+++ b/libs/client/src/client.spec.ts
@@ -51,6 +51,29 @@ describe("client.run headers", () => {
     expect(call.headers["x-fal-request-timeout"]).toBeUndefined();
   });
 
+  it("includes the packed tags header when tags are provided", async () => {
+    const client = createFalClient({ credentials: "test-key" });
+    await client.run("fal-ai/fast-sdxl", {
+      input: { prompt: "hello" },
+      tags: { team: "design", env: "prod" },
+    });
+
+    expect(dispatchRequest).toHaveBeenCalledTimes(1);
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.headers["x-fal-tags"]).toBe("team=design,env=prod");
+  });
+
+  it("omits the tags header when tags are not provided", async () => {
+    const client = createFalClient({ credentials: "test-key" });
+    await client.run("fal-ai/fast-sdxl", {
+      input: { prompt: "hello" },
+    });
+
+    expect(dispatchRequest).toHaveBeenCalledTimes(1);
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.headers["x-fal-tags"]).toBeUndefined();
+  });
+
   it("throws error when startTimeout is <= 1 second", async () => {
     const client = createFalClient({ credentials: "test-key" });
     await expect(

--- a/libs/client/src/client.ts
+++ b/libs/client/src/client.ts
@@ -1,5 +1,5 @@
 import { Config, createConfig } from "./config";
-import { buildTimeoutHeaders } from "./headers";
+import { buildTagsHeaders, buildTimeoutHeaders } from "./headers";
 import { createQueueClient, QueueClient, QueueSubscribeOptions } from "./queue";
 import { createRealtimeClient, RealtimeClient } from "./realtime";
 import { buildUrl, dispatchRequest } from "./request";
@@ -118,6 +118,7 @@ export function createFalClient(userConfig: Config = {}): FalClient {
         headers: {
           ...buildObjectLifecycleHeaders(options.storageSettings),
           ...buildTimeoutHeaders(options.startTimeout),
+          ...buildTagsHeaders(options.tags),
         },
         config: {
           ...config,

--- a/libs/client/src/headers.spec.ts
+++ b/libs/client/src/headers.spec.ts
@@ -1,7 +1,13 @@
 import {
+  buildTagsHeaders,
   buildTimeoutHeaders,
+  MAX_TAG_PAIRS,
+  MAX_TAG_VALUE_LENGTH,
+  MAX_TAGS_SIZE_BYTES,
   MIN_REQUEST_TIMEOUT_SECONDS,
   REQUEST_TIMEOUT_HEADER,
+  TAGS_HEADER,
+  validateTagsHeader,
   validateTimeoutHeader,
 } from "./headers";
 
@@ -61,6 +67,87 @@ describe("headers utilities", () => {
       );
       expect(() => buildTimeoutHeaders(0)).toThrow(
         `Timeout must be greater than ${MIN_REQUEST_TIMEOUT_SECONDS} seconds`,
+      );
+    });
+  });
+
+  describe("validateTagsHeader", () => {
+    it("should pack the pairs into a single header value", () => {
+      expect(validateTagsHeader({ team: "design", env: "prod" })).toBe(
+        "team=design,env=prod",
+      );
+    });
+
+    it("should lowercase keys and keep the last value for duplicates", () => {
+      expect(validateTagsHeader({ Team: "design", TEAM: "growth" })).toBe(
+        "team=growth",
+      );
+    });
+
+    it("should throw for keys outside the allowed charset", () => {
+      expect(() => validateTagsHeader({ "team name": "design" })).toThrow(
+        'Tag key "team name" must match',
+      );
+    });
+
+    it("should throw for reserved keys", () => {
+      expect(() => validateTagsHeader({ "fal.internal": "1" })).toThrow(
+        "reserved",
+      );
+    });
+
+    it("should throw for values with commas or control characters", () => {
+      expect(() => validateTagsHeader({ team: "design,growth" })).toThrow(
+        'Tag value for "team" must be printable ASCII without commas',
+      );
+      expect(() => validateTagsHeader({ team: "design\n" })).toThrow(
+        'Tag value for "team" must be printable ASCII without commas',
+      );
+    });
+
+    it("should throw for values over the length limit", () => {
+      expect(() =>
+        validateTagsHeader({ team: "d".repeat(MAX_TAG_VALUE_LENGTH + 1) }),
+      ).toThrow(`at most ${MAX_TAG_VALUE_LENGTH} characters`);
+    });
+
+    it("should throw for more than the maximum number of pairs", () => {
+      const tags = Object.fromEntries(
+        Array.from({ length: MAX_TAG_PAIRS + 1 }, (_, i) => [`k${i}`, "v"]),
+      );
+      expect(() => validateTagsHeader(tags)).toThrow(
+        `at most ${MAX_TAG_PAIRS} pairs`,
+      );
+    });
+
+    it("should throw when the total size exceeds the limit", () => {
+      const tags = Object.fromEntries(
+        Array.from({ length: MAX_TAG_PAIRS }, (_, i) => [
+          `k${i}`,
+          "v".repeat(MAX_TAG_VALUE_LENGTH),
+        ]),
+      );
+      expect(() => validateTagsHeader(tags)).toThrow(
+        `at most ${MAX_TAGS_SIZE_BYTES} bytes`,
+      );
+    });
+  });
+
+  describe("buildTagsHeaders", () => {
+    it("should return empty object when tags are undefined or empty", () => {
+      expect(buildTagsHeaders(undefined)).toEqual({});
+      expect(buildTagsHeaders({})).toEqual({});
+    });
+
+    it("should return the packed tags header", () => {
+      expect(buildTagsHeaders({ team: "design", env: "prod" })).toEqual({
+        [TAGS_HEADER]: "team=design,env=prod",
+      });
+    });
+
+    it("should throw for invalid tags", () => {
+      expect(() => buildTagsHeaders({ team: "design,growth" })).toThrow(
+        "printable ASCII",
       );
     });
   });

--- a/libs/client/src/headers.spec.ts
+++ b/libs/client/src/headers.spec.ts
@@ -84,6 +84,19 @@ describe("headers utilities", () => {
       );
     });
 
+    it("should trim keys and values, matching what the server stores", () => {
+      expect(validateTagsHeader({ "  Team  ": "  design  " })).toBe(
+        "team=design",
+      );
+    });
+
+    it("should apply length limits to the trimmed value", () => {
+      const padded = ` ${"d".repeat(MAX_TAG_VALUE_LENGTH)} `;
+      expect(validateTagsHeader({ team: padded })).toBe(
+        `team=${"d".repeat(MAX_TAG_VALUE_LENGTH)}`,
+      );
+    });
+
     it("should throw for keys outside the allowed charset", () => {
       expect(() => validateTagsHeader({ "team name": "design" })).toThrow(
         'Tag key "team name" must match',
@@ -100,7 +113,7 @@ describe("headers utilities", () => {
       expect(() => validateTagsHeader({ team: "design,growth" })).toThrow(
         'Tag value for "team" must be printable ASCII without commas',
       );
-      expect(() => validateTagsHeader({ team: "design\n" })).toThrow(
+      expect(() => validateTagsHeader({ team: "des\nign" })).toThrow(
         'Tag value for "team" must be printable ASCII without commas',
       );
     });

--- a/libs/client/src/headers.ts
+++ b/libs/client/src/headers.ts
@@ -62,3 +62,125 @@ export function buildTimeoutHeaders(timeout?: number): Record<string, string> {
     [REQUEST_TIMEOUT_HEADER]: validateTimeoutHeader(timeout),
   };
 }
+
+/**
+ * Header name for request tags.
+ */
+export const TAGS_HEADER = "x-fal-tags";
+
+/**
+ * Maximum number of tag pairs allowed in a single request.
+ */
+export const MAX_TAG_PAIRS = 10;
+
+/**
+ * Maximum length of a tag key, in characters.
+ */
+export const MAX_TAG_KEY_LENGTH = 64;
+
+/**
+ * Maximum length of a tag value, in characters.
+ */
+export const MAX_TAG_VALUE_LENGTH = 256;
+
+/**
+ * Maximum size of all key and value bytes combined, in bytes.
+ */
+export const MAX_TAGS_SIZE_BYTES = 1024;
+
+/**
+ * Tag keys are lowercased and restricted to `[a-z0-9._-]`.
+ */
+const TAG_KEY_PATTERN = /^[a-z0-9._-]+$/;
+
+/**
+ * Tag values are printable ASCII, excluding `,` (the pair separator).
+ */
+const TAG_VALUE_PATTERN = /^[\x20-\x2b\x2d-\x7e]*$/;
+
+/**
+ * Keys under this prefix are reserved for fal and cannot be set by callers.
+ */
+const RESERVED_TAG_KEY_PREFIX = "fal.";
+
+/**
+ * Validates the tags and serializes them into the packed `X-Fal-Tags` header
+ * value, i.e. a comma-separated list of `key=value` pairs. Keys are lowercased
+ * to match the canonical form the server stores; duplicates after lowercasing
+ * follow the server's last-wins rule.
+ *
+ * Throws an error if the tags don't match the limits enforced by the server.
+ *
+ * @param tags - The tag key/value pairs
+ * @returns The packed header value
+ * @throws Error if any pair is invalid or the limits are exceeded
+ */
+export function validateTagsHeader(tags: Record<string, string>): string {
+  const entries = Object.entries(tags);
+  if (entries.length > MAX_TAG_PAIRS) {
+    throw new Error(
+      `Tags must contain at most ${MAX_TAG_PAIRS} pairs, got ${entries.length}`,
+    );
+  }
+
+  const pairs = new Map<string, string>();
+  // Keys and values are ASCII-only once validated, so length is the byte size.
+  let size = 0;
+  for (const [rawKey, value] of entries) {
+    const key = rawKey.toLowerCase();
+    if (!TAG_KEY_PATTERN.test(key)) {
+      throw new Error(
+        `Tag key "${rawKey}" must match ${TAG_KEY_PATTERN} once lowercased`,
+      );
+    }
+    if (key.length > MAX_TAG_KEY_LENGTH) {
+      throw new Error(
+        `Tag key "${rawKey}" must be at most ${MAX_TAG_KEY_LENGTH} characters`,
+      );
+    }
+    if (key.startsWith(RESERVED_TAG_KEY_PREFIX)) {
+      throw new Error(
+        `Tag key "${rawKey}" uses the reserved "${RESERVED_TAG_KEY_PREFIX}" prefix`,
+      );
+    }
+    if (typeof value !== "string" || !TAG_VALUE_PATTERN.test(value)) {
+      throw new Error(
+        `Tag value for "${rawKey}" must be printable ASCII without commas`,
+      );
+    }
+    if (value.length > MAX_TAG_VALUE_LENGTH) {
+      throw new Error(
+        `Tag value for "${rawKey}" must be at most ${MAX_TAG_VALUE_LENGTH} characters`,
+      );
+    }
+    size += key.length + value.length;
+    pairs.set(key, value);
+  }
+
+  if (size > MAX_TAGS_SIZE_BYTES) {
+    throw new Error(
+      `Tags must be at most ${MAX_TAGS_SIZE_BYTES} bytes, got ${size}`,
+    );
+  }
+
+  return Array.from(pairs, ([key, value]) => `${key}=${value}`).join(",");
+}
+
+/**
+ * Creates headers object with the packed tags header if tags are provided.
+ * Returns an empty object if tags are undefined or empty.
+ *
+ * @param tags - Optional tag key/value pairs
+ * @returns Headers object with TAGS_HEADER if tags are provided
+ */
+export function buildTagsHeaders(
+  tags?: Record<string, string>,
+): Record<string, string> {
+  if (tags === undefined || Object.keys(tags).length === 0) {
+    return {};
+  }
+
+  return {
+    [TAGS_HEADER]: validateTagsHeader(tags),
+  };
+}

--- a/libs/client/src/headers.ts
+++ b/libs/client/src/headers.ts
@@ -105,9 +105,10 @@ const RESERVED_TAG_KEY_PREFIX = "fal.";
 
 /**
  * Validates the tags and serializes them into the packed `X-Fal-Tags` header
- * value, i.e. a comma-separated list of `key=value` pairs. Keys are lowercased
- * to match the canonical form the server stores; duplicates after lowercasing
- * follow the server's last-wins rule.
+ * value, i.e. a comma-separated list of `key=value` pairs.
+ *
+ * Keys and values are trimmed and keys lowercased, matching what the server
+ * stores; limits apply to that normalized form. Duplicate keys are last-wins.
  *
  * Throws an error if the tags don't match the limits enforced by the server.
  *
@@ -126,8 +127,9 @@ export function validateTagsHeader(tags: Record<string, string>): string {
   const pairs = new Map<string, string>();
   // Keys and values are ASCII-only once validated, so length is the byte size.
   let size = 0;
-  for (const [rawKey, value] of entries) {
-    const key = rawKey.toLowerCase();
+  for (const [rawKey, rawValue] of entries) {
+    const key = rawKey.trim().toLowerCase();
+    const value = typeof rawValue === "string" ? rawValue.trim() : rawValue;
     if (!TAG_KEY_PATTERN.test(key)) {
       throw new Error(
         `Tag key "${rawKey}" must match ${TAG_KEY_PATTERN} once lowercased`,

--- a/libs/client/src/queue.spec.ts
+++ b/libs/client/src/queue.spec.ts
@@ -109,6 +109,41 @@ describe("queue.submit headers", () => {
     expect(call.headers["x-fal-request-timeout"]).toBe("60");
   });
 
+  it("includes the packed tags header when tags are provided", async () => {
+    const queue = createQueueClient({ config, storage });
+    await queue.submit("fal-ai/fast-sdxl", {
+      input: { prompt: "hi" },
+      tags: { team: "design", env: "prod" },
+    });
+
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.headers["x-fal-tags"]).toBe("team=design,env=prod");
+  });
+
+  it("omits the tags header when tags are not provided", async () => {
+    const queue = createQueueClient({ config, storage });
+    await queue.submit("fal-ai/fast-sdxl", {
+      input: { prompt: "hi" },
+    });
+
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.headers["x-fal-tags"]).toBeUndefined();
+  });
+
+  it("tags override a user-provided x-fal-tags header", async () => {
+    const queue = createQueueClient({ config, storage });
+    await queue.submit("fal-ai/fast-sdxl", {
+      input: { prompt: "hi" },
+      headers: {
+        "x-fal-tags": "team=old",
+      },
+      tags: { team: "design" },
+    });
+
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.headers["x-fal-tags"]).toBe("team=design");
+  });
+
   it("throws error when startTimeout is <= 1 second", async () => {
     const queue = createQueueClient({ config, storage });
     await expect(

--- a/libs/client/src/queue.ts
+++ b/libs/client/src/queue.ts
@@ -1,5 +1,6 @@
 import { RequiredConfig } from "./config";
 import {
+  buildTagsHeaders,
   buildTimeoutHeaders,
   QUEUE_PRIORITY_HEADER,
   RUNNER_HINT_HEADER,
@@ -118,10 +119,11 @@ type QueueCommonSubscribeOptions = {
 
   /**
    * Additional HTTP headers to include in the submit request.
-   * Note: `priority`, `hint`, `startTimeout`, and `objectLifecycle` will override the following headers:
+   * Note: `priority`, `hint`, `startTimeout`, `tags`, and `objectLifecycle` will override the following headers:
    *  - `x-fal-queue-priority`
    *  - `x-fal-runner-hint`
    *  - `x-fal-request-timeout`
+   *  - `x-fal-tags`
    *  - `x-fal-object-lifecycle-preference`
    */
   headers?: Record<string, string>;
@@ -169,10 +171,11 @@ export type SubmitOptions<Input> = RunOptions<Input> & {
   /**
    * Additional HTTP headers to include in the submit request.
    *
-   * Note: `priority`, `hint`, `startTimeout`, and `objectLifecycle` will override the following headers:
+   * Note: `priority`, `hint`, `startTimeout`, `tags`, and `objectLifecycle` will override the following headers:
    *  - `x-fal-queue-priority`
    *  - `x-fal-runner-hint`
    *  - `x-fal-request-timeout`
+   *  - `x-fal-tags`
    *  - `x-fal-object-lifecycle-preference`
    */
   headers?: Record<string, string>;
@@ -316,6 +319,7 @@ export const createQueueClient = ({
         priority,
         hint,
         startTimeout,
+        tags,
         headers,
         storageSettings,
         ...runOptions
@@ -342,6 +346,7 @@ export const createQueueClient = ({
           [QUEUE_PRIORITY_HEADER]: priority ?? "normal",
           ...(hint && { [RUNNER_HINT_HEADER]: hint }),
           ...buildTimeoutHeaders(startTimeout),
+          ...buildTagsHeaders(tags),
         },
         input: input as Input,
         config,

--- a/libs/client/src/streaming.spec.ts
+++ b/libs/client/src/streaming.spec.ts
@@ -1,0 +1,40 @@
+jest.mock("./request", () => {
+  const actual = jest.requireActual("./request");
+  return {
+    ...actual,
+    dispatchRequest: jest.fn(),
+  };
+});
+
+import { createFalClient } from "./client";
+import { dispatchRequest } from "./request";
+
+describe("stream headers", () => {
+  beforeEach(() => {
+    (dispatchRequest as jest.Mock).mockReset();
+    (dispatchRequest as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("includes the packed tags header when tags are provided", async () => {
+    const client = createFalClient({ credentials: "test-key" });
+    await client.stream("fal-ai/fast-sdxl", {
+      input: { prompt: "hello" },
+      tags: { team: "design", env: "prod" },
+    });
+
+    expect(dispatchRequest).toHaveBeenCalledTimes(1);
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.options.headers["x-fal-tags"]).toBe("team=design,env=prod");
+  });
+
+  it("omits the tags header when tags are not provided", async () => {
+    const client = createFalClient({ credentials: "test-key" });
+    await client.stream("fal-ai/fast-sdxl", {
+      input: { prompt: "hello" },
+    });
+
+    expect(dispatchRequest).toHaveBeenCalledTimes(1);
+    const call = (dispatchRequest as jest.Mock).mock.calls[0][0];
+    expect(call.options.headers["x-fal-tags"]).toBeUndefined();
+  });
+});

--- a/libs/client/src/streaming.ts
+++ b/libs/client/src/streaming.ts
@@ -1,6 +1,7 @@
 import { createParser } from "eventsource-parser";
 import { type TokenProvider, getTemporaryAuthToken } from "./auth";
 import { RequiredConfig } from "./config";
+import { buildTagsHeaders } from "./headers";
 import { buildUrl, dispatchRequest } from "./request";
 import { ApiError, defaultResponseHandler } from "./response";
 import { type StorageClient } from "./storage";
@@ -76,6 +77,13 @@ export type StreamOptions<Input> = {
    * instead of the default internal token fetching mechanism.
    */
   readonly tokenProvider?: TokenProvider;
+
+  /**
+   * Tags to attribute the request's usage and cost to your own dimensions.
+   *
+   * @see RunOptions.tags
+   */
+  readonly tags?: Record<string, string>;
 };
 
 const EVENT_STREAM_TIMEOUT = 15 * 1000;
@@ -190,6 +198,7 @@ export class FalStream<Input, Output> {
           headers: {
             accept: options.accept ?? CONTENT_TYPE_EVENT_STREAM,
             "content-type": "application/json",
+            ...buildTagsHeaders(options.tags),
           },
           body: input && method !== "get" ? JSON.stringify(input) : undefined,
           signal: this.abortController.signal,
@@ -205,6 +214,7 @@ export class FalStream<Input, Output> {
         options: {
           headers: {
             accept: options.accept ?? CONTENT_TYPE_EVENT_STREAM,
+            ...buildTagsHeaders(options.tags),
           },
           responseHandler: async (response) => {
             this._requestId = response.headers.get("x-fal-request-id");

--- a/libs/client/src/types/common.ts
+++ b/libs/client/src/types/common.ts
@@ -56,8 +56,9 @@ export type RunOptions<Input> = {
    * Values cannot contain commas, which separate pairs. Surrounding whitespace
    * is stripped from keys and values before they are recorded.
    *
-   * This will be sent as a single packed `x-fal-tags` header. Streaming and
-   * realtime requests cannot carry headers, so they cannot be tagged.
+   * This will be sent as a single packed `x-fal-tags` header. Realtime
+   * requests are WebSocket-based and carry no headers, so they cannot be
+   * tagged.
    */
   readonly tags?: Record<string, string>;
 };

--- a/libs/client/src/types/common.ts
+++ b/libs/client/src/types/common.ts
@@ -47,6 +47,16 @@ export type RunOptions<Input> = {
    * This will be sent as the `x-fal-request-timeout` header.
    */
   readonly startTimeout?: number;
+
+  /**
+   * Tags to attribute the request's usage and cost to your own dimensions,
+   * e.g. `{ team: "design", env: "prod" }`. Keys are lowercased, and both keys
+   * and values are limited (at most 10 pairs, 1 KB in total).
+   *
+   * This will be sent as a single packed `x-fal-tags` header. Streaming and
+   * realtime requests cannot carry headers, so they cannot be tagged.
+   */
+  readonly tags?: Record<string, string>;
 };
 
 export type UrlOptions = {

--- a/libs/client/src/types/common.ts
+++ b/libs/client/src/types/common.ts
@@ -53,6 +53,9 @@ export type RunOptions<Input> = {
    * e.g. `{ team: "design", env: "prod" }`. Keys are lowercased, and both keys
    * and values are limited (at most 10 pairs, 1 KB in total).
    *
+   * Values cannot contain commas, which separate pairs. Surrounding whitespace
+   * is stripped from keys and values before they are recorded.
+   *
    * This will be sent as a single packed `x-fal-tags` header. Streaming and
    * realtime requests cannot carry headers, so they cannot be tagged.
    */


### PR DESCRIPTION
Callers want to attribute their fal usage to their own dimensions — team, environment, feature — so that usage and cost can be sliced by those dimensions in reporting. Tags supplied on a request are the first hop for that.

Adds a `tags?: Record<string, string>` run option that serializes to a single packed `X-Fal-Tags: k=v,k=v` header on `fal.run()` and `fal.queue.submit()` (and therefore `subscribe()`). Tags are validated client-side against the same limits the gateway enforces — at most 10 pairs, keys lowercased to `[a-z0-9._-]` and 64 chars, values printable ASCII without commas and 256 chars, 1 KB total, and the reserved `fal.` key prefix rejected. Streaming and realtime requests cannot carry headers, which the option docs call out.