### PR TITLE
chore: remove redundant dependencies

### DIFF
--- a/libs/create-app/package.json
+++ b/libs/create-app/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^3.3.0",
-    "@inquirer/select": "^1.3.1",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "execa": "^8.0.1",

--- a/libs/create-app/src/index.ts
+++ b/libs/create-app/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-import { input } from "@inquirer/prompts";
-import select from "@inquirer/select";
+import { input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import childProcess from "child_process";
 import { Command } from "commander";

--- a/libs/proxy/package.json
+++ b/libs/proxy/package.json
@@ -54,9 +54,7 @@
     "@sveltejs/kit": "^2.0.0",
     "express": "^4.0.0",
     "hono": "^4.0.0",
-    "next": "13.4 - 14 || >=15.0.0-0",
-    "react": "^18.0.0 || >=19.0.0-0",
-    "react-dom": "^18.0.0 || >=19.0.0-0"
+    "next": "13.4 - 14 || >=15.0.0-0"
   },
   "peerDependenciesMeta": {
     "@remix-run/dev": {
@@ -72,12 +70,6 @@
       "optional": true
     },
     "next": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
       "optional": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^3.3.0",
-        "@inquirer/select": "^1.3.1",
         "@msgpack/msgpack": "^3.0.0-beta2",
         "@oclif/core": "^2.3.0",
         "@oclif/plugin-help": "^5.2.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^3.3.0",
-    "@inquirer/select": "^1.3.1",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "@oclif/core": "^2.3.0",
     "@oclif/plugin-help": "^5.2.5",


### PR DESCRIPTION
- Drop `@inquirer/select` from the root and create-app manifests; `select` is already re-exported by `@inquirer/prompts@3`, so import it from there.
- Drop `react`/`react-dom` from the proxy's optional peer dependencies. The proxy only imports `next/server` and `next/types`, and Next declares React as its own peer, so these entries added nothing.