### PR TITLE
feat(client): add optional WMA receive preferences

### DIFF
--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -149,6 +149,50 @@ An extension that _does_ own a closed set of endpoints can add an optional
 starts. It is a guard, not a router; most protocols have no such set and should
 omit it.
 
+### Optional WMA receive preferences
+
+The existing `receive: ["video", "audio"]` syntax keeps browser defaults.
+Object entries opt into preferences for an individual receive slot:
+
+```ts
+import { fal } from "@fal-ai/client";
+import { wma } from "@fal-ai/client/realtime";
+
+const session = fal.realtime.open(wma("my-owner/my-model"), {
+  receive: [
+    { kind: "video", codecPreferences: ["video/H264", "video/VP8"] },
+    {
+      kind: "audio",
+      opus: { stereo: true, maxAverageBitrate: 192_000 },
+    },
+  ],
+  onMedia: (stream) => {
+    videoElement.srcObject = stream;
+  },
+  onError: console.error,
+});
+```
+
+These optional settings apply before negotiation and require reconnecting to
+change. Opus settings describe reception, even when a local track shares the
+slot through `sendrecv`. They do not configure local capture or sender bitrate.
+Codec preferences participate in negotiation and can affect the codec used in
+both directions on a `sendrecv` transceiver.
+
+- `codecPreferences` orders supported codec MIME types without removing
+  browser fallback or repair codecs. Unavailable types produce a diagnostic;
+  if none are available, the browser order is unchanged. A nonempty list
+  requires `setCodecPreferences` support in the browser.
+- `opus.stereo` requests stereo or mono; omission preserves the browser default.
+- `opus.maxAverageBitrate` is a receive ceiling in bits/s (integer 6000–510000),
+  not a target or a guarantee of actual bandwidth. Opus preferences require
+  Opus in the offer but do not force the server to select it.
+
+The model still controls its encoder. For example, Director separately accepts
+`audio_bitrate: 192000` in its initial `configure` message. No model-specific
+configuration is sent automatically by fal-js. Omitting these new options
+preserves existing SDP and behavior.
+
 ### fal's own WebSocket protocol, behind `open()`
 
 `websocket()` speaks the same wire protocol as `fal.realtime.connect()` —

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/client",
   "description": "The fal.ai client for JavaScript and TypeScript",
-  "version": "1.11.0-alpha.2",
+  "version": "1.11.0-alpha.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/realtime/wma-media.spec.ts
+++ b/libs/client/src/realtime/wma-media.spec.ts
@@ -1,0 +1,229 @@
+import {
+  applyWmaCodecPreferences,
+  applyWmaOpusPreferences,
+  normalizeWmaReceiveTrack,
+  type WmaReceiveTrack,
+} from "./wma-media";
+
+const audio =
+  [
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111 0",
+    "a=mid:0",
+    "a=rtpmap:111 opus/48000/2",
+    "a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1;stereo=0",
+    "a=rtpmap:0 PCMU/8000",
+    "a=recvonly",
+  ].join("\r\n") + "\r\n";
+const video = "m=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\n";
+const data =
+  "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=sctp-port:5000\r\n";
+const music = normalizeWmaReceiveTrack({
+  kind: "audio",
+  opus: { stereo: true, maxAverageBitrate: 192000 },
+});
+
+describe("WMA receive preferences", () => {
+  it.each([
+    "audio",
+    "video",
+    { kind: "audio" },
+    { kind: "audio", opus: {} },
+    { kind: "video", codecPreferences: [] },
+  ])(
+    "keeps default SDP byte-for-byte and requires no new browser APIs: %p",
+    (entry) => {
+      const track = normalizeWmaReceiveTrack(entry as WmaReceiveTrack);
+      const sdp = "v=0\r\n" + audio + video + data;
+      expect(applyWmaOpusPreferences(sdp, [track])).toBe(sdp);
+      expect(() =>
+        applyWmaCodecPreferences({} as RTCRtpTransceiver, track, jest.fn()),
+      ).not.toThrow();
+    },
+  );
+
+  it("snapshots options so mutations while gathering cannot change the offer", () => {
+    const source = {
+      kind: "audio" as const,
+      opus: { stereo: true },
+      codecPreferences: ["audio/OPUS"],
+    };
+    const normalized = normalizeWmaReceiveTrack(source);
+    source.opus.stereo = false;
+    source.codecPreferences[0] = "audio/PCMU";
+    expect(normalized).toEqual({
+      kind: "audio",
+      opus: { stereo: true },
+      codecPreferences: ["audio/opus"],
+    });
+  });
+
+  it.each([
+    null,
+    "text",
+    { kind: "video", opus: {} },
+    { kind: "audio", opus: [] },
+    { kind: "audio", opus: { stereo: 1 } },
+    { kind: "audio", codecPreferences: ["video/H264"] },
+    { kind: "video", codecPreferences: "video/VP8" },
+    ...[0, 5999, 510001, 1.5, NaN, Infinity, "192000"].map(
+      (maxAverageBitrate) => ({ kind: "audio", opus: { maxAverageBitrate } }),
+    ),
+  ])("rejects invalid opt-in settings: %p", (entry) => {
+    expect(() => normalizeWmaReceiveTrack(entry as WmaReceiveTrack)).toThrow();
+  });
+
+  it.each([6000, 192000, 510000])(
+    "accepts RFC bitrate bounds: %i",
+    (maxAverageBitrate) => {
+      expect(
+        normalizeWmaReceiveTrack({ kind: "audio", opus: { maxAverageBitrate } })
+          .opus?.maxAverageBitrate,
+      ).toBe(maxAverageBitrate);
+    },
+  );
+
+  it.each(["\r\n", "\n"])(
+    "edits only the requested audio slot, preserving other media and Opus parameters (%p)",
+    (newline) => {
+      const sdp = ("v=0\r\n" + video + audio + audio + data).replace(
+        /\r\n/g,
+        newline,
+      );
+      const result = applyWmaOpusPreferences(sdp, [
+        { kind: "video" },
+        music,
+        { kind: "audio" },
+      ]);
+      const expected = sdp.replace(
+        "sprop-stereo=1;stereo=0",
+        "sprop-stereo=1;stereo=1;maxaveragebitrate=192000",
+      );
+      expect(result).toBe(expected);
+      expect(
+        applyWmaOpusPreferences(result, [
+          { kind: "video" },
+          music,
+          { kind: "audio" },
+        ]),
+      ).toBe(result);
+    },
+  );
+
+  it("adds missing fmtp and supports separate preferences on multiple audio slots", () => {
+    const bare = audio.replace(/^a=fmtp:.*\r\n/m, "");
+    const result = applyWmaOpusPreferences(bare + audio, [
+      music,
+      { kind: "audio", opus: { stereo: false } },
+    ]);
+    expect(result).toContain(
+      "a=rtpmap:111 opus/48000/2\r\na=fmtp:111 stereo=1;maxaveragebitrate=192000\r\n",
+    );
+    expect(result.endsWith(audio)).toBe(true);
+  });
+
+  it("preserves an unspecified bitrate or stereo preference, including a sendrecv slot", () => {
+    const sdp = audio
+      .replace("stereo=0\r", "stereo=0;maxaveragebitrate=64000\r")
+      .replace("a=recvonly", "a=sendrecv");
+    expect(
+      applyWmaOpusPreferences(sdp, [{ kind: "audio", opus: { stereo: true } }]),
+    ).toBe(
+      sdp.replace(
+        ";stereo=0;maxaveragebitrate=64000",
+        ";maxaveragebitrate=64000;stereo=1",
+      ),
+    );
+    expect(
+      applyWmaOpusPreferences(audio, [
+        { kind: "audio", opus: { maxAverageBitrate: 192000 } },
+      ]),
+    ).toContain("sprop-stereo=1;stereo=0;maxaveragebitrate=192000");
+  });
+
+  it("fails explicitly rather than claiming Opus settings worked without Opus", () => {
+    expect(() => applyWmaOpusPreferences(video, [music])).toThrow(
+      "section is missing",
+    );
+    expect(() =>
+      applyWmaOpusPreferences(
+        "m=audio 9 UDP/TLS/RTP/SAVPF 0\r\na=rtpmap:0 PCMU/8000\r\n",
+        [music],
+      ),
+    ).toThrow("offered Opus");
+  });
+});
+
+describe("WMA codec ordering", () => {
+  const originalReceiver = global.RTCRtpReceiver;
+  afterEach(() => {
+    global.RTCRtpReceiver = originalReceiver;
+  });
+  const codecs = [
+    { mimeType: "video/VP8", clockRate: 90000 },
+    { mimeType: "video/rtx", clockRate: 90000 },
+    {
+      mimeType: "video/H264",
+      clockRate: 90000,
+      sdpFmtpLine: "profile-level-id=42e01f",
+    },
+    {
+      mimeType: "video/H264",
+      clockRate: 90000,
+      sdpFmtpLine: "profile-level-id=64001f",
+    },
+    { mimeType: "video/red", clockRate: 90000 },
+    { mimeType: "video/ulpfec", clockRate: 90000 },
+  ];
+  function receiver() {
+    global.RTCRtpReceiver = {
+      getCapabilities: jest.fn(() => ({ codecs })),
+    } as unknown as typeof RTCRtpReceiver;
+    const setCodecPreferences = jest.fn();
+    return {
+      transceiver: { setCodecPreferences } as unknown as RTCRtpTransceiver,
+      setCodecPreferences,
+    };
+  }
+  it("reorders MIME preferences without losing profiles, fallback or repair codecs", () => {
+    const { transceiver, setCodecPreferences } = receiver();
+    const warn = jest.fn();
+    applyWmaCodecPreferences(
+      transceiver,
+      normalizeWmaReceiveTrack({
+        kind: "video",
+        codecPreferences: ["video/H264", "video/AV1", "video/VP8"],
+      }),
+      warn,
+    );
+    expect(setCodecPreferences).toHaveBeenCalledWith([
+      codecs[2],
+      codecs[3],
+      codecs[0],
+      codecs[1],
+      codecs[4],
+      codecs[5],
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("video/av1 is unavailable"),
+    );
+    expect(codecs[0].mimeType).toBe("video/VP8");
+  });
+  it("leaves browser defaults when no preferred codec is available", () => {
+    const { transceiver, setCodecPreferences } = receiver();
+    applyWmaCodecPreferences(
+      transceiver,
+      { kind: "video", codecPreferences: ["video/av1"] },
+      jest.fn(),
+    );
+    expect(setCodecPreferences).not.toHaveBeenCalled();
+  });
+  it("reports unsupported browser APIs only for an explicit preference", () => {
+    expect(() =>
+      applyWmaCodecPreferences(
+        {} as RTCRtpTransceiver,
+        { kind: "video", codecPreferences: ["video/vp8"] },
+        jest.fn(),
+      ),
+    ).toThrow("not supported");
+  });
+});

--- a/libs/client/src/realtime/wma-media.ts
+++ b/libs/client/src/realtime/wma-media.ts
@@ -1,0 +1,199 @@
+/** A WebRTC media kind the browser should offer to receive from the model. */
+export type WmaReceiveTrackKind = "audio" | "video";
+
+/** Optional Opus receive preferences; not a setting for the browser's sender. */
+export interface WmaOpusReceiveOptions {
+  /** Prefer stereo (true) or mono (false). Omit to keep the browser default. */
+  stereo?: boolean;
+  /** Receive ceiling in bits/s, an integer from 6000 to 510000, not a target. */
+  maxAverageBitrate?: number;
+}
+
+/** Optional, connection-time preferences for one receive slot. */
+export type WmaReceiveTrackOptions = {
+  /**
+   * Preferred codec MIME types, in order (for example ["video/H264", "video/VP8"]).
+   * Unavailable codecs are skipped with a diagnostic; all browser fallback and repair codecs
+   * remain offered. Requires browser support for setCodecPreferences when nonempty.
+   */
+  codecPreferences?: readonly string[];
+} & (
+  | { kind: "audio"; opus?: WmaOpusReceiveOptions }
+  | { kind: "video"; opus?: never }
+);
+
+/** Strings retain the browser defaults; objects opt into per-slot preferences. */
+export type WmaReceiveTrack = WmaReceiveTrackKind | WmaReceiveTrackOptions;
+
+/** Validate and snapshot options before any asynchronous ICE discovery. */
+export function normalizeWmaReceiveTrack(
+  track: WmaReceiveTrack,
+): WmaReceiveTrackOptions {
+  const value: WmaReceiveTrackOptions =
+    typeof track === "string" ? { kind: track } : track;
+  if (!value || (value.kind !== "audio" && value.kind !== "video")) {
+    throw new TypeError("WMA receive kind must be audio or video.");
+  }
+  const codecs = value.codecPreferences;
+  if (
+    codecs !== undefined &&
+    (!Array.isArray(codecs) ||
+      codecs.some(
+        (codec) =>
+          typeof codec !== "string" ||
+          !new RegExp(`^${value.kind}/[a-z0-9.+_-]+$`, "i").test(codec),
+      ))
+  ) {
+    throw new TypeError(
+      "WMA codecPreferences must contain MIME types matching the track kind.",
+    );
+  }
+  const opus = value.opus;
+  if (opus !== undefined) {
+    if (
+      value.kind !== "audio" ||
+      !opus ||
+      typeof opus !== "object" ||
+      Array.isArray(opus)
+    ) {
+      throw new TypeError(
+        "WMA Opus preferences require an audio receive track.",
+      );
+    }
+    if (opus.stereo !== undefined && typeof opus.stereo !== "boolean") {
+      throw new TypeError("WMA Opus stereo must be a boolean.");
+    }
+    const bitrate = opus.maxAverageBitrate;
+    if (
+      bitrate !== undefined &&
+      (!Number.isInteger(bitrate) || bitrate < 6000 || bitrate > 510000)
+    ) {
+      throw new TypeError(
+        "WMA Opus maxAverageBitrate must be an integer from 6000 to 510000 bits/s.",
+      );
+    }
+  }
+  const common = {
+    ...(codecs !== undefined
+      ? { codecPreferences: codecs.map((codec) => codec.toLowerCase()) }
+      : {}),
+  };
+  return value.kind === "audio"
+    ? {
+        ...common,
+        kind: "audio",
+        ...(opus !== undefined ? { opus: { ...opus } } : {}),
+      }
+    : { ...common, kind: "video" };
+}
+
+export function applyWmaCodecPreferences(
+  transceiver: RTCRtpTransceiver,
+  track: WmaReceiveTrackOptions,
+  warn: (message: string) => void,
+): void {
+  const preferred = track.codecPreferences;
+  if (!preferred?.length) return;
+  if (
+    typeof transceiver.setCodecPreferences !== "function" ||
+    typeof RTCRtpReceiver === "undefined" ||
+    typeof RTCRtpReceiver.getCapabilities !== "function"
+  ) {
+    throw new Error("WMA codecPreferences are not supported by this browser.");
+  }
+  const codecs = RTCRtpReceiver.getCapabilities(track.kind)?.codecs ?? [];
+  for (const mime of preferred) {
+    if (!codecs.some((codec) => codec.mimeType.toLowerCase() === mime)) {
+      warn(
+        `WMA receive codec ${mime} is unavailable; retaining browser fallbacks.`,
+      );
+    }
+  }
+  if (!codecs.some((codec) => preferred.includes(codec.mimeType.toLowerCase())))
+    return;
+  const rank = (mime: string) => {
+    const index = preferred.indexOf(mime.toLowerCase());
+    return index === -1 ? preferred.length : index;
+  };
+  // Retain every profile and repair codec; only their preference order changes.
+  transceiver.setCodecPreferences(
+    [...codecs].sort((a, b) => rank(a.mimeType) - rank(b.mimeType)),
+  );
+}
+
+/**
+ * Only touch explicitly configured Opus fmtp parameters in the matching receive section.
+ * Receive slots are created first, in array order, on this fresh peer connection.
+ * Run before setLocalDescription so the browser and the bridge see the same offer.
+ */
+export function applyWmaOpusPreferences(
+  sdp: string,
+  tracks: readonly WmaReceiveTrackOptions[],
+): string {
+  if (
+    !tracks.some(
+      (track) =>
+        track.opus?.stereo !== undefined ||
+        track.opus?.maxAverageBitrate !== undefined,
+    )
+  )
+    return sdp;
+  const sections = sdp.split(/(?=^m=)/m);
+  const offset = sections[0].startsWith("m=") ? 0 : 1;
+  tracks.forEach((track, index) => {
+    const options = track.opus;
+    if (
+      !options ||
+      (options.stereo === undefined && options.maxAverageBitrate === undefined)
+    )
+      return;
+    const section = sections[offset + index];
+    if (!section?.startsWith("m=audio "))
+      throw new Error("WMA Opus receive section is missing.");
+    const newline = section.includes("\r\n") ? "\r\n" : "\n";
+    const lines = section.split(newline);
+    const payloads = lines.flatMap((line) => {
+      const match = /^a=rtpmap:(\d+) opus\/48000\/2\s*$/i.exec(line);
+      return match ? [match[1]] : [];
+    });
+    if (!payloads.length)
+      throw new Error("WMA Opus preferences require an offered Opus codec.");
+    const parameters: Record<string, string> = {};
+    if (options.stereo !== undefined)
+      parameters.stereo = options.stereo ? "1" : "0";
+    if (options.maxAverageBitrate !== undefined)
+      parameters.maxaveragebitrate = String(options.maxAverageBitrate);
+    for (const payload of payloads) {
+      const prefix = `a=fmtp:${payload} `;
+      const fmtpIndex = lines.findIndex((line) => line.startsWith(prefix));
+      const previous =
+        fmtpIndex === -1
+          ? []
+          : lines[fmtpIndex].slice(prefix.length).split(";");
+      const retained = previous.filter(
+        (parameter) =>
+          !Object.prototype.hasOwnProperty.call(
+            parameters,
+            parameter.split("=")[0].trim().toLowerCase(),
+          ),
+      );
+      const fmtp =
+        prefix +
+        [
+          ...retained,
+          ...Object.entries(parameters).map(
+            ([key, value]) => `${key}=${value}`,
+          ),
+        ].join(";");
+      if (fmtpIndex !== -1) lines[fmtpIndex] = fmtp;
+      else {
+        const rtpIndex = lines.findIndex((line) =>
+          line.toLowerCase().startsWith(`a=rtpmap:${payload} `),
+        );
+        lines.splice(rtpIndex + 1, 0, fmtp);
+      }
+    }
+    sections[offset + index] = lines.join(newline);
+  });
+  return sections.join("");
+}

--- a/libs/client/src/realtime/wma.spec.ts
+++ b/libs/client/src/realtime/wma.spec.ts
@@ -25,7 +25,9 @@ function fakePeer() {
       createDataChannel: jest.fn(() => channel),
       addTrack: jest.fn(),
       createOffer: jest.fn(async () => ({ sdp: "local-offer", type: "offer" })),
-      setLocalDescription: jest.fn(async () => undefined),
+      setLocalDescription: jest.fn<Promise<void>, [RTCSessionDescriptionInit]>(
+        async () => undefined,
+      ),
       setRemoteDescription: jest.fn(async () => undefined),
       close: jest.fn(),
       addEventListener: (type: string, fn: (event: unknown) => void) => {
@@ -1002,6 +1004,70 @@ describe("wma", () => {
       ["video", { direction: "recvonly" }],
       ["audio", { direction: "recvonly" }],
     ]);
+  });
+
+  it.each([false, true])(
+    "applies per-slot preferences before local SDP and sends the gathered offer (local audio: %p)",
+    async (sendAudio) => {
+      const { peer } = install();
+      const offered =
+        "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\na=fmtp:111 useinbandfec=1\r\n";
+      peer.createOffer.mockResolvedValue({ type: "offer", sdp: offered });
+      peer.setLocalDescription.mockImplementation(async (description) => {
+        // Stand in for ICE gathering adding candidates to the tuned local offer.
+        peer.localDescription = {
+          type: description.type,
+          sdp: description.sdp + "a=candidate:gathered\r\n",
+        };
+      });
+      const fetch = jest.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ session_id: "s", sdp: "answer", type: "answer" }),
+          ),
+      );
+      const track = { kind: "audio", stop: jest.fn() };
+      const stream = { getTracks: () => [track] } as unknown as MediaStream;
+      const session = await wma().open(fakeExtensionContext({ fetch }), {
+        iceServers: [],
+        localStream: sendAudio ? stream : null,
+        receive: [
+          { kind: "audio", opus: { stereo: true, maxAverageBitrate: 192000 } },
+        ],
+      });
+      expect(peer.addTransceiver).toHaveBeenCalledWith(
+        sendAudio ? track : "audio",
+        sendAudio
+          ? { direction: "sendrecv", streams: [stream] }
+          : { direction: "recvonly" },
+      );
+      expect(peer.setLocalDescription).toHaveBeenCalledWith({
+        type: "offer",
+        sdp: offered.replace(
+          "useinbandfec=1",
+          "useinbandfec=1;stereo=1;maxaveragebitrate=192000",
+        ),
+      });
+      const request = fetch.mock.calls[0] as unknown as [string, RequestInit];
+      expect(JSON.parse(String(request[1].body)).sdp).toBe(
+        peer.localDescription.sdp,
+      );
+      expect(track.stop).not.toHaveBeenCalled();
+      session.close();
+    },
+  );
+
+  it("rejects invalid preferences before ICE discovery or peer creation", async () => {
+    const PeerConnection = jest.fn();
+    global.RTCPeerConnection = PeerConnection as never;
+    const fetch = jest.fn();
+    await expect(
+      wma().open(fakeExtensionContext({ fetch }), {
+        receive: [{ kind: "audio", opus: { maxAverageBitrate: 0 } }],
+      }),
+    ).rejects.toThrow("maxAverageBitrate");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(PeerConnection).not.toHaveBeenCalled();
   });
 
   it("uses sendrecv for matched local tracks and recvonly for unmatched outputs", async () => {

--- a/libs/client/src/realtime/wma.ts
+++ b/libs/client/src/realtime/wma.ts
@@ -28,6 +28,18 @@ import {
   type RealtimeSession,
 } from "./extension";
 import { countTurnServers } from "./ice";
+import {
+  applyWmaCodecPreferences,
+  applyWmaOpusPreferences,
+  normalizeWmaReceiveTrack,
+  type WmaReceiveTrack,
+} from "./wma-media";
+export type {
+  WmaOpusReceiveOptions,
+  WmaReceiveTrack,
+  WmaReceiveTrackKind,
+  WmaReceiveTrackOptions,
+} from "./wma-media";
 
 const WMA_URL = "https://wma.fal.run";
 const ICE_DISCOVERY_TIMEOUT_MS = 5_000;
@@ -46,9 +58,6 @@ const DEFAULT_STUN_URL = "stun:stun.l.google.com:19302";
 
 /** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
 export type WmaControlMessage = object;
-
-/** A WebRTC media kind the browser should offer to receive from the model. */
-export type WmaReceiveTrackKind = "audio" | "video";
 
 /** @experimental The `fal.realtime.open()` extension API is experimental and may change in a minor release. */
 export interface WmaOptions {
@@ -80,8 +89,13 @@ export interface WmaOptions {
    * Omit this option to preserve the legacy behavior: local tracks use `direction` (defaulting to
    * `sendrecv`), while a session without local tracks offers one `recvonly` video transceiver.
    * Because this option derives directions per track, it cannot be combined with `direction`.
+   *
+   * Object entries optionally tune receive preferences before negotiation. Strings retain defaults.
+   * Opus preferences describe reception; codec ordering may affect both directions on sendrecv
+   * tracks. Close and reopen to change them. These do not set the model's encoder target or
+   * guarantee a negotiated codec/bitrate.
    */
-  receive?: readonly WmaReceiveTrackKind[];
+  receive?: readonly WmaReceiveTrack[];
   /**
    * Media to send UP, on the same peer connection the output comes back on.
    *
@@ -620,6 +634,7 @@ export function wma(endpointId?: string) {
           "WMA receive tracks cannot be combined with an explicit direction.",
         );
       }
+      const receive = options.receive?.map(normalizeWmaReceiveTrack);
       const iceServers = options.iceServers ?? (await fetchIceServers(context));
       const pc = new RTCPeerConnection({
         iceServers,
@@ -640,22 +655,26 @@ export function wma(endpointId?: string) {
       // A local track is added through a transceiver so the caller's requested direction reaches
       // SDP. Never add a second media transceiver for the same track.
       const localTracks = options.localStream?.getTracks() ?? [];
-      if (options.receive !== undefined) {
+      if (receive !== undefined) {
         const unmatchedLocalTracks = [...localTracks];
-        for (const kind of options.receive) {
+        for (const preferences of receive) {
+          const { kind } = preferences;
           const localIndex = unmatchedLocalTracks.findIndex(
             (track) => track.kind === kind,
           );
-          if (localIndex === -1) {
-            pc.addTransceiver(kind, { direction: "recvonly" });
-            continue;
-          }
-
-          const [track] = unmatchedLocalTracks.splice(localIndex, 1);
-          pc.addTransceiver(track, {
-            direction: "sendrecv",
-            streams: [options.localStream!],
-          });
+          const transceiver =
+            localIndex === -1
+              ? pc.addTransceiver(kind, { direction: "recvonly" })
+              : pc.addTransceiver(
+                  unmatchedLocalTracks.splice(localIndex, 1)[0],
+                  {
+                    direction: "sendrecv",
+                    streams: [options.localStream!],
+                  },
+                );
+          applyWmaCodecPreferences(transceiver, preferences, (message) =>
+            context.diagnostic({ kind: "warning", message }),
+          );
         }
         for (const track of unmatchedLocalTracks) {
           pc.addTransceiver(track, {
@@ -934,6 +953,9 @@ export function wma(endpointId?: string) {
 
       try {
         const offer = await pc.createOffer();
+        if (offer.sdp !== undefined && receive !== undefined) {
+          offer.sdp = applyWmaOpusPreferences(offer.sdp, receive);
+        }
         // Attach listeners BEFORE setLocalDescription starts gathering — fast host/srflx
         // candidates otherwise fire before the waiter exists and are never counted.
         // Non-trickle signalling needs the kernel's sufficient-set / quiet-period / hard-bound


### PR DESCRIPTION
## Summary

Add optional, per-receive-slot preferences to WMA without changing existing defaults. String entries remain supported; object entries can request Opus stereo/bitrate and order codec preferences.

```ts
fal.realtime.open(wma("my-owner/my-model"), {
  receive: [
    "video",
    { kind: "audio", opus: { stereo: true, maxAverageBitrate: 192_000 } },
  ],
});
```

Optional codec ordering is available through `{ kind: "video", codecPreferences: ["video/H264", "video/VP8"] }`.

## Behavior and scope

- Omitted settings, string entries, and bare objects preserve default SDP and transceiver allocation.
- Opus settings modify only the opted-in receive slot before `setLocalDescription`. Signalling uses the resulting ICE-complete local description.
- `maxAverageBitrate` is a receive ceiling in bits/s, not an encoder target. Stereo and bitrate are receiver preferences, including on sendrecv slots.
- Codec ordering preserves browser-supported profiles, fallback codecs, and repair codecs. Unsupported preferences emit diagnostics; no matches leave browser ordering unchanged. Explicit nonempty preferences require the browser API. Negotiated codecs can affect both directions on sendrecv.
- Validate and snapshot preferences before ICE discovery. Invalid options fail without starting signalling.
- No local-capture controls, sender-bitrate controls, renegotiation, video bitrate ceilings, model-specific messages, dependency updates, or automatic publication.
- Bump `@fal-ai/client` to `1.11.0-alpha.3` for the next staged alpha release.

For Director, the playground will separately opt into these receive preferences and set `audio_bitrate: 192000` in its configure message once an SDK alpha containing this API is available.

## Stack

Depends on #232; the base is `noah/wma-session-wait-timeout` so this diff contains media preferences and their alpha version bump.

## Change size

| Area | Added lines |
| --- | ---: |
| Implementation and public types | 237 |
| Tests | 296 |
| Usage documentation | 44 |
| Package version | 1 |

18 lines removed; six files changed.

## Validation

- All 293 client tests pass (16 suites), including 75 WMA tests.
- Client Nx build and TypeScript check pass; built package version verified as `1.11.0-alpha.3`.
- Scoped formatting, secret scan, and diff whitespace checks pass.
- ESLint reports zero errors; existing WMA warnings remain.
- Actual headless Chromium 143 offer test: default SDP unchanged, H264 preference applied, one audio slot advertises stereo/192000 and a second audio slot stays untouched; setLocalDescription accepts the offer.
- Safari/Firefox and an end-to-end runner session are not validated. No model jobs or camera/microphone capture were started.
